### PR TITLE
Typo fixes

### DIFF
--- a/sdk/1.0/docs/man/clEnqueueReadImage.xml
+++ b/sdk/1.0/docs/man/clEnqueueReadImage.xml
@@ -196,7 +196,7 @@ in all copies or substantial portions of the Materials.</holder>
 				
 				<listitem>
 					<para>
-						The pointer to a buffer in host memory where image data is to be read from.
+						The pointer to a buffer in host memory where image data is to be written to.
 					</para>
 				</listitem>
 			</varlistentry>

--- a/sdk/1.0/docs/man/clEnqueueWriteImage.xml
+++ b/sdk/1.0/docs/man/clEnqueueWriteImage.xml
@@ -193,7 +193,7 @@ command. When the write command has completed, the memory pointed to by <varname
 				
 				<listitem>
 					<para>
-						The pointer to a buffer in host memory where image data is to be written to.
+						The pointer to a buffer in host memory where image data is to be read from.
 					</para>
 				</listitem>
 			</varlistentry>

--- a/sdk/1.0/docs/man/integerFunctions.xml
+++ b/sdk/1.0/docs/man/integerFunctions.xml
@@ -43,7 +43,7 @@ in all copies or substantial portions of the Materials.</holder>
 		</row>
 		<row>
 			<entry><citerefentry href="abs">
-				<refentrytitle>abs-diff</refentrytitle>
+				<refentrytitle>abs_diff</refentrytitle>
 			</citerefentry></entry>
 			<entry>|<varname>x</varname>-<varname>y</varname>| without modulo overflow</entry>
 		</row>

--- a/sdk/1.1/docs/man/clEnqueueReadImage.xml
+++ b/sdk/1.1/docs/man/clEnqueueReadImage.xml
@@ -195,7 +195,7 @@ in all copies or substantial portions of the Materials.</holder>
                 
                 <listitem>
                     <para>
-                        The pointer to a buffer in host memory where image data is to be read from.
+                        The pointer to a buffer in host memory where image data is to be written to.
                     </para>
                 </listitem>
             </varlistentry>

--- a/sdk/1.1/docs/man/clEnqueueWriteImage.xml
+++ b/sdk/1.1/docs/man/clEnqueueWriteImage.xml
@@ -192,7 +192,7 @@ command. When the write command has completed, the memory pointed to by <varname
                 
                 <listitem>
                     <para>
-                        The pointer to a buffer in host memory where image data is to be written to.
+                        The pointer to a buffer in host memory where image data is to be read from.
                     </para>
                 </listitem>
             </varlistentry>

--- a/sdk/1.1/docs/man/integerFunctions.xml
+++ b/sdk/1.1/docs/man/integerFunctions.xml
@@ -45,7 +45,7 @@ in all copies or substantial portions of the Materials.</holder>
         </row>
         <row>
             <entry><citerefentry href="abs">
-                <refentrytitle>abs-diff</refentrytitle>
+                <refentrytitle>abs_diff</refentrytitle>
             </citerefentry></entry>
             <entry>|<varname>x</varname>-<varname>y</varname>| without modulo overflow</entry>
         </row>

--- a/sdk/1.2/docs/man/clEnqueueReadImage.xml
+++ b/sdk/1.2/docs/man/clEnqueueReadImage.xml
@@ -221,7 +221,7 @@ in all copies or substantial portions of the Materials.</holder>
                 <term> <varname> ptr </varname> </term>
                 <listitem>
                     <para>
-                      The pointer to a buffer in host memory where image data is to be read from.
+                      The pointer to a buffer in host memory where image data is to be written to.
                     </para>
                 </listitem>
             </varlistentry>

--- a/sdk/1.2/docs/man/clEnqueueWriteImage.xml
+++ b/sdk/1.2/docs/man/clEnqueueWriteImage.xml
@@ -222,7 +222,7 @@ in all copies or substantial portions of the Materials.</holder>
                 <term> <varname> ptr </varname> </term>
                 <listitem>
                     <para>
-                        The pointer to a buffer in host memory where image data is to be written to.
+                      The pointer to a buffer in host memory where image data is to be read from.
                     </para>
                 </listitem>
             </varlistentry>

--- a/sdk/1.2/docs/man/imageDescriptor.xml
+++ b/sdk/1.2/docs/man/imageDescriptor.xml
@@ -31,7 +31,7 @@ in all copies or substantial portions of the Materials.</holder>
 
 <!-- ================================ SYNOPSIS -->
 
-    <refnamediv id="cl_image_format">
+    <refnamediv id="cl_image_desc">
         <refname>imageDescriptor</refname>
 
         <refpurpose>

--- a/sdk/1.2/docs/man/integerFunctions.xml
+++ b/sdk/1.2/docs/man/integerFunctions.xml
@@ -48,7 +48,7 @@ in all copies or substantial portions of the Materials.</holder>
 
         <row>
             <entry><citerefentry href="abs">
-                <refentrytitle>abs-diff</refentrytitle>
+                <refentrytitle>abs_diff</refentrytitle>
             </citerefentry></entry>
             <entry>|<varname>x</varname>-<varname>y</varname>| without modulo overflow</entry>
         </row>

--- a/sdk/1.2/docs/man/restrictions.xml
+++ b/sdk/1.2/docs/man/restrictions.xml
@@ -123,7 +123,7 @@ in all copies or substantial portions of the Materials.</holder>
 
           <para>
             The sampler type cannot be used to declare a structure or union field, an array of
-            samplers, a ponter to a sampler, or the return type of a function. The sampler type
+            samplers, a pointer to a sampler, or the return type of a function. The sampler type
             cannot be used with the __local and __global address space qualifiers.
           </para>
         </listitem>

--- a/sdk/2.0/docs/man/clEnqueueReadImage.xml
+++ b/sdk/2.0/docs/man/clEnqueueReadImage.xml
@@ -221,7 +221,7 @@ in all copies or substantial portions of the Materials.</holder>
                 <term> <varname> ptr </varname> </term>
                 <listitem>
                     <para>
-                      The pointer to a buffer in host memory where image data is to be read from.
+                      The pointer to a buffer in host memory where image data is to be written to.
                     </para>
                 </listitem>
             </varlistentry>

--- a/sdk/2.0/docs/man/clEnqueueWriteImage.xml
+++ b/sdk/2.0/docs/man/clEnqueueWriteImage.xml
@@ -222,7 +222,7 @@ in all copies or substantial portions of the Materials.</holder>
                 <term> <varname> ptr </varname> </term>
                 <listitem>
                     <para>
-                        The pointer to a buffer in host memory where image data is to be written to.
+                      The pointer to a buffer in host memory where image data is to be read from.
                     </para>
                 </listitem>
             </varlistentry>

--- a/sdk/2.1/docs/man/clEnqueueReadImage.xml
+++ b/sdk/2.1/docs/man/clEnqueueReadImage.xml
@@ -221,7 +221,7 @@ in all copies or substantial portions of the Materials.</holder>
                 <term> <varname> ptr </varname> </term>
                 <listitem>
                     <para>
-                      The pointer to a buffer in host memory where image data is to be read from.
+                      The pointer to a buffer in host memory where image data is to be written to.
                     </para>
                 </listitem>
             </varlistentry>

--- a/sdk/2.1/docs/man/clEnqueueWriteImage.xml
+++ b/sdk/2.1/docs/man/clEnqueueWriteImage.xml
@@ -222,7 +222,7 @@ in all copies or substantial portions of the Materials.</holder>
                 <term> <varname> ptr </varname> </term>
                 <listitem>
                     <para>
-                        The pointer to a buffer in host memory where image data is to be written to.
+                      The pointer to a buffer in host memory where image data is to be read from.
                     </para>
                 </listitem>
             </varlistentry>


### PR DESCRIPTION
A variety of typographical corrections for the man pages. I opted for editing only the `xml` files, so after the merge the `html` documentation will need to be rebuilt (and committed).