### PR TITLE
cl_intel_subgroups rev7 - fixed summary typos

### DIFF
--- a/extensions/intel/cl_intel_subgroups.html
+++ b/extensions/intel/cl_intel_subgroups.html
@@ -798,7 +798,7 @@ Biju George, Intel</p></div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph"><p>Copyright (c) 2019 Intel Corporation.  All rights reserved.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -810,8 +810,8 @@ Biju George, Intel</p></div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Built On: 2018-12-02<br>
-Revision: 6</p></div>
+<div class="paragraph"><p>Built On: 2019-01-15<br>
+Revision: 7</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -971,8 +971,8 @@ http://www.gnu.org/software/src-highlite -->
 <span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
 
 <span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
+<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
+<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
 
 <span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span>
 <span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span>
@@ -2055,6 +2055,12 @@ width:100%;
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Added back a section that was inadvertently removed during conversion to asciidoc.</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2019-01-15</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Fixed a typo in the summary section of new built-in functions.</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -2064,7 +2070,7 @@ width:100%;
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2018-12-02 04:02:41 PST
+ 2019-01-15 08:30:21 PST
 </div>
 </div>
 </body>


### PR DESCRIPTION
Please post rev 7 of the cl_intel_subgroups extension specification, which fixes a few typos introduced in the conversion from plaintext to asciidoc.

The PR to update the asciidoc source is here:

https://github.com/KhronosGroup/OpenCL-Docs/pull/40