### PR TITLE
api/cl.xml fixes

### DIFF
--- a/api/cl.xml
+++ b/api/cl.xml
@@ -524,7 +524,7 @@ has no formal schema defined.
         <enum value="0x1030"      name="CL_DEVICE_EXTENSIONS"/>
         <enum value="0x1031"      name="CL_DEVICE_PLATFORM"/>
         <enum value="0x1032"      name="CL_DEVICE_DOUBLE_FP_CONFIG"/>
-        <enum value="0x1033       name="CL_DEVICE_HALF_FP_CONFIG"/>
+        <enum value="0x1033"      name="CL_DEVICE_HALF_FP_CONFIG"/>
         <enum value="0x1034"      name="CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF"/>
         <enum value="0x1035"      name="CL_DEVICE_HOST_UNIFIED_MEMORY"/>
         <enum value="0x1036"      name="CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR"/>

--- a/api/cl.xml
+++ b/api/cl.xml
@@ -303,13 +303,6 @@ has no formal schema defined.
         <enum value="(1<<0)"    name="CL_QUEUE_PRIORITY_HIGH_KHR"/>
         <enum value="(1<<1)"    name="CL_QUEUE_PRIORITY_MED_KHR"/>
         <enum value="(1<<2)"    name="CL_QUEUE_PRIORITY_LOW_KHR"/>
-            <unused start="1<<3" end="1="<<31"/>
-    </enums>
-
-    <enums namespace="CL" group="cl_queue_priority_khr" vendor="Khronos" type="bitmask">
-        <enum value="(1<<0)"    name="CL_QUEUE_PRIORITY_HIGH_KHR"/>
-        <enum value="(1<<1)"    name="CL_QUEUE_PRIORITY_MED_KHR"/>
-        <enum value="(1<<2)"    name="CL_QUEUE_PRIORITY_LOW_KHR"/>
             <unused start="1<<3" end="1<<31"/>
     </enums>
 


### PR DESCRIPTION
Minor cleanups for the `cl.xml` API file, including the removal of a duplicate block and the introduction of a missing closing double quote.