### PR TITLE
added CL_MAX_SIZE_RESTRICTION_EXCEEDED

### DIFF
--- a/api/cl.xml
+++ b/api/cl.xml
@@ -99,7 +99,8 @@ has no formal schema defined.
         <enum value="-69"         name="CL_INVALID_PIPE_SIZE"/>
         <enum value="-70"         name="CL_INVALID_DEVICE_QUEUE"/>
         <enum value="-71"         name="CL_INVALID_SPEC_ID"/>
-            <unused start="-72" end="-999" comment="Reserved for Khronos"/>
+        <enum value="-72"         name="CL_MAX_SIZE_RESTRICTION_EXCEEDED"/>
+            <unused start="-73" end="-999" comment="Reserved for Khronos"/>
     </enums>
 
     <enums namespace="CL" start="-1000" end="-1001" group="ErrorCodes" vendor="Khronos" comment="Extension error codes start at -1000 and decrease">


### PR DESCRIPTION
Adds the CL_MAX_SIZE_RESTRICTION_EXCEEDED error code, needed for OpenCL 2.2.