### PR TITLE
allocate a new enum block for Intel extensions

### DIFF
--- a/xml/cl.xml
+++ b/xml/cl.xml
@@ -1091,8 +1091,12 @@ has no formal schema defined.
         <enum value="0x417F"      name="CL_DEVICE_PLANAR_YUV_MAX_HEIGHT_INTEL"/>
     </enums>
 
-    <enums namespace="CL" start="0x4180" end="0x4FFF" comment="Reserved for vendor extensions. Allocate in groups of 16.">
-            <unused start="0x4180" end="0x4FFF"/>
+    <enums namespace="CL" start="0x4180" end="0x418F" vendor="Intel">
+            <unused start="0x4180" end="0x418F"/>
+    </enums>
+
+    <enums namespace="CL" start="0x4190" end="0x4FFF" comment="Reserved for vendor extensions. Allocate in groups of 16.">
+            <unused start="0x4190" end="0x4FFF"/>
     </enums>
 
     <enums namespace="CL" start="0x10000" end="0x10FFF" vendor="Khronos" comment="Experimental range for internal development only. Do not allocate.">


### PR DESCRIPTION
I didn't add a "comment" for this enum block since the enums aren't requested via Bugzilla anymore.  Let me know if you'd like something else recorded as a "comment" instead.