### PR TITLE
re-add inadvertently removed section from cl_intel_subgroups

### DIFF
--- a/extensions/intel/cl_intel_subgroups.html
+++ b/extensions/intel/cl_intel_subgroups.html
@@ -810,8 +810,8 @@ Biju George, Intel</p></div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Built On: 2018-11-16<br>
-Revision: 5</p></div>
+<div class="paragraph"><p>Built On: 2018-12-02<br>
+Revision: 6</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -1799,6 +1799,9 @@ These are new functions:
 <dd>
 <div class="openblock">
 <div class="content">
+<div class="paragraph"><p>The OpenCL C programming language implements the following built-in functions to allow data to be read or written as a block by all work items in a subgroup.
+These built-in functions must be encountered by all work items in a subgroup executing the kernel.
+Furthermore, since these are block operations, the <em>pointer</em>, <em>image</em>, and <em>coordinate</em> arguments to these built-in functions must be the same for all work items in the subgroup (when applicable, only the <em>data</em> argument may be different).</p></div>
 <table class="tableblock frame-all grid-all"
 style="
 width:100%;
@@ -2046,6 +2049,12 @@ width:100%;
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Converted to asciidoc.</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-12-02</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Added back a section that was inadvertently removed during conversion to asciidoc.</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -2055,7 +2064,7 @@ width:100%;
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-11-16 09:14:13 PST
+ 2018-12-02 04:02:41 PST
 </div>
 </div>
 </body>


### PR DESCRIPTION
I accidentally removed a section of the cl_intel_subgroups extension during the conversion to asciidoc.  This PR re-adds the accidentally removed text.