### PR TITLE
Fix various token suffixing and related issues with mipmap extension ref

### DIFF
--- a/sdk/2.0/docs/man/clCreateSamplerWithProperties.xml
+++ b/sdk/2.0/docs/man/clCreateSamplerWithProperties.xml
@@ -77,16 +77,16 @@ in all copies or substantial portions of the Materials.</holder>
                 <term> <varname>sampler_properties</varname> </term>
                 <listitem>
                     <para>
-                        Specifies a list of sampler property names and 
-                        their corresponding values. 
-                        Each sampler property name is immediately followed 
-                        by the corresponding desired value. The 
-                        list is terminated with 0. The list of supported 
-                        properties is described in the table below. If a 
-                        supported property and its value is not specified in 
-                        <varname>sampler_properties</varname>, its default value will be 
-                        used. <varname>sampler_properties</varname> can be 
-                        NULL in which case the default values for supported sampler 
+                        Specifies a list of sampler property names and
+                        their corresponding values.
+                        Each sampler property name is immediately followed
+                        by the corresponding desired value. The
+                        list is terminated with 0. The list of supported
+                        properties is described in the table below. If a
+                        supported property and its value is not specified in
+                        <varname>sampler_properties</varname>, its default value will be
+                        used. <varname>sampler_properties</varname> can be
+                        NULL in which case the default values for supported sampler
                         properties will be used.
                     </para>
 
@@ -110,13 +110,13 @@ in all copies or substantial portions of the Materials.</holder>
                         <entry><type>cl_bool</type></entry>
                         <entry>
                             <para>
-                                A boolean value that specifies 
-                                whether the image coordinates 
+                                A boolean value that specifies
+                                whether the image coordinates
                                 specified are normalized or not.
                             </para>
 
                             <para>
-                                The default value (i.e. the value used 
+                                The default value (i.e. the value used
                                 if this property is not specified in
                                 <varname>sampler_properties</varname>) is <constant>CL_TRUE</constant>.
                             </para>
@@ -128,8 +128,8 @@ in all copies or substantial portions of the Materials.</holder>
                         <entry><type>cl_addressing_mode</type></entry>
                         <entry>
                             <para>
-                                Specifies how out-of-range image 
-                                coordinates are handled when reading 
+                                Specifies how out-of-range image
+                                coordinates are handled when reading
                                 from an image.
                             </para>
 
@@ -170,8 +170,8 @@ in all copies or substantial portions of the Materials.</holder>
                         <entry><type>cl_filter_mode</type></entry>
                         <entry>
                             <para>
-                                Specifies the type of filter that must 
-                                be applied when reading an image. 
+                                Specifies the type of filter that must
+                                be applied when reading an image.
                                 Valid values are:
                             </para>
 
@@ -191,19 +191,19 @@ in all copies or substantial portions of the Materials.</holder>
                             </para>
                         </entry>
                     </row>
-                </tbody>  
+                </tbody>
             </tgroup>
         </informaltable>
 
         <!-- Table 5.14, additions from the extension spec -->
 
         <para>
-            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry> 
-            extension is supported, the following sampler 
-            properties can be specified when a sampler object is 
+            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry>
+            extension is supported, the following sampler
+            properties can be specified when a sampler object is
             created using <function>clCreateSamplerWithProperties</function>:
         </para>
-              
+
         <informaltable frame="all">
             <tgroup cols="3" align="left" colsep="1" rowsep="1">
                 <colspec colname="col1" colnum="1" />
@@ -219,23 +219,23 @@ in all copies or substantial portions of the Materials.</holder>
 
                 <tbody>
                     <row>
-                        <entry><constant>CL_SAMPLER_MIP_FILTER_MODE</constant></entry>
+                        <entry><constant>CL_SAMPLER_MIP_FILTER_MODE_KHR</constant></entry>
                         <entry><type>cl_filter_mode</type></entry>
-                        <entry><constant>CL_FILTER_NONE</constant></entry>
+                        <entry><constant>CL_FILTER_NEAREST</constant></entry>
                     </row>
 
                     <row>
-                        <entry><constant>CL_SAMPLER_LOD_MIN</constant></entry>
-                        <entry><type>float</type></entry>
+                        <entry><constant>CL_SAMPLER_LOD_MIN_KHR</constant></entry>
+                        <entry><type>cl_float</type></entry>
                         <entry><constant>0.0f</constant></entry>
                     </row>
 
                     <row>
-                        <entry><constant>CL_SAMPLER_LOD_MAX</constant></entry>
-                        <entry><type>float</type></entry>
+                        <entry><constant>CL_SAMPLER_LOD_MAX_KHR</constant></entry>
+                        <entry><type>cl_float</type></entry>
                         <entry><constant>MAXFLOAT</constant></entry>
                     </row>
-                </tbody>  
+                </tbody>
             </tgroup>
         </informaltable>
 
@@ -272,17 +272,17 @@ in all copies or substantial portions of the Materials.</holder>
         </para>
 
         <para>
-            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry> 
-            extension is supported, the sampler properties 
-            <constant>CL_SAMPLER_MIP_FILTER_MODE</constant>, 
-            <constant>CL_SAMPLER_LOD_MIN</constant> and 
-            <constant>CL_SAMPLER_LOD_MAX</constant> cannot be 
-            specified with any samplers initialized in the OpenCL 
-            program source. Only the default values for these 
-            properties will be used. To create a sampler 
-            with specific values for these properties, a 
-            sampler object must be created with 
-            <function>clCreateSamplerWithProperties</function> 
+            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry>
+            extension is supported, the sampler properties
+            <constant>CL_SAMPLER_MIP_FILTER_MODE_KHR</constant>,
+            <constant>CL_SAMPLER_LOD_MIN_KHR</constant> and
+            <constant>CL_SAMPLER_LOD_MAX_KHR</constant> cannot be
+            specified with any samplers initialized in the OpenCL
+            program source. Only the default values for these
+            properties will be used. To create a sampler
+            with specific values for these properties, a
+            sampler object must be created with
+            <function>clCreateSamplerWithProperties</function>
             and passed as an argument to a kernel.
         </para>
 
@@ -305,10 +305,10 @@ in all copies or substantial portions of the Materials.</holder>
             </listitem>
 
             <listitem>
-              <errorname>CL_INVALID_VALUE</errorname> if the property 
-                name in <varname>sampler_properties</varname> is not a supported 
-                property name, if the value specified for a supported property 
-                name is not valid, or if the 
+              <errorname>CL_INVALID_VALUE</errorname> if the property
+                name in <varname>sampler_properties</varname> is not a supported
+                property name, if the value specified for a supported property
+                name is not valid, or if the
                 same property name is specified more than once.
             </listitem>
 
@@ -376,7 +376,7 @@ in all copies or substantial portions of the Materials.</holder>
             <citerefentry><refentrytitle>clRetainSampler</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>clReleaseSampler</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>clGetSamplerInfo</refentrytitle></citerefentry>
-            <citerefentry><refentrytitle>sampler_t</refentrytitle></citerefentry>,     
+            <citerefentry><refentrytitle>sampler_t</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry>
         </para>
     </refsect1>

--- a/sdk/2.0/docs/man/cl_khr_mipmap_image.xml
+++ b/sdk/2.0/docs/man/cl_khr_mipmap_image.xml
@@ -66,101 +66,101 @@ in all copies or substantial portions of the Materials.</holder>
 
     <refsect1 id="description"><title>Description</title>
         <para>
-            This extension adds support for mipmaps. This proposal is implemented 
-            as two optional extensions. The <function>cl_khr_mipmap_image</function> 
-            extension implements support to create a mipmapped image, enqueue commands 
-            to read/write/copy/map a region of a mipmapped image and built-in 
-            functions that can be used to read a mip-mapped image in an OpenCL C 
-            program. The <function>cl_khr_mipmap_image_writes</function> extension 
-            adds built-in functions that can be used to write a mip-mapped image in 
-            an OpenCL C program. If the <function>cl_khr_mipmap_image_writes</function> 
-            extension is supported by the OpenCL device, the 
+            This extension adds support for mipmaps. This proposal is implemented
+            as two optional extensions. The <function>cl_khr_mipmap_image</function>
+            extension implements support to create a mipmapped image, enqueue commands
+            to read/write/copy/map a region of a mipmapped image and built-in
+            functions that can be used to read a mip-mapped image in an OpenCL C
+            program. The <function>cl_khr_mipmap_image_writes</function> extension
+            adds built-in functions that can be used to write a mip-mapped image in
+            an OpenCL C program. If the <function>cl_khr_mipmap_image_writes</function>
+            extension is supported by the OpenCL device, the
             <function>cl_khr_mipmap_image</function> extension must also be supported.
         </para>
 
         <bridgehead>Additions to section 5.3 – Image Objects:</bridgehead>
 
         <para>
-            A mip-mapped 1D image, 1D image array, 2D image, 2D image array 
-            or 3D image is created by specifying <varname>num_mip_levels</varname> 
-            to be a value &gt; 1 in <varname>cl_image_desc</varname> passed to 
-            <citerefentry><refentrytitle>clCreateImage</refentrytitle></citerefentry>. 
-            The dimensions of a mip-mapped image can be a power of two or a 
-            non-power of two. Each successively smaller mipmap level is half 
-            the size of the previous level. If this half value is a fractional 
+            A mip-mapped 1D image, 1D image array, 2D image, 2D image array
+            or 3D image is created by specifying <varname>num_mip_levels</varname>
+            to be a value &gt; 1 in <varname>cl_image_desc</varname> passed to
+            <citerefentry><refentrytitle>clCreateImage</refentrytitle></citerefentry>.
+            The dimensions of a mip-mapped image can be a power of two or a
+            non-power of two. Each successively smaller mipmap level is half
+            the size of the previous level. If this half value is a fractional
             value, it is rounded down to the nearest integer.
         </para>
 
         <itemizedlist>
             <listitem>
-                The following restrictions apply when mip-mapped images are created 
+                The following restrictions apply when mip-mapped images are created
                 with <citerefentry><refentrytitle>clCreateImage</refentrytitle></citerefentry>:
             </listitem>
 
             <listitem>
-                <constant>CL_MEM_USE_HOST_PTR</constant> or <constant>CL_MEM_COPY_HOST_PTR</constant> 
+                <constant>CL_MEM_USE_HOST_PTR</constant> or <constant>CL_MEM_COPY_HOST_PTR</constant>
                 cannot be specified if a mipmapped image is created.
             </listitem>
 
             <listitem>
-                The <varname>host_ptr</varname> argument to 
-                <citerefentry><refentrytitle>clCreateImage</refentrytitle></citerefentry> 
+                The <varname>host_ptr</varname> argument to
+                <citerefentry><refentrytitle>clCreateImage</refentrytitle></citerefentry>
                 must be a NULL value.
             </listitem>
 
             <listitem>
-                Mip-mapped images cnnot be created for <constant>CL_MEM_OBJECT_IMAGE1D_BUFFER</constant> 
+                Mip-mapped images cnnot be created for <constant>CL_MEM_OBJECT_IMAGE1D_BUFFER</constant>
                 images and multi-sampled (i.e. msaa) images.
             </listitem>
         </itemizedlist>
 
         <para>
-            Calls to <citerefentry><refentrytitle>clEnqueueReadImage</refentrytitle></citerefentry>, 
-            <citerefentry><refentrytitle>clEnqueueWriteImage</refentrytitle></citerefentry>, and 
+            Calls to <citerefentry><refentrytitle>clEnqueueReadImage</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>clEnqueueWriteImage</refentrytitle></citerefentry>, and
             <citerefentry><refentrytitle>clEnqueueMapImage</refentrytitle></citerefentry> can be used
-            to read from or write to a specific mip-level of a mip-mapped image. 
-            If <varname>image</varname> argument is a 1D image, 
-            <varname>origin</varname>[1] specifies the mip-level to use. 
-            If <varname>image</varname> argument is a 1D image array, 
-            <varname>origin</varname>[2] specifies the mip-level to use. 
-            If <varname>image</varname> argument is a 2D image, 
-            <varname>origin</varname>[3] specifies the mip-level to use. 
-            If <varname>image</varname> argument is a 2D image array or a 3D image, 
+            to read from or write to a specific mip-level of a mip-mapped image.
+            If <varname>image</varname> argument is a 1D image,
+            <varname>origin</varname>[1] specifies the mip-level to use.
+            If <varname>image</varname> argument is a 1D image array,
+            <varname>origin</varname>[2] specifies the mip-level to use.
+            If <varname>image</varname> argument is a 2D image,
+            <varname>origin</varname>[3] specifies the mip-level to use.
+            If <varname>image</varname> argument is a 2D image array or a 3D image,
             <varname>origin</varname>[3] specifies the mip-level to use.
         </para>
 
         <para>
-            Calls to <citerefentry><refentrytitle>clEnqueueCopyImage</refentrytitle></citerefentry>, 
+            Calls to <citerefentry><refentrytitle>clEnqueueCopyImage</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>clEnqueueCopyImageToBuffer</refentrytitle></citerefentry>, and
-            <citerefentry><refentrytitle>clEnqueueCopyBufferToImage</refentrytitle></citerefentry> can also 
-            be used to copy from and to a specific mip-level of a mip-mapped image. 
-            If <varname>src_image</varname> argument is a 1D image, 
-            <varname>src_origin</varname>[1] specifies the mip-level to use. 
-            If <varname>src_image</varname> argument is a 1D image array, 
+            <citerefentry><refentrytitle>clEnqueueCopyBufferToImage</refentrytitle></citerefentry> can also
+            be used to copy from and to a specific mip-level of a mip-mapped image.
+            If <varname>src_image</varname> argument is a 1D image,
+            <varname>src_origin</varname>[1] specifies the mip-level to use.
+            If <varname>src_image</varname> argument is a 1D image array,
             <varname>src_origin</varname>[2] specifies the mip-level to use.
-            If <varname>src_image</varname> argument is a 2D image, 
-            <varname>src_origin</varname>[3] specifies the mip-level to use. 
-            If <varname>src_image</varname> argument is a 2D image array or a 3D image, 
-            <varname>src_origin</varname>[3] specifies the mip-level to use. 
-            If <varname>dst_image</varname> argument is a 1D image, 
-            <varname>dst_origin</varname>[1] specifies the mip-level to use. 
-            If <varname>dst_image</varname> argument is a 1D image array, 
-            <varname>dst_origin</varname>[2] specifies the mip-level to use. 
-            If <varname>dst_image</varname> argument is a 2D image, 
-            <varname>dst_origin</varname>[3] specifies the mip-level to use. 
-            If <varname>dst_image</varname> argument is a 2D image array or a 3D image, 
+            If <varname>src_image</varname> argument is a 2D image,
+            <varname>src_origin</varname>[3] specifies the mip-level to use.
+            If <varname>src_image</varname> argument is a 2D image array or a 3D image,
+            <varname>src_origin</varname>[3] specifies the mip-level to use.
+            If <varname>dst_image</varname> argument is a 1D image,
+            <varname>dst_origin</varname>[1] specifies the mip-level to use.
+            If <varname>dst_image</varname> argument is a 1D image array,
+            <varname>dst_origin</varname>[2] specifies the mip-level to use.
+            If <varname>dst_image</varname> argument is a 2D image,
+            <varname>dst_origin</varname>[3] specifies the mip-level to use.
+            If <varname>dst_image</varname> argument is a 2D image array or a 3D image,
             <varname>dst_origin</varname>[3] specifies the mip-level to use.
         </para>
 
         <para>
-            If the mip level specified is not a valid value, these functions 
+            If the mip level specified is not a valid value, these functions
             return the error <errorname>CL_INVALID_MIP_LEVEL</errorname>.
         </para>
 
         <bridgehead>Additions to section 5.7 – Sampler Objects:</bridgehead>
 
         <para>
-            Add the following sampler properties that can be specified when a sampler object is created using 
+            Add the following sampler properties that can be specified when a sampler object is created using
             <citerefentry><refentrytitle>clCreateSamplerWithProperties</refentrytitle></citerefentry>.
         </para>
 
@@ -180,20 +180,20 @@ in all copies or substantial portions of the Materials.</holder>
 
                 <tbody>
                     <row>
-                        <entry><constant>CL_SAMPLER_MIP_FILTER_MODE</constant></entry>
+                        <entry><constant>CL_SAMPLER_MIP_FILTER_MODE_KHR</constant></entry>
                         <entry>cl_filter_mode</entry>
-                        <entry><constant>CL_FILTER_NONE</constant></entry>
+                        <entry><constant>CL_FILTER_NEAREST</constant></entry>
                     </row>
 
                     <row>
-                        <entry><constant>CL_SAMPLER_LOD_MIN</constant></entry>
-                        <entry>float</entry>
+                        <entry><constant>CL_SAMPLER_LOD_MIN_KHR</constant></entry>
+                        <entry>cl_float</entry>
                         <entry>0.0f</entry>
                     </row>
 
                     <row>
-                        <entry><constant>CL_SAMPLER_LOD_MAX</constant></entry>
-                        <entry>float</entry>
+                        <entry><constant>CL_SAMPLER_LOD_MAX_KHR</constant></entry>
+                        <entry>cl_float</entry>
                         <entry><constant>MAXFLOAT</constant></entry>
                     </row>
 
@@ -202,52 +202,52 @@ in all copies or substantial portions of the Materials.</holder>
         </informaltable>
 
         <para>
-            NOTE: The sampler properties <constant>CL_SAMPLER_MIP_FILTER_MODE</constant>,
-             <constant>CL_SAMPLER_LOD_MIN</constant>, and 
-            <constant>CL_SAMPLER_LOD_MAX</constant> cannot be specified with any 
-            samplers initialized in the OpenCL program source. Only the default 
-            values for these properties will be used. To create a sampler with 
+            NOTE: The sampler properties <constant>CL_SAMPLER_MIP_FILTER_MODE_KHR</constant>,
+            <constant>CL_SAMPLER_LOD_MIN_KHR</constant>, and
+            <constant>CL_SAMPLER_LOD_MAX_KHR</constant> cannot be specified with any
+            samplers initialized in the OpenCL program source. Only the default
+            values for these properties will be used. To create a sampler with
             specific values for these properties, a sampler object must be created with
-            <citerefentry><refentrytitle>clCreateSamplerWithProperties</refentrytitle></citerefentry> 
+            <citerefentry><refentrytitle>clCreateSamplerWithProperties</refentrytitle></citerefentry>
             and passed as an argument to a kernel.
         </para>
 
         <bridgehead>Additions to section 6.13.14 – Image Read, Write, and Query Functions</bridgehead>
 
         <para>
-            The image read and write functions read from and write to mip-level 
-            0 if the <varname>image</varname> argument is a mip-mapped image. 
-            New built-in image read, write, and query functions are added to the 
-            <citerefentry href="imageFunctions"><refentrytitle>image functions</refentrytitle></citerefentry> 
+            The image read and write functions read from and write to mip-level
+            0 if the <varname>image</varname> argument is a mip-mapped image.
+            New built-in image read, write, and query functions are added to the
+            <citerefentry href="imageFunctions"><refentrytitle>image functions</refentrytitle></citerefentry>
             available.
         </para>
 
         <para>
-            NOTE: <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be 
-            <constant>CL_TRUE</constant> for the new built-in read functions 
-            referred to above that read from a mip-mapped image; otherwise 
-            the behavior is undefined. The value specified in the 
-            <varname>lod</varname> argument is clamped to the minimum of 
-            (actual number of mip-levels – 1) in the image or value 
-            specified for <constant>CL_SAMPLER_LOD_MAX</constant>.
+            NOTE: <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be
+            <constant>CL_TRUE</constant> for the new built-in read functions
+            referred to above that read from a mip-mapped image; otherwise
+            the behavior is undefined. The value specified in the
+            <varname>lod</varname> argument is clamped to the minimum of
+            (actual number of mip-levels – 1) in the image or value
+            specified for <constant>CL_SAMPLER_LOD_MAX_KHR</constant>.
         </para>
 
         <bridgehead>Additions to section 9.7 – Sharing Memory Objects with OpenGL / OpenGL ES Texture Objects</bridgehead>
 
         <para>
-            If the <function>cl_khr_mipmap_image</function> extension is 
-            supported by the OpenCL device, the 
-            <citerefentry><refentrytitle>cl_khr_gl_sharing</refentrytitle></citerefentry> 
+            If the <function>cl_khr_mipmap_image</function> extension is
+            supported by the OpenCL device, the
+            <citerefentry><refentrytitle>cl_khr_gl_sharing</refentrytitle></citerefentry>
             extension adds support for creating a mip-mapped CL image from a mip-mapped GL texture.
         </para>
 
         <para>
-            To create a mip-mapped CL image from a mip-mapped GL texture, the 
-            <varname>miplevel</varname> argument to 
-            <citerefentry><refentrytitle>clCreateFromGLTexture</refentrytitle></citerefentry> 
-            should be a negative value. If <varname>miplevel</varname> is a negative 
-            value then a CL mipmapped image object is created from a mipmapped 
-            GL texture object instead of a CL image object for a specific 
+            To create a mip-mapped CL image from a mip-mapped GL texture, the
+            <varname>miplevel</varname> argument to
+            <citerefentry><refentrytitle>clCreateFromGLTexture</refentrytitle></citerefentry>
+            should be a negative value. If <varname>miplevel</varname> is a negative
+            value then a CL mipmapped image object is created from a mipmapped
+            GL texture object instead of a CL image object for a specific
             miplevel of a GL texture.
         </para>
 
@@ -297,12 +297,12 @@ in all copies or substantial portions of the Materials.</holder>
             <citerefentry><refentrytitle>clCreateProgramWithBinary</refentrytitle></citerefentry>,
             <citerefentry href="imageFunctions"><refentrytitle>Image Functions</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>clCreateFromGLTexture</refentrytitle></citerefentry>,
-            <citerefentry><refentrytitle>clEnqueueCopyImage</refentrytitle></citerefentry>, 
-            <citerefentry><refentrytitle>clEnqueueCopyImageToBuffer</refentrytitle></citerefentry>, 
-            <citerefentry><refentrytitle>clEnqueueCopyBufferToImage</refentrytitle></citerefentry>, 
-            <citerefentry><refentrytitle>clEnqueueReadImage</refentrytitle></citerefentry>, 
-            <citerefentry><refentrytitle>clEnqueueWriteImage</refentrytitle></citerefentry>,  
-            <citerefentry><refentrytitle>clEnqueueMapImage</refentrytitle></citerefentry>, 
+            <citerefentry><refentrytitle>clEnqueueCopyImage</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>clEnqueueCopyImageToBuffer</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>clEnqueueCopyBufferToImage</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>clEnqueueReadImage</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>clEnqueueWriteImage</refentrytitle></citerefentry>,
+            <citerefentry><refentrytitle>clEnqueueMapImage</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>clCreateImage</refentrytitle></citerefentry>
         </para>
     </refsect1>

--- a/sdk/2.0/docs/man/imageMappingInc.xml
+++ b/sdk/2.0/docs/man/imageMappingInc.xml
@@ -1,5 +1,5 @@
   <bridgehead>Mapping image channels to color values</bridgehead>
-  
+
   <para>
     <!-- section 6.13.14.7 --> The following table describes the mapping
     of the number of channels of an image element to the appropriate components in the
@@ -46,9 +46,9 @@
 
           <row>
             <entry>
-               <constant>CL_RGB</constant>, 
-               <constant>CL_RGBx</constant>, 
-               <constant>CL_sRGB</constant>, 
+               <constant>CL_RGB</constant>,
+               <constant>CL_RGBx</constant>,
+               <constant>CL_sRGB</constant>,
                <constant>CL_sRGBx</constant>
             </entry>
 
@@ -76,7 +76,7 @@
   </para>
 
   <para>
-      For <constant>CL_DEPTH</constant> images, a scalar value is 
+      For <constant>CL_DEPTH</constant> images, a scalar value is
       returned by <function>read_imagef</function> or supplied to
       <function>write_imagef</function>.
   </para>
@@ -95,14 +95,14 @@
   </para>
 
     <para>
-        <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be 
+        <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be
         <constant>CL_TRUE</constant> for built-in functions
-        described in the table above that read from a mip-mapped 
+        described in the table above that read from a mip-mapped
         image; otherwise the behavior is
-        undefined. The value specified in the <varname>lod</varname> 
+        undefined. The value specified in the <varname>lod</varname>
         argument is clamped to the minimum of (actual
-        number of mip-levels – 1) in the image or value specified for 
-        <constant>CL_SAMPLER_LOD_MAX</constant>.
+        number of mip-levels – 1) in the image or value specified for
+        <constant>CL_SAMPLER_LOD_MAX_KHR</constant>.
     </para>
 
 <!-- 17-Dec-2013, rev. 19 -->

--- a/sdk/2.0/docs/man/read_imagef3d.xml
+++ b/sdk/2.0/docs/man/read_imagef3d.xml
@@ -109,7 +109,7 @@ in all copies or substantial portions of the Materials.</holder>
             </funcprototype>
         </funcsynopsis>
 
-        <bridgehead>Functions added with mipmap support enabled by extension 
+        <bridgehead>Functions added with mipmap support enabled by extension
         <code>cl_khr_mipmap_image</code>:</bridgehead>
 
         <funcsynopsis>
@@ -240,14 +240,14 @@ in all copies or substantial portions of the Materials.</holder>
         <bridgehead>Mipmap read image functions:</bridgehead>
 
         <para>
-            <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be 
+            <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be
             <constant>CL_TRUE</constant> for built-in functions
-            described in the table above that read from a mip-mapped 
+            described in the table above that read from a mip-mapped
             image; otherwise the behavior is
-            undefined. The value specified in the <varname>lod</varname> 
+            undefined. The value specified in the <varname>lod</varname>
             argument is clamped to the minimum of (actual
-            number of mip-levels – 1) in the image or value specified 
-            for <constant>CL_SAMPLER_LOD_MAX</constant>.
+            number of mip-levels – 1) in the image or value specified
+            for <constant>CL_SAMPLER_LOD_MAX_KHR</constant>.
         </para>
 
     </refsect1>

--- a/sdk/2.0/docs/man/read_imagei2d.xml
+++ b/sdk/2.0/docs/man/read_imagei2d.xml
@@ -310,7 +310,7 @@ in all copies or substantial portions of the Materials.</holder>
         </funcsynopsis>
 
 
-        <bridgehead>Functions added with mipmap support enabled by extension 
+        <bridgehead>Functions added with mipmap support enabled by extension
         <code>cl_khr_mipmap_image</code>:</bridgehead>
 
         <funcsynopsis>
@@ -533,7 +533,7 @@ in all copies or substantial portions of the Materials.</holder>
         </funcsynopsis>
 
 
-        <bridgehead>Functions added with MSAA support enabled by extension 
+        <bridgehead>Functions added with MSAA support enabled by extension
         <code>cl_khr_gl_msaa_sharing</code>:</bridgehead>
 
         <funcsynopsis>
@@ -641,9 +641,9 @@ in all copies or substantial portions of the Materials.</holder>
 
         <para>
           For the forms that take an <type>image2d_array_t</type> object, use
-          the gradients to compute the lod and 
-          coordinate <emphasis>coord.xy</emphasis> to do an element lookup in 
-          the mip-level specified by the computed lod in 
+          the gradients to compute the lod and
+          coordinate <emphasis>coord.xy</emphasis> to do an element lookup in
+          the mip-level specified by the computed lod in
           the 2D image object specified by <varname>image</varname>.
         </para>
 
@@ -655,15 +655,15 @@ in all copies or substantial portions of the Materials.</holder>
 
         <para>
             For forms that take <type>image2d_msaa_t</type>,
-            use the coordinate (<varname>coord.x, coord.y</varname>) and <varname>sample</varname> to 
-            do an element lookup in the 2D image object 
+            use the coordinate (<varname>coord.x, coord.y</varname>) and <varname>sample</varname> to
+            do an element lookup in the 2D image object
             specified by <varname>image</varname>.
         </para>
 
         <para>
             For forms that take <type>image2d_array_msaa_t</type>,
-            use <varname>coord.xy</varname> and <varname>sample</varname> to do an element lookup in 
-            the 2D image identified by <varname>coord.z</varname> in the 2D image 
+            use <varname>coord.xy</varname> and <varname>sample</varname> to do an element lookup in
+            the 2D image identified by <varname>coord.z</varname> in the 2D image
             array specified by <varname>image</varname>.
         </para>
 
@@ -701,7 +701,7 @@ in all copies or substantial portions of the Materials.</holder>
         </para>
 
         <para>
-          For the forms that take a sampler, the <function>read_imagei</function> and 
+          For the forms that take a sampler, the <function>read_imagei</function> and
           <function>read_imageui</function> calls
           support a nearest filter only. The <varname>filter_mode</varname> specified in
           <varname>sampler</varname> must be set to <constant>CLK_FILTER_NEAREST</constant>;
@@ -709,7 +709,7 @@ in all copies or substantial portions of the Materials.</holder>
         </para>
 
         <para>
-          Furthermore, for the forms that take a sampler, the <function>read_imagei</function> 
+          Furthermore, for the forms that take a sampler, the <function>read_imagei</function>
           and <function>read_imageui</function>
           calls that take integer coordinates must use a sampler with normalized coordinates
           set to <constant>CLK_NORMALIZED_COORDS_FALSE</constant> and addressing mode set to
@@ -735,7 +735,7 @@ in all copies or substantial portions of the Materials.</holder>
             <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be <constant>CL_TRUE</constant> for built-in functions
             described in the table above that read from a mip-mapped image; otherwise the behavior is
             undefined. The value specified in the <varname>lod</varname> argument is clamped to the minimum of (actual
-            number of mip-levels – 1) in the image or value specified for <constant>CL_SAMPLER_LOD_MAX</constant>.
+            number of mip-levels – 1) in the image or value specified for <constant>CL_SAMPLER_LOD_MAX_KHR</constant>.
         </para>
 
     </refsect1>

--- a/sdk/2.0/docs/man/read_imagei3d.xml
+++ b/sdk/2.0/docs/man/read_imagei3d.xml
@@ -179,7 +179,7 @@ in all copies or substantial portions of the Materials.</holder>
             </funcprototype>
         </funcsynopsis>
 
-        <bridgehead>Functions added with mipmap support enabled by extension 
+        <bridgehead>Functions added with mipmap support enabled by extension
         <code>cl_khr_mipmap_image</code>:</bridgehead>
 
         <funcsynopsis>
@@ -313,8 +313,8 @@ in all copies or substantial portions of the Materials.</holder>
           For the forms that take
           a <type>sampler_t</type> and which are enabled by the
           <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry>
-          extension, use the coordinate <emphasis>coord.xyz</emphasis> to do an 
-          element lookup in the mip-level specified by <varname>lod</varname> 
+          extension, use the coordinate <emphasis>coord.xyz</emphasis> to do an
+          element lookup in the mip-level specified by <varname>lod</varname>
           in the 3D image object specified by <varname>image</varname>.
         </para>
 
@@ -379,14 +379,14 @@ in all copies or substantial portions of the Materials.</holder>
         <bridgehead>Mipmap read image functions:</bridgehead>
 
         <para>
-            <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be 
+            <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be
             <constant>CL_TRUE</constant> for built-in functions
-            described in the table above that read from a mip-mapped 
+            described in the table above that read from a mip-mapped
             image; otherwise the behavior is
-            undefined. The value specified in the <varname>lod</varname> 
+            undefined. The value specified in the <varname>lod</varname>
             argument is clamped to the minimum of (actual
-            number of mip-levels – 1) in the image or value specified for 
-            <constant>CL_SAMPLER_LOD_MAX</constant>.
+            number of mip-levels – 1) in the image or value specified for
+            <constant>CL_SAMPLER_LOD_MAX_KHR</constant>.
         </para>
     </refsect1>
 

--- a/sdk/2.1/docs/man/clCreateSamplerWithProperties.xml
+++ b/sdk/2.1/docs/man/clCreateSamplerWithProperties.xml
@@ -77,16 +77,16 @@ in all copies or substantial portions of the Materials.</holder>
                 <term> <varname>sampler_properties</varname> </term>
                 <listitem>
                     <para>
-                        Specifies a list of sampler property names and 
-                        their corresponding values. 
-                        Each sampler property name is immediately followed 
-                        by the corresponding desired value. The 
-                        list is terminated with 0. The list of supported 
-                        properties is described in the table below. If a 
-                        supported property and its value is not specified in 
-                        <varname>sampler_properties</varname>, its default value will be 
-                        used. <varname>sampler_properties</varname> can be 
-                        NULL in which case the default values for supported sampler 
+                        Specifies a list of sampler property names and
+                        their corresponding values.
+                        Each sampler property name is immediately followed
+                        by the corresponding desired value. The
+                        list is terminated with 0. The list of supported
+                        properties is described in the table below. If a
+                        supported property and its value is not specified in
+                        <varname>sampler_properties</varname>, its default value will be
+                        used. <varname>sampler_properties</varname> can be
+                        NULL in which case the default values for supported sampler
                         properties will be used.
                     </para>
 
@@ -110,13 +110,13 @@ in all copies or substantial portions of the Materials.</holder>
                         <entry><type>cl_bool</type></entry>
                         <entry>
                             <para>
-                                A boolean value that specifies 
-                                whether the image coordinates 
+                                A boolean value that specifies
+                                whether the image coordinates
                                 specified are normalized or not.
                             </para>
 
                             <para>
-                                The default value (i.e. the value used 
+                                The default value (i.e. the value used
                                 if this property is not specified in
                                 <varname>sampler_properties</varname>) is <constant>CL_TRUE</constant>.
                             </para>
@@ -128,8 +128,8 @@ in all copies or substantial portions of the Materials.</holder>
                         <entry><type>cl_addressing_mode</type></entry>
                         <entry>
                             <para>
-                                Specifies how out-of-range image 
-                                coordinates are handled when reading 
+                                Specifies how out-of-range image
+                                coordinates are handled when reading
                                 from an image.
                             </para>
 
@@ -170,8 +170,8 @@ in all copies or substantial portions of the Materials.</holder>
                         <entry><type>cl_filter_mode</type></entry>
                         <entry>
                             <para>
-                                Specifies the type of filter that must 
-                                be applied when reading an image. 
+                                Specifies the type of filter that must
+                                be applied when reading an image.
                                 Valid values are:
                             </para>
 
@@ -191,19 +191,19 @@ in all copies or substantial portions of the Materials.</holder>
                             </para>
                         </entry>
                     </row>
-                </tbody>  
+                </tbody>
             </tgroup>
         </informaltable>
 
         <!-- Table 5.14, additions from the extension spec -->
 
         <para>
-            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry> 
-            extension is supported, the following sampler 
-            properties can be specified when a sampler object is 
+            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry>
+            extension is supported, the following sampler
+            properties can be specified when a sampler object is
             created using <function>clCreateSamplerWithProperties</function>:
         </para>
-              
+
         <informaltable frame="all">
             <tgroup cols="3" align="left" colsep="1" rowsep="1">
                 <colspec colname="col1" colnum="1" />
@@ -226,31 +226,31 @@ in all copies or substantial portions of the Materials.</holder>
 
                     <row>
                         <entry><constant>CL_SAMPLER_LOD_MIN_KHR</constant></entry>
-                        <entry><type>float</type></entry>
+                        <entry><type>cl_float</type></entry>
                         <entry><constant>0.0f</constant></entry>
                     </row>
 
                     <row>
                         <entry><constant>CL_SAMPLER_LOD_MAX_KHR</constant></entry>
-                        <entry><type>float</type></entry>
+                        <entry><type>cl_float</type></entry>
                         <entry><constant>MAXFLOAT</constant></entry>
                     </row>
-                </tbody>  
+                </tbody>
             </tgroup>
         </informaltable>
 
         <para>
-            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry> 
+            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry>
             extension is supported,
-            The sampler properties 
+            The sampler properties
             <constant>CL_SAMPLER_MIP_FILTER_MODE_KHR</constant>,
-            <constant>CL_SAMPLER_LOD_MIN_KHR</constant> and 
+            <constant>CL_SAMPLER_LOD_MIN_KHR</constant> and
             <constant>CL_SAMPLER_LOD_MAX_KHR</constant> cannot be specified with
-            any samplers initialized in the OpenCL program 
+            any samplers initialized in the OpenCL program
             source. Only the default values for these
-            properties will be used. To create a sampler 
+            properties will be used. To create a sampler
             with specific values for these properties, a sampler
-            object must be created with 
+            object must be created with
             <function>clCreateSamplerWithProperties</function>
             and passed as an argument to a kernel.
         </para>
@@ -288,17 +288,17 @@ in all copies or substantial portions of the Materials.</holder>
         </para>
 
         <para>
-            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry> 
-            extension is supported, the sampler properties 
-            <constant>CL_SAMPLER_MIP_FILTER_MODE</constant>, 
-            <constant>CL_SAMPLER_LOD_MIN</constant> and 
-            <constant>CL_SAMPLER_LOD_MAX</constant> cannot be 
-            specified with any samplers initialized in the OpenCL 
-            program source. Only the default values for these 
-            properties will be used. To create a sampler 
-            with specific values for these properties, a 
-            sampler object must be created with 
-            <function>clCreateSamplerWithProperties</function> 
+            If the <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry>
+            extension is supported, the sampler properties
+            <constant>CL_SAMPLER_MIP_FILTER_MODE_KHR</constant>,
+            <constant>CL_SAMPLER_LOD_MIN_KHR</constant> and
+            <constant>CL_SAMPLER_LOD_MAX_KHR</constant> cannot be
+            specified with any samplers initialized in the OpenCL
+            program source. Only the default values for these
+            properties will be used. To create a sampler
+            with specific values for these properties, a
+            sampler object must be created with
+            <function>clCreateSamplerWithProperties</function>
             and passed as an argument to a kernel.
         </para>
 
@@ -321,10 +321,10 @@ in all copies or substantial portions of the Materials.</holder>
             </listitem>
 
             <listitem>
-              <errorname>CL_INVALID_VALUE</errorname> if the property 
-                name in <varname>sampler_properties</varname> is not a supported 
-                property name, if the value specified for a supported property 
-                name is not valid, or if the 
+              <errorname>CL_INVALID_VALUE</errorname> if the property
+                name in <varname>sampler_properties</varname> is not a supported
+                property name, if the value specified for a supported property
+                name is not valid, or if the
                 same property name is specified more than once.
             </listitem>
 
@@ -392,7 +392,7 @@ in all copies or substantial portions of the Materials.</holder>
             <citerefentry><refentrytitle>clRetainSampler</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>clReleaseSampler</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>clGetSamplerInfo</refentrytitle></citerefentry>
-            <citerefentry><refentrytitle>sampler_t</refentrytitle></citerefentry>,     
+            <citerefentry><refentrytitle>sampler_t</refentrytitle></citerefentry>,
             <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry>
         </para>
     </refsect1>

--- a/sdk/2.1/docs/man/enums.xml
+++ b/sdk/2.1/docs/man/enums.xml
@@ -66,7 +66,7 @@ in all copies or substantial portions of the Materials.</holder>
 <constant>CL_TRUE</constant>
 </literallayout>
                 <para>
-                  Note: Unlike <code>cl_</code> types in <code>cl_platform.h</code>, 
+                  Note: Unlike <code>cl_</code> types in <code>cl_platform.h</code>,
                   <type>cl_bool</type> is not guaranteed to be
                   the same size as the <type>bool</type> in kernels.
                 </para>

--- a/sdk/2.1/docs/man/imageMipmapFunctions1DInc.xml
+++ b/sdk/2.1/docs/man/imageMipmapFunctions1DInc.xml
@@ -1,58 +1,58 @@
 <!-- imageMipmapFunctionsInc -->
- 
+
     <bridgehead>Mipmap read image functions:</bridgehead>
 
     <para>
-        For the forms that take an <type>image1d_t</type> object, 
-        use the coordinate <emphasis>coord</emphasis> to 
-        do an element lookup in the mip-level specified by  
-        <varname>lod</varname> in the 1D image object specified 
+        For the forms that take an <type>image1d_t</type> object,
+        use the coordinate <emphasis>coord</emphasis> to
+        do an element lookup in the mip-level specified by
+        <varname>lod</varname> in the 1D image object specified
         by <varname>image</varname>.
     </para>
 
     <para>
-        For the forms that use gradients, use the gradients to compute 
-        the lod and coordinate <emphasis>coord</emphasis> to do an 
+        For the forms that use gradients, use the gradients to compute
+        the lod and coordinate <emphasis>coord</emphasis> to do an
         element lookup in
         the mip-level specified by the computed lod in
         the 1D image object specified by <varname>image</varname>.
     </para>
 
     <para>
-        For the forms that take an <type>image1d_array_t</type> object, 
-        use the coordinate <emphasis>coord.x</emphasis> to 
-        do an element lookup in the 1D image identified by 
-        <emphasis>coord.x</emphasis> and mip-level specified by  
-        <varname>lod</varname> in the 1D image object specified 
+        For the forms that take an <type>image1d_array_t</type> object,
+        use the coordinate <emphasis>coord.x</emphasis> to
+        do an element lookup in the 1D image identified by
+        <emphasis>coord.x</emphasis> and mip-level specified by
+        <varname>lod</varname> in the 1D image object specified
         by <varname>image</varname>.
     </para>
 
     <para>
-        When a multisample image is accessed in a kernel, 
-        the access takes one vector of 
-        integers describing which pixel to fetch and an 
-        integer corresponding to the sample numbers 
-        describing which sample within the pixel to fetch. 
-        sample identifies the sample position in the 
+        When a multisample image is accessed in a kernel,
+        the access takes one vector of
+        integers describing which pixel to fetch and an
+        integer corresponding to the sample numbers
+        describing which sample within the pixel to fetch.
+        sample identifies the sample position in the
         multi-sample image.
     </para>
 
     <para>
-        For best performance, we recommend that <varname>sample</varname> 
-        be a literal value so it is known at 
-        compile time and the OpenCL compiler can perform appropriate 
+        For best performance, we recommend that <varname>sample</varname>
+        be a literal value so it is known at
+        compile time and the OpenCL compiler can perform appropriate
         optimizationsfor multisample reads on the device.
     </para>
 
     <para>
-        NOTE: <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> 
+        NOTE: <constant>CL_SAMPLER_NORMALIZED_COORDS</constant>
         must be <constant>CL_TRUE</constant> for built-in functions
-        described in the table above that read from a 
+        described in the table above that read from a
         mip-mapped image; otherwise the behavior is
-        undefined. The value specified in the 
+        undefined. The value specified in the
         <varname>lod</varname> argument is clamped to the minimum of (actual
-        number of mip-levels - 1) in the image or value 
-        specified for <constant>CL_SAMPLER_LOD_MAX</constant>.
+        number of mip-levels - 1) in the image or value
+        specified for <constant>CL_SAMPLER_LOD_MAX_KHR</constant>.
     </para>
 
 <!-- 4-Nov-2015, API ver 2.1 rev 19; Ext ver 2.1 rev 10 -->

--- a/sdk/2.1/docs/man/imageMipmapFunctions2DInc.xml
+++ b/sdk/2.1/docs/man/imageMipmapFunctions2DInc.xml
@@ -1,62 +1,62 @@
 <!-- imageMipmapFunctionsInc -->
- 
+
     <bridgehead>Mipmap read image functions:</bridgehead>
 
     <para>
-        For the forms that take an <type>image2d_t</type> object, 
-        use the coordinate <varname>coord.xy</varname> to 
-        do an element lookup in the mip-level specified by  
-        <varname>lod</varname> in the 2D image object specified 
+        For the forms that take an <type>image2d_t</type> object,
+        use the coordinate <varname>coord.xy</varname> to
+        do an element lookup in the mip-level specified by
+        <varname>lod</varname> in the 2D image object specified
         by <varname>image</varname>.
     </para>
 
     <para>
-        For the forms that use gradients, use the gradients to compute 
-        the lod and coordinate <emphasis>coord.xy</emphasis> to do an 
+        For the forms that use gradients, use the gradients to compute
+        the lod and coordinate <emphasis>coord.xy</emphasis> to do an
         element lookup in
         the mip-level specified by the computed lod in
         the 2D image object specified by <varname>image</varname>.
     </para>
 
     <para>
-        For the forms that take an <type>image2d_array_t</type> object, 
-        use the coordinate <emphasis>coord.xy</emphasis> to 
-        do an element lookup in the 2D image identified by 
-        <emphasis>coord.z</emphasis> and mip-level specified by  
-        <varname>lod</varname> in the 2D image object specified 
+        For the forms that take an <type>image2d_array_t</type> object,
+        use the coordinate <emphasis>coord.xy</emphasis> to
+        do an element lookup in the 2D image identified by
+        <emphasis>coord.z</emphasis> and mip-level specified by
+        <varname>lod</varname> in the 2D image object specified
         by <varname>image</varname>.
     </para>
 
     <para>
-        For the forms that take an <type>image2d_array_t</type> 
-        object and that use gradients, 
+        For the forms that take an <type>image2d_array_t</type>
+        object and that use gradients,
         use the gradients to compute the lod coordinate
-        and <emphasis>coord.xy</emphasis> to 
-        do an element lookup in the 2D image identified by 
-        <emphasis>coord.z</emphasis> and mip-level specified by  
-        <varname>lod</varname> in the 2D image object specified 
+        and <emphasis>coord.xy</emphasis> to
+        do an element lookup in the 2D image identified by
+        <emphasis>coord.z</emphasis> and mip-level specified by
+        <varname>lod</varname> in the 2D image object specified
         by <varname>image</varname>.
     </para>
 
     <para>
-        When a multisample image is accessed in a kernel, 
-        the access takes one vector of 
-        integers describing which pixel to fetch and an 
-        integer corresponding to the sample numbers 
-        describing which sample within the pixel to fetch. 
-        sample identifies the sample position in the 
+        When a multisample image is accessed in a kernel,
+        the access takes one vector of
+        integers describing which pixel to fetch and an
+        integer corresponding to the sample numbers
+        describing which sample within the pixel to fetch.
+        sample identifies the sample position in the
         multi-sample image.
     </para>
 
     <para>
-        NOTE: <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> 
+        NOTE: <constant>CL_SAMPLER_NORMALIZED_COORDS</constant>
         must be <constant>CL_TRUE</constant> for built-in functions
-        described in the table above that read from a 
+        described in the table above that read from a
         mip-mapped image; otherwise the behavior is
-        undefined. The value specified in the 
+        undefined. The value specified in the
         <varname>lod</varname> argument is clamped to the minimum of (actual
-        number of mip-levels - 1) in the image or value 
-        specified for <constant>CL_SAMPLER_LOD_MAX</constant>.
+        number of mip-levels - 1) in the image or value
+        specified for <constant>CL_SAMPLER_LOD_MAX_KHR</constant>.
     </para>
 
 <!-- 17-Dec-2013, rev. 19 -->

--- a/sdk/2.1/docs/man/read_imagef3d.xml
+++ b/sdk/2.1/docs/man/read_imagef3d.xml
@@ -109,7 +109,7 @@ in all copies or substantial portions of the Materials.</holder>
             </funcprototype>
         </funcsynopsis>
 
-        <bridgehead>Functions added with mipmap support enabled by extension 
+        <bridgehead>Functions added with mipmap support enabled by extension
         <code>cl_khr_mipmap_image</code>:</bridgehead>
 
         <funcsynopsis>
@@ -176,7 +176,7 @@ in all copies or substantial portions of the Materials.</holder>
 
     <refsect1 id="description"><title>Description</title>
         <para>
-            <varname>aQual</varname> refers to one of the access qualifiers 
+            <varname>aQual</varname> refers to one of the access qualifiers
             <code>read_only</code>, <code>write_only</code>, or <code>read_write</code>.
             For samplerless read functions this may be <code>read_only</code> or <code>read_write</code>.
         </para>
@@ -246,14 +246,14 @@ in all copies or substantial portions of the Materials.</holder>
         <bridgehead>Mipmap read image functions:</bridgehead>
 
         <para>
-            <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be 
+            <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be
             <constant>CL_TRUE</constant> for built-in functions
-            described in the table above that read from a mip-mapped 
+            described in the table above that read from a mip-mapped
             image; otherwise the behavior is
-            undefined. The value specified in the <varname>lod</varname> 
+            undefined. The value specified in the <varname>lod</varname>
             argument is clamped to the minimum of (actual
-            number of mip-levels – 1) in the image or value specified 
-            for <constant>CL_SAMPLER_LOD_MAX</constant>.
+            number of mip-levels – 1) in the image or value specified
+            for <constant>CL_SAMPLER_LOD_MAX_KHR</constant>.
         </para>
 
     </refsect1>

--- a/sdk/2.1/docs/man/read_imagei3d.xml
+++ b/sdk/2.1/docs/man/read_imagei3d.xml
@@ -176,7 +176,7 @@ in all copies or substantial portions of the Materials.</holder>
             </funcprototype>
         </funcsynopsis>
 
-        <bridgehead>Functions added with mipmap support enabled by extension 
+        <bridgehead>Functions added with mipmap support enabled by extension
         <code>cl_khr_mipmap_image</code>:</bridgehead>
 
         <funcsynopsis>
@@ -300,7 +300,7 @@ in all copies or substantial portions of the Materials.</holder>
 
     <refsect1 id="description"><title>Description</title>
         <para>
-            <varname>aQual</varname> refers to one of the access qualifiers 
+            <varname>aQual</varname> refers to one of the access qualifiers
             <code>read_only</code>, <code>write_only</code>, or <code>read_write</code>.
             For samplerless read functions this may be <code>read_only</code> or <code>read_write</code>.
         </para>
@@ -316,8 +316,8 @@ in all copies or substantial portions of the Materials.</holder>
           For the forms that take
           a <type>sampler_t</type> and which are enabled by the
           <citerefentry><refentrytitle>cl_khr_mipmap_image</refentrytitle></citerefentry>
-          extension, use the coordinate <emphasis>coord.xyz</emphasis> to do an 
-          element lookup in the mip-level specified by <varname>lod</varname> 
+          extension, use the coordinate <emphasis>coord.xyz</emphasis> to do an
+          element lookup in the mip-level specified by <varname>lod</varname>
           in the 3D image object specified by <varname>image</varname>.
         </para>
 
@@ -382,14 +382,14 @@ in all copies or substantial portions of the Materials.</holder>
         <bridgehead>Mipmap read image functions:</bridgehead>
 
         <para>
-            <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be 
+            <constant>CL_SAMPLER_NORMALIZED_COORDS</constant> must be
             <constant>CL_TRUE</constant> for built-in functions
-            described in the table above that read from a mip-mapped 
+            described in the table above that read from a mip-mapped
             image; otherwise the behavior is
-            undefined. The value specified in the <varname>lod</varname> 
+            undefined. The value specified in the <varname>lod</varname>
             argument is clamped to the minimum of (actual
-            number of mip-levels – 1) in the image or value specified for 
-            <constant>CL_SAMPLER_LOD_MAX</constant>.
+            number of mip-levels – 1) in the image or value specified for
+            <constant>CL_SAMPLER_LOD_MAX_KHR</constant>.
         </para>
     </refsect1>
 


### PR DESCRIPTION
Fixes #12, raises other issues. There's a ton of things messed up here. I started fixing the 2.0 / 2.1 ref pages to add KHR suffixes, and discovered that the CL_FILTER_NONE token doesn't even exist, FILTER_NEAREST is used instead. Also, while the CL_SAMPLER_MIP_FILTER_MODE, CL_SAMPLER_LOD_MIN, and CL_SAMPLER_LOD_MAX tokens have KHR suffixes in the 2.1 and 2.2 extension specs, they do not have suffixes in the 2.0 / 2.1 headers in the OpenCL-Headers repository.

Given all this I'm going to punt this off to the CL working group to see what they want to do. Realistically I think the most that could be done in the headers is to add _KHR aliases of the non-suffixed tokens that have been in there for a long time. The 2.1 / 2.2 extension specs are consistent with each other and should be controlling, the ref pages should (and do, with this PR) reflect the specs. 

If reviewing the diff listing, I suggest turning on "Hide whitespace changes" (or whatever exactly it's called) in the diff options button - there were a bunch of trailing spaces which got eaten by my editor.