### PR TITLE
Fix CP_FP_FMA => CL_FP_FMA typo

### DIFF
--- a/sdk/1.0/docs/man/clGetDeviceInfo.xml
+++ b/sdk/1.0/docs/man/clGetDeviceInfo.xml
@@ -116,7 +116,7 @@ in all copies or substantial portions of the Materials.</holder>
 		<listitem>CL_FP_ROUND_TO_NEAREST - round to nearest even rounding mode supported.</listitem>
 		<listitem>CL_FP_ROUND_TO_ZERO - round to zero rounding mode supported.</listitem>
 		<listitem>CL_FP_ROUND_TO_INF - round to +ve and -ve infinity rounding modes supported.</listitem>
-		<listitem>CP_FP_FMA - IEEE754-2008 fused multiply-add is supported. </listitem>
+		<listitem>CL_FP_FMA - IEEE754-2008 fused multiply-add is supported. </listitem>
 	</itemizedlist>
 <para>The mandated minimum double precision floating-point capability is CL_FP_FMA |  CL_FP_ROUND_TO_NEAREST | CL_FP_ROUND_TO_ZERO | CL_FP_ROUND_TO_INF | CL_FP_INF_NAN | CL_FP_DENORM.</para></entry>
 		</row>
@@ -187,7 +187,7 @@ CL_READ_ONLY_CACHE, and CL_READ_WRITE_CACHE.</para></entry>
 		<listitem>CL_FP_ROUND_TO_NEAREST - round to nearest even rounding mode supported.</listitem>
 		<listitem>CL_FP_ROUND_TO_ZERO - round to zero rounding mode supported.</listitem>
 		<listitem>CL_FP_ROUND_TO_INF - round to +ve and -ve infinity rounding modes supported.</listitem>
-		<listitem>CP_FP_FMA - IEEE754-2008 fused multiply-add is supported. </listitem>
+		<listitem>CL_FP_FMA - IEEE754-2008 fused multiply-add is supported. </listitem>
 	</itemizedlist>
 <para>The required minimum half precision floating-point capability as implemented by this extension is CL_FP_ROUND_TO_ZERO |
 CL_FP_ROUND_TO_INF | CL_FP_INF_NAN.</para></entry>

--- a/sdk/1.1/docs/man/clGetDeviceInfo.xml
+++ b/sdk/1.1/docs/man/clGetDeviceInfo.xml
@@ -117,7 +117,7 @@ in all copies or substantial portions of the Materials.</holder>
         <listitem>CL_FP_ROUND_TO_NEAREST - round to nearest even rounding mode supported.</listitem>
         <listitem>CL_FP_ROUND_TO_ZERO - round to zero rounding mode supported.</listitem>
         <listitem>CL_FP_ROUND_TO_INF - round to +ve and -ve infinity rounding modes supported.</listitem>
-        <listitem>CP_FP_FMA - IEEE754-2008 fused multiply-add is supported. </listitem>
+        <listitem>CL_FP_FMA - IEEE754-2008 fused multiply-add is supported. </listitem>
     </itemizedlist>
 <para>The mandated minimum double precision floating-point capability is CL_FP_FMA |  CL_FP_ROUND_TO_NEAREST | CL_FP_ROUND_TO_ZERO | CL_FP_ROUND_TO_INF | CL_FP_INF_NAN | CL_FP_DENORM.</para></entry>
         </row>
@@ -185,7 +185,7 @@ CL_READ_ONLY_CACHE, and CL_READ_WRITE_CACHE.</para></entry>
         <listitem>CL_FP_ROUND_TO_NEAREST - round to nearest even rounding mode supported.</listitem>
         <listitem>CL_FP_ROUND_TO_ZERO - round to zero rounding mode supported.</listitem>
         <listitem>CL_FP_ROUND_TO_INF - round to +ve and -ve infinity rounding modes supported.</listitem>
-        <listitem>CP_FP_FMA - IEEE754-2008 fused multiply-add is supported. </listitem>
+        <listitem>CL_FP_FMA - IEEE754-2008 fused multiply-add is supported. </listitem>
         <listitem>CL_FP_SOFT_FLOAT - Basic floating-point operations (such as addition, subtraction, multiplication) are implemented in software. </listitem>
     </itemizedlist>
 <para>The required minimum half precision floating-point capability as implemented by this extension is CL_FP_ROUND_TO_ZERO or 

--- a/sdk/1.2/docs/man/clGetDeviceInfo.xml
+++ b/sdk/1.2/docs/man/clGetDeviceInfo.xml
@@ -198,7 +198,7 @@ in all copies or substantial portions of the Materials.</holder>
                         <listitem><constant>CL_FP_ROUND_TO_ZERO</constant> - round to zero rounding mode supported.</listitem>
                         <listitem><constant>CL_FP_ROUND_TO_INF</constant> -
                             round to positive and negative infinity rounding modes supported.</listitem>
-                        <listitem><constant>CP_FP_FMA</constant> - IEEE754-2008 fused multiply-add is supported. </listitem>
+                        <listitem><constant>CL_FP_FMA</constant> - IEEE754-2008 fused multiply-add is supported. </listitem>
                         <listitem><constant>CL_FP_SOFT_FLOAT</constant> -  Basic floating-point operations (such as
                             addition, subtraction, multiplication) are implemented in software.</listitem>
                       </itemizedlist>
@@ -337,7 +337,7 @@ in all copies or substantial portions of the Materials.</holder>
                         <listitem><constant>CL_FP_ROUND_TO_ZERO</constant> - round to zero rounding mode supported.</listitem>
                         <listitem><constant>CL_FP_ROUND_TO_INF</constant> - round
                     to +ve and -ve infinity rounding modes supported.</listitem>
-                        <listitem><constant>CP_FP_FMA</constant> - IEEE754-2008 fused multiply-add is supported. </listitem>
+                        <listitem><constant>CL_FP_FMA</constant> - IEEE754-2008 fused multiply-add is supported. </listitem>
                         <listitem>
                         <constant>CL_FP_SOFT_FLOAT</constant> - Basic floating-point operations
                         (such as addition, subtraction, multiplication) are implemented in software.</listitem>

--- a/sdk/2.0/docs/man/clGetDeviceInfo.xml
+++ b/sdk/2.0/docs/man/clGetDeviceInfo.xml
@@ -208,7 +208,7 @@ in all copies or substantial portions of the Materials.</holder>
                         <listitem><constant>CL_FP_ROUND_TO_ZERO</constant> - round to zero rounding mode supported.</listitem>
                         <listitem><constant>CL_FP_ROUND_TO_INF</constant> -
                             round to positive and negative infinity rounding modes supported.</listitem>
-                        <listitem><constant>CP_FP_FMA</constant> - IEEE754-2008 fused multiply-add is supported. </listitem>
+                        <listitem><constant>CL_FP_FMA</constant> - IEEE754-2008 fused multiply-add is supported. </listitem>
                         <listitem><constant>CL_FP_SOFT_FLOAT</constant> -  Basic floating-point operations (such as
                             addition, subtraction, multiplication) are implemented in software.</listitem>
                       </itemizedlist>

--- a/sdk/2.1/docs/man/clGetDeviceInfo.xml
+++ b/sdk/2.1/docs/man/clGetDeviceInfo.xml
@@ -213,7 +213,7 @@ in all copies or substantial portions of the Materials.</holder>
                         <listitem><constant>CL_FP_ROUND_TO_ZERO</constant> - round to zero rounding mode supported.</listitem>
                         <listitem><constant>CL_FP_ROUND_TO_INF</constant> -
                             round to positive and negative infinity rounding modes supported.</listitem>
-                        <listitem><constant>CP_FP_FMA</constant> - IEEE754-2008 fused multiply-add is supported. </listitem>
+                        <listitem><constant>CL_FP_FMA</constant> - IEEE754-2008 fused multiply-add is supported. </listitem>
                         <listitem><constant>CL_FP_SOFT_FLOAT</constant> -  Basic floating-point operations (such as
                             addition, subtraction, multiplication) are implemented in software.</listitem>
                       </itemizedlist>


### PR DESCRIPTION
 A typo fix I forgot in the previous round of typo fixes 8-)