### PR TITLE
Fix border color for CL_DEPTH images

### DIFF
--- a/sdk/2.0/docs/man/sampler_t.xml
+++ b/sdk/2.0/docs/man/sampler_t.xml
@@ -272,7 +272,7 @@ __constant sampler_t &lt;sampler name&gt; = &lt;value&gt;
           <listitem>
             <para>
               If the image channel order is <constant>CL_DEPTH</constant>,
-              the border value is 1.0f.
+              the border value is 0.0f.
             </para>
           </listitem>
 

--- a/sdk/2.0/docs/man/xhtml/sampler_t.html
+++ b/sdk/2.0/docs/man/xhtml/sampler_t.html
@@ -454,7 +454,7 @@ __constant sampler_t &lt;sampler name&gt; = &lt;value&gt;
             <li class="listitem" style="list-style-type: disc">
               <p>
               If the image channel order is <code class="constant">CL_DEPTH</code>,
-              the border value is 1.0f.
+              the border value is 0.0f.
             </p>
             </li>
           </ul>

--- a/sdk/2.1/docs/man/sampler_t.xml
+++ b/sdk/2.1/docs/man/sampler_t.xml
@@ -279,7 +279,7 @@ __constant sampler_t &lt;sampler name&gt; = &lt;value&gt;
           <listitem>
             <para>
               If the image channel order is <constant>CL_DEPTH</constant>,
-              the border value is 1.0f.
+              the border value is 0.0f.
             </para>
           </listitem>
 

--- a/sdk/2.1/docs/man/xhtml/sampler_t.html
+++ b/sdk/2.1/docs/man/xhtml/sampler_t.html
@@ -460,7 +460,7 @@ __constant sampler_t &lt;sampler name&gt; = &lt;value&gt;
             <li class="listitem" style="list-style-type: disc">
               <p>
               If the image channel order is <code class="constant">CL_DEPTH</code>,
-              the border value is 1.0f.
+              the border value is 0.0f.
             </p>
             </li>
           </ul>


### PR DESCRIPTION
The PDF spec has the correct value. Fixes #10.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>