### PR TITLE
remove 2.2 from the SPIR-V Environment Spec link

### DIFF
--- a/index.php
+++ b/index.php
@@ -40,7 +40,7 @@ include_once("../../assets/static_pages/khr_page_top.php");
      (<a href="specs/2.2/html/OpenCL_Ext.html">HTML</a>)
      (<a href="specs/2.2/pdf/OpenCL_Ext.pdf">PDF</a>)
      (May 12, 2018). </li>
-<li> OpenCL 2.2 SPIR-V Environment Specification
+<li> OpenCL SPIR-V Environment Specification
      (<a href="specs/2.2/html/OpenCL_Env.html">HTML</a>)
      (<a href="specs/2.2/pdf/OpenCL_Env.pdf">PDF</a>)
      (May 12, 2018). </li>


### PR DESCRIPTION
The OpenCL SPIR-V Environment Spec is "unified" for all versions of OpenCL; it is not specific to OpenCL 2.2.  It effectively replaces the OpenCL 2.1 SPIR-V Environment spec.