### PR TITLE
Modify pageNumberLookup.rb script

### DIFF
--- a/sdk/2.1/docs/man/xhtml/ATOMIC_VAR_INIT.html
+++ b/sdk/2.1/docs/man/xhtml/ATOMIC_VAR_INIT.html
@@ -299,7 +299,7 @@ data-race.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=104" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=ATOMIC_VAR_INIT" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/EXTENSION.html
+++ b/sdk/2.1/docs/man/xhtml/EXTENSION.html
@@ -728,7 +728,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=7" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=EXTENSION" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/FP_CONTRACT.html
+++ b/sdk/2.1/docs/man/xhtml/FP_CONTRACT.html
@@ -333,7 +333,7 @@ FP_FAST_FMA_HALF        </p></div>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=79" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=FP_CONTRACT" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/abs.html
+++ b/sdk/2.1/docs/man/xhtml/abs.html
@@ -319,7 +319,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/accessQualifiers.html
+++ b/sdk/2.1/docs/man/xhtml/accessQualifiers.html
@@ -330,7 +330,7 @@ foo (read_only image2d_t imageA, <br />
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=46" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=accessQualifiers" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/acos.html
+++ b/sdk/2.1/docs/man/xhtml/acos.html
@@ -343,7 +343,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/add_sat.html
+++ b/sdk/2.1/docs/man/xhtml/add_sat.html
@@ -301,7 +301,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/addressSpaceQualifierFuncs.html
+++ b/sdk/2.1/docs/man/xhtml/addressSpaceQualifierFuncs.html
@@ -371,7 +371,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=99" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=addressSpaceQualifierFuncs" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/any.html
+++ b/sdk/2.1/docs/man/xhtml/any.html
@@ -298,7 +298,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/as_typen.html
+++ b/sdk/2.1/docs/man/xhtml/as_typen.html
@@ -374,7 +374,7 @@ float3 g = as_float3(f);
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=24" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=as_typen" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/asin.html
+++ b/sdk/2.1/docs/man/xhtml/asin.html
@@ -343,7 +343,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/asyncCopyFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/asyncCopyFunctions.html
@@ -292,7 +292,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=100" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=asyncCopyFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/async_work_group_copy.html
+++ b/sdk/2.1/docs/man/xhtml/async_work_group_copy.html
@@ -358,7 +358,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=100" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=asyncCopyFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/async_work_group_strided_copy.html
+++ b/sdk/2.1/docs/man/xhtml/async_work_group_strided_copy.html
@@ -371,7 +371,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=100" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=asyncCopyFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atan.html
+++ b/sdk/2.1/docs/man/xhtml/atan.html
@@ -383,7 +383,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomicFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/atomicFunctions.html
@@ -426,7 +426,7 @@ Click an item in the table below for details about that function.
         <h2>Specification</h2>
         <p>
             <img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=103" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomicFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_compare_exchange.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_compare_exchange.html
@@ -591,7 +591,7 @@ else<br />
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=108" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_compare_exchange" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_exchange.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_exchange.html
@@ -430,7 +430,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=108" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_exchange" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_fetch_key.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_fetch_key.html
@@ -522,7 +522,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=109" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_fetch_key" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_flag.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_flag.html
@@ -298,7 +298,7 @@ global atomic_flag guard = ATOMIC_FLAG_INIT;
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=110" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_flag" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_flag_clear.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_flag_clear.html
@@ -417,7 +417,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=111" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_flag_clear" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_flag_test_and_set.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_flag_test_and_set.html
@@ -417,7 +417,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=111" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_flag_test_and_set" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_init.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_init.html
@@ -369,7 +369,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=104" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_init" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_load.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_load.html
@@ -411,7 +411,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=107" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_load" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_store.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_store.html
@@ -432,7 +432,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=107" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_store" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/atomic_work_item_fence.html
+++ b/sdk/2.1/docs/man/xhtml/atomic_work_item_fence.html
@@ -349,7 +349,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=105" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=atomic_work_item_fence" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/attribute.html
+++ b/sdk/2.1/docs/man/xhtml/attribute.html
@@ -314,7 +314,7 @@ attribute-argument:
         <p>
           In general, the rules for how an attribute binds for a given context are non-trivial
           and the reader is pointed to GCC's documentation and Maurer and Wong's paper (See the
-          "References" section in the <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=1" target="OpenCL Spec">OpenCL specification</a>
+          "References" section in the <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=referenceWong" target="OpenCL Spec">OpenCL specification</a>
           for details.)
         </p>
       </div>
@@ -324,7 +324,7 @@ attribute-argument:
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=56" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=attribute" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/attributes-blocksAndControlFlow.html
+++ b/sdk/2.1/docs/man/xhtml/attributes-blocksAndControlFlow.html
@@ -286,7 +286,7 @@ __attribute__((attr1)) {...}
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=61" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=attributes-blocksAndControlFlow" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/attributes-loopUnroll.html
+++ b/sdk/2.1/docs/man/xhtml/attributes-loopUnroll.html
@@ -427,7 +427,7 @@ my_kernel( … )
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=61" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=attributes-loopUnroll" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/attributes-types.html
+++ b/sdk/2.1/docs/man/xhtml/attributes-types.html
@@ -412,7 +412,7 @@ __attribute__ ((packed))
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=57" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=attributes-types" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/attributes-variables.html
+++ b/sdk/2.1/docs/man/xhtml/attributes-variables.html
@@ -468,7 +468,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=59" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=attributes-variables" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/barrier.html
+++ b/sdk/2.1/docs/man/xhtml/barrier.html
@@ -244,7 +244,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=97" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_barrier" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/bitselect.html
+++ b/sdk/2.1/docs/man/xhtml/bitselect.html
@@ -316,7 +316,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/blocks.html
+++ b/sdk/2.1/docs/man/xhtml/blocks.html
@@ -607,7 +607,7 @@ void foo()<br />
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=64" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=blocks" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/capture_event_profiling_info.html
+++ b/sdk/2.1/docs/man/xhtml/capture_event_profiling_info.html
@@ -459,7 +459,7 @@ foo(queue_t q, ...)
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=171" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=eventFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cbrt.html
+++ b/sdk/2.1/docs/man/xhtml/cbrt.html
@@ -311,7 +311,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/ceil.html
+++ b/sdk/2.1/docs/man/xhtml/ceil.html
@@ -313,7 +313,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clBuildProgram.html
+++ b/sdk/2.1/docs/man/xhtml/clBuildProgram.html
@@ -687,7 +687,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=200" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clBuildProgram" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCloneKernel.html
+++ b/sdk/2.1/docs/man/xhtml/clCloneKernel.html
@@ -360,7 +360,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=230" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCloneKernel" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCompileProgram.html
+++ b/sdk/2.1/docs/man/xhtml/clCompileProgram.html
@@ -786,7 +786,7 @@ clCompileProgram(program_A,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=202" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCompileProgram" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateBuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateBuffer.html
@@ -577,7 +577,7 @@ memory pointer that is aligned to the data types used to access these buffers in
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=104" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateBuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateCommandQueueWithProperties.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateCommandQueueWithProperties.html
@@ -593,7 +593,7 @@ properties</span>
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=97" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateCommandQueueWithProperties" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateContext.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateContext.html
@@ -895,7 +895,7 @@ _initialize_khr</span>
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateContext" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateContextFromType.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateContextFromType.html
@@ -873,7 +873,7 @@ _initialize_khr</span>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=92" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateContextFromType" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateEventFromEGLSyncKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateEventFromEGLSyncKHR.html
@@ -411,7 +411,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=175" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateEventFromEGLSyncKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateEventFromGLsyncKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateEventFromGLsyncKHR.html
@@ -362,7 +362,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=60" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateEventFromGLsyncKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromD3D10BufferKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromD3D10BufferKHR.html
@@ -406,7 +406,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=71" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromD3D10BufferKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromD3D10Texture2DKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromD3D10Texture2DKHR.html
@@ -437,7 +437,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromD3D10Texture2DKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromD3D10Texture3DKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromD3D10Texture3DKHR.html
@@ -633,7 +633,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=73" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromD3D10Texture3DKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromD3D11BufferKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromD3D11BufferKHR.html
@@ -413,7 +413,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=102" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromD3D11BufferKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromD3D11Texture2DKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromD3D11Texture2DKHR.html
@@ -442,7 +442,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=103" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromD3D11Texture2DKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromD3D11Texture3DKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromD3D11Texture3DKHR.html
@@ -753,7 +753,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=104" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromD3D11Texture3DKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromDX9MediaSurfaceKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromDX9MediaSurfaceKHR.html
@@ -670,7 +670,7 @@ typedef struct _cl_dx9_surface_info_khr<br />
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=87" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromDX9MediaSurfaceKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromEGLImageKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromEGLImageKHR.html
@@ -474,7 +474,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=167" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromEGLImageKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromGLBuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromGLBuffer.html
@@ -910,7 +910,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=47" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromGLBuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromGLRenderbuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromGLRenderbuffer.html
@@ -912,7 +912,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=51" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromGLRenderbuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateFromGLTexture.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateFromGLTexture.html
@@ -995,7 +995,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=48" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clCreateFromGLTexture" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateImage.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateImage.html
@@ -901,7 +901,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=128" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateImage" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateKernel.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateKernel.html
@@ -341,7 +341,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=221" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateKernel" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateKernelsInProgram.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateKernelsInProgram.html
@@ -366,7 +366,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=222" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateKernelsInProgram" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreatePipe.html
+++ b/sdk/2.1/docs/man/xhtml/clCreatePipe.html
@@ -577,7 +577,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=160" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreatePipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateProgramWithBinary.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateProgramWithBinary.html
@@ -448,7 +448,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=196" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateProgramWithBinary" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateProgramWithBuiltInKernels.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateProgramWithBuiltInKernels.html
@@ -349,7 +349,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=198" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateProgramWithBuiltInKernels" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateProgramWithIL.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateProgramWithIL.html
@@ -341,7 +341,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=195" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateProgramWithIL" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateProgramWithSource.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateProgramWithSource.html
@@ -354,7 +354,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=194" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateProgramWithSource" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateSamplerWithProperties.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateSamplerWithProperties.html
@@ -524,7 +524,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=190" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateSamplerWithProperties" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateSubBuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateSubBuffer.html
@@ -644,7 +644,7 @@ typedef struct _cl_buffer_region {<br />
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=107" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateSubBuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateSubDevices.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateSubDevices.html
@@ -588,7 +588,7 @@ AFFINITY_DOMAIN (cl_device_affinity_domain)</td>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=85" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateSubDevices" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clCreateUserEvent.html
+++ b/sdk/2.1/docs/man/xhtml/clCreateUserEvent.html
@@ -318,7 +318,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=250" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clCreateUserEvent" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueAcquireD3D10ObjectsKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueAcquireD3D10ObjectsKHR.html
@@ -470,7 +470,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=75" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueAcquireD3D10ObjectsKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueAcquireD3D11ObjectsKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueAcquireD3D11ObjectsKHR.html
@@ -477,7 +477,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=106" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueAcquireD3D11ObjectsKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueAcquireDX9MediaSurfacesKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueAcquireDX9MediaSurfacesKHR.html
@@ -635,7 +635,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=89" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueAcquireDX9MediaSurfacesKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueAcquireEGLObjectsKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueAcquireEGLObjectsKHR.html
@@ -415,7 +415,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=169" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueAcquireEGLObjectsKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueAcquireGLObjects.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueAcquireGLObjects.html
@@ -982,7 +982,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=55" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueAcquireGLObjects" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueBarrierWithWaitList.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueBarrierWithWaitList.html
@@ -383,7 +383,7 @@
         <h2>Specification</h2>
         <p>
             <img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=260" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueBarrierWithWaitList" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueCopyBuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueCopyBuffer.html
@@ -443,7 +443,7 @@
             <img src="pdficon_small1.gif" />
 
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=117" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueCopyBuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueCopyBufferRect.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueCopyBufferRect.html
@@ -566,7 +566,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=119" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueCopyBufferRect" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueCopyBufferToImage.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueCopyBufferToImage.html
@@ -543,7 +543,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=151" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueCopyBufferToImage" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueCopyImage.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueCopyImage.html
@@ -548,7 +548,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=144" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueCopyImage" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueCopyImageToBuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueCopyImageToBuffer.html
@@ -530,7 +530,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=149" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueCopyImageToBuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueFillBuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueFillBuffer.html
@@ -484,7 +484,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=122" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueFillBuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueFillImage.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueFillImage.html
@@ -488,7 +488,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=147" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueFillImage" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueMapBuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueMapBuffer.html
@@ -689,7 +689,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=124" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueMapBuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueMapImage.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueMapImage.html
@@ -813,7 +813,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=154" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueMapImage" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueMarkerWithWaitList.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueMarkerWithWaitList.html
@@ -385,7 +385,7 @@
             <img src="pdficon_small1.gif" />
 
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=259" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueMarkerWithWaitList" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueMigrateMemObjects.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueMigrateMemObjects.html
@@ -515,7 +515,7 @@ CONTENT_UNDEFINED</code>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=168" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueMigrateMemObjects" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueNDRangeKernel.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueNDRangeKernel.html
@@ -630,7 +630,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=242" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueNDRangeKernel" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueNativeKernel.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueNativeKernel.html
@@ -491,7 +491,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=246" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueNativeKernel" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueReadBuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueReadBuffer.html
@@ -491,7 +491,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=110" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueReadBuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueReadBufferRect.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueReadBufferRect.html
@@ -658,7 +658,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=112" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueReadBufferRect" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueReadImage.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueReadImage.html
@@ -605,7 +605,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=140" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueReadImage" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueReleaseD3D10ObjectsKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueReleaseD3D10ObjectsKHR.html
@@ -450,7 +450,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=77" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueReleaseD3D10ObjectsKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueReleaseD3D11ObjectsKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueReleaseD3D11ObjectsKHR.html
@@ -455,7 +455,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=108" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueReleaseD3D11ObjectsKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueReleaseDX9MediaSurfacesKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueReleaseDX9MediaSurfacesKHR.html
@@ -621,7 +621,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=91" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueReleaseDX9MediaSurfacesKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueReleaseEGLObjectsKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueReleaseEGLObjectsKHR.html
@@ -416,7 +416,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=170" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueReleaseEGLObjectsKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueReleaseGLObjects.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueReleaseGLObjects.html
@@ -1003,7 +1003,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=56" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clEnqueueReleaseGLObjects" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueSVMFree.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueSVMFree.html
@@ -447,7 +447,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=179" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueSVMFree" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueSVMMap.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueSVMMap.html
@@ -535,7 +535,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=184" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueSVMMap" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueSVMMemFill.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueSVMMemFill.html
@@ -456,7 +456,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=182" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueSVMMemFill" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueSVMMemcpy.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueSVMMemcpy.html
@@ -473,7 +473,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=180" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueSVMMemcpy" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueSVMMigrateMem.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueSVMMigrateMem.html
@@ -472,7 +472,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=187" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueSVMMigrateMem" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueSVMUnmap.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueSVMUnmap.html
@@ -437,7 +437,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=185" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueSVMUnmap" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueUnmapMemObject.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueUnmapMemObject.html
@@ -505,7 +505,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=165" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueUnmapMemObject" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueWriteBuffer.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueWriteBuffer.html
@@ -486,7 +486,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=110" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueWriteBuffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueWriteBufferRect.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueWriteBufferRect.html
@@ -659,7 +659,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=113" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueWriteBufferRect" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clEnqueueWriteImage.html
+++ b/sdk/2.1/docs/man/xhtml/clEnqueueWriteImage.html
@@ -611,7 +611,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=140" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clEnqueueWriteImage" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clFinish.html
+++ b/sdk/2.1/docs/man/xhtml/clFinish.html
@@ -287,7 +287,7 @@
             <img src="pdficon_small1.gif" />
 
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=266" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clFinish" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clFlush.html
+++ b/sdk/2.1/docs/man/xhtml/clFlush.html
@@ -318,7 +318,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=266" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clFlush" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetCommandQueueInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetCommandQueueInfo.html
@@ -475,7 +475,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=101" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetCommandQueueInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetContextInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetContextInfo.html
@@ -481,7 +481,7 @@ SHARED_RESOURCES_KHR</code>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=94" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetContextInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetDeviceAndHostTimer.html
+++ b/sdk/2.1/docs/man/xhtml/clGetDeviceAndHostTimer.html
@@ -359,7 +359,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetDeviceAndHostTimer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetDeviceIDs.html
+++ b/sdk/2.1/docs/man/xhtml/clGetDeviceIDs.html
@@ -459,7 +459,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=64" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetDeviceIDs" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetDeviceIDsFromD3D10KHR.html
+++ b/sdk/2.1/docs/man/xhtml/clGetDeviceIDsFromD3D10KHR.html
@@ -509,7 +509,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clGetDeviceIDsFromD3D10KHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetDeviceIDsFromD3D11KHR.html
+++ b/sdk/2.1/docs/man/xhtml/clGetDeviceIDsFromD3D11KHR.html
@@ -516,7 +516,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=100" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clGetDeviceIDsFromD3D11KHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetDeviceIDsFromDX9MediaAdapterKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clGetDeviceIDsFromDX9MediaAdapterKHR.html
@@ -717,7 +717,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=85" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clGetDeviceIDsFromDX9MediaAdapterKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetDeviceInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetDeviceInfo.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>clGetDeviceInfo</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="clGetDeviceInfo" />
   </head>
   <body>
@@ -353,7 +353,7 @@
                 Table 4.3:
             </p>
               <div class="informaltable">
-                <table border="1">
+                <table class="informaltable" border="1">
                   <colgroup>
                     <col align="left" class="col1" />
                     <col align="left" class="col2" />
@@ -1717,7 +1717,7 @@ FORWARD_PROGRESS</code>
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=66" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetDeviceInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetEventInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetEventInfo.html
@@ -546,7 +546,7 @@ associated with a GL sync object, rather than an OpenCL command)<br />
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=252" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetEventInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetEventProfilingInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetEventProfilingInfo.html
@@ -460,7 +460,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=263" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetEventProfilingInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetExtensionFunctionAddressForPlatform.html
+++ b/sdk/2.1/docs/man/xhtml/clGetExtensionFunctionAddressForPlatform.html
@@ -421,7 +421,7 @@ typedef CL_API_ENTRY cl_int
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=9" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clGetExtensionFunctionAddressForPlatform" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetGLContextInfoKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clGetGLContextInfoKHR.html
@@ -1026,7 +1026,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=41" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clGetGLContextInfoKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetGLObjectInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetGLObjectInfo.html
@@ -327,7 +327,7 @@ Query an OpenGL object used to create an OpenCL memory object.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=53" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clGetGLObjectInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetGLTextureInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetGLTextureInfo.html
@@ -416,7 +416,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=54" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clGetGLTextureInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetHostTimer.html
+++ b/sdk/2.1/docs/man/xhtml/clGetHostTimer.html
@@ -337,7 +337,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=83" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetHostTimer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetImageInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetImageInfo.html
@@ -610,7 +610,7 @@ SUBRESOURCE_KHR</code>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=157" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetImageInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetKernelArgInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetKernelArgInfo.html
@@ -553,7 +553,7 @@ type_qualifier</td>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=238" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetKernelArgInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetKernelInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetKernelInfo.html
@@ -470,7 +470,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=231" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetKernelInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetKernelSubGroupInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetKernelSubGroupInfo.html
@@ -574,7 +574,7 @@ FOR_SUB_GROUP_COUNT</code>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=236" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetKernelSubGroupInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetKernelWorkGroupInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetKernelWorkGroupInfo.html
@@ -531,7 +531,7 @@ GROUP_SIZE_MULTIPLE</code>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=233" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetKernelWorkGroupInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetMemObjectInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetMemObjectInfo.html
@@ -656,7 +656,7 @@ SURFACE_INFO_KHR</code>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=170" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetMemObjectInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetPipeInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetPipeInfo.html
@@ -415,7 +415,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=161" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetPipeInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetPlatformIDs.html
+++ b/sdk/2.1/docs/man/xhtml/clGetPlatformIDs.html
@@ -329,7 +329,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=62" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetPlatformIDs" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetPlatformInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetPlatformInfo.html
@@ -474,7 +474,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=62" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetPlatformInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetProgramBuildInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetProgramBuildInfo.html
@@ -621,7 +621,7 @@ VARIABLE_TOTAL_SIZE</code>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=217" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetProgramBuildInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetProgramInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetProgramInfo.html
@@ -603,7 +603,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=214" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetProgramInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetSamplerInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clGetSamplerInfo.html
@@ -432,7 +432,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=192" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetSamplerInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clGetSupportedImageFormats.html
+++ b/sdk/2.1/docs/man/xhtml/clGetSupportedImageFormats.html
@@ -1027,7 +1027,7 @@ extension is enabled:</h4>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=136" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clGetSupportedImageFormats" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clIcdGetPlatformIDsKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clIcdGetPlatformIDsKHR.html
@@ -338,7 +338,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=130" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clIcdGetPlatformIDsKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clLinkProgram.html
+++ b/sdk/2.1/docs/man/xhtml/clLinkProgram.html
@@ -558,7 +558,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=205" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clLinkProgram" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clReleaseCommandQueue.html
+++ b/sdk/2.1/docs/man/xhtml/clReleaseCommandQueue.html
@@ -299,7 +299,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=100" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clReleaseCommandQueue" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clReleaseContext.html
+++ b/sdk/2.1/docs/man/xhtml/clReleaseContext.html
@@ -306,7 +306,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clReleaseContext" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clReleaseDevice.html
+++ b/sdk/2.1/docs/man/xhtml/clReleaseDevice.html
@@ -293,7 +293,7 @@
         <h2>Specification</h2>
         <p>
             <img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clReleaseDevice" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clReleaseEvent.html
+++ b/sdk/2.1/docs/man/xhtml/clReleaseEvent.html
@@ -321,7 +321,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=257" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clReleaseEvent" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clReleaseKernel.html
+++ b/sdk/2.1/docs/man/xhtml/clReleaseKernel.html
@@ -286,7 +286,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=223" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clReleaseKernel" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clReleaseMemObject.html
+++ b/sdk/2.1/docs/man/xhtml/clReleaseMemObject.html
@@ -288,7 +288,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=163" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clReleaseMemObject" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clReleaseProgram.html
+++ b/sdk/2.1/docs/man/xhtml/clReleaseProgram.html
@@ -287,7 +287,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=199" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clReleaseProgram" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clReleaseSampler.html
+++ b/sdk/2.1/docs/man/xhtml/clReleaseSampler.html
@@ -304,7 +304,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=192" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clReleaseSampler" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clRetainCommandQueue.html
+++ b/sdk/2.1/docs/man/xhtml/clRetainCommandQueue.html
@@ -294,7 +294,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=100" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clRetainCommandQueue" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clRetainContext.html
+++ b/sdk/2.1/docs/man/xhtml/clRetainContext.html
@@ -307,7 +307,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clRetainContext" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clRetainDevice.html
+++ b/sdk/2.1/docs/man/xhtml/clRetainDevice.html
@@ -290,7 +290,7 @@
             <img src="pdficon_small1.gif" />
 
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clRetainDevice" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clRetainEvent.html
+++ b/sdk/2.1/docs/man/xhtml/clRetainEvent.html
@@ -296,7 +296,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=257" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clRetainEvent" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clRetainKernel.html
+++ b/sdk/2.1/docs/man/xhtml/clRetainKernel.html
@@ -279,7 +279,7 @@
         <h2>Specification</h2>
         <p>
             <img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=223" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clRetainKernel" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clRetainMemObject.html
+++ b/sdk/2.1/docs/man/xhtml/clRetainMemObject.html
@@ -302,7 +302,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=163" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clRetainMemObject" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clRetainProgram.html
+++ b/sdk/2.1/docs/man/xhtml/clRetainProgram.html
@@ -282,7 +282,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=199" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clRetainProgram" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clRetainSampler.html
+++ b/sdk/2.1/docs/man/xhtml/clRetainSampler.html
@@ -295,7 +295,7 @@
         <h2>Specification</h2>
         <p>
             <img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=191" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clRetainSampler" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clSVMAlloc.html
+++ b/sdk/2.1/docs/man/xhtml/clSVMAlloc.html
@@ -504,7 +504,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=175" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clSVMAlloc" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clSVMFree.html
+++ b/sdk/2.1/docs/man/xhtml/clSVMFree.html
@@ -329,7 +329,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=178" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clSVMFree" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clSetDefaultDeviceCommandQueue.html
+++ b/sdk/2.1/docs/man/xhtml/clSetDefaultDeviceCommandQueue.html
@@ -323,7 +323,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=99" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clSetDefaultDeviceCommandQueue" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clSetEventCallback.html
+++ b/sdk/2.1/docs/man/xhtml/clSetEventCallback.html
@@ -458,7 +458,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=255" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clSetEventCallback" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/clSetKernelArg.html
+++ b/sdk/2.1/docs/man/xhtml/clSetKernelArg.html
@@ -583,7 +583,7 @@ image_filter (int n, int m,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=224" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clSetKernelArg" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clSetKernelArgSVMPointer.html
+++ b/sdk/2.1/docs/man/xhtml/clSetKernelArgSVMPointer.html
@@ -401,7 +401,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=226" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clSetKernelArgSVMPointer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clSetKernelExecInfo.html
+++ b/sdk/2.1/docs/man/xhtml/clSetKernelExecInfo.html
@@ -560,7 +560,7 @@ clSetKernelExecInfo(kernel,<br />
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=227" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clSetKernelExecInfo" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clSetMemObjectDestructorCallback.html
+++ b/sdk/2.1/docs/man/xhtml/clSetMemObjectDestructorCallback.html
@@ -414,7 +414,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=164" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clSetMemObjectDestructorCallback" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clSetUserEventStatus.html
+++ b/sdk/2.1/docs/man/xhtml/clSetUserEventStatus.html
@@ -380,7 +380,7 @@ clReleaseMemObject(buf2);
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=250" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clSetUserEventStatus" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clTerminateContextKHR.html
+++ b/sdk/2.1/docs/man/xhtml/clTerminateContextKHR.html
@@ -387,7 +387,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=123" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=clTerminateContextKHR" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clUnloadPlatformCompiler.html
+++ b/sdk/2.1/docs/man/xhtml/clUnloadPlatformCompiler.html
@@ -281,7 +281,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=213" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clUnloadPlatformCompiler" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/clWaitForEvents.html
+++ b/sdk/2.1/docs/man/xhtml/clWaitForEvents.html
@@ -347,7 +347,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=251" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=clWaitForEvents" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_image_desc.html
+++ b/sdk/2.1/docs/man/xhtml/cl_image_desc.html
@@ -423,7 +423,7 @@ specified (or computed if pitch specified is 0) must be a multiple of the maximu
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=134" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_image_desc" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_image_format.html
+++ b/sdk/2.1/docs/man/xhtml/cl_image_format.html
@@ -435,7 +435,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                               
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=131" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_image_format" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_3d_image_writes.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_3d_image_writes.html
@@ -253,7 +253,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=32" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_3d_image_writes" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_byte_addressable_store.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_byte_addressable_store.html
@@ -258,7 +258,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=78" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_khr_byte_addressable_store" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_context_abort.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_context_abort.html
@@ -258,7 +258,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=78" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_khr_context_abort" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_d3d10_sharing.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_d3d10_sharing.html
@@ -358,7 +358,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=64" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_d3d10_sharing" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_d3d11_sharing.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_d3d11_sharing.html
@@ -355,7 +355,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=95" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_d3d11_sharing" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_depth_images.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_depth_images.html
@@ -258,7 +258,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=78" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_khr_depth_images" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_device_enqueue_local_arg_types.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_device_enqueue_local_arg_types.html
@@ -271,7 +271,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=178" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_device_enqueue_local_arg_types" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_dx9_media_sharing.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_dx9_media_sharing.html
@@ -507,7 +507,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=81" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_dx9_media_sharing" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_egl_event.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_egl_event.html
@@ -322,7 +322,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=174" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_egl_event" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_egl_image.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_egl_image.html
@@ -295,7 +295,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=166" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_egl_image" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_fp16.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_fp16.html
@@ -604,7 +604,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=12" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_fp16" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_fp64.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_fp64.html
@@ -262,7 +262,7 @@
             <img src="pdficon_small1.gif" />
 
             
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=78" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_khr_fp64" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_gl_depth_images.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_gl_depth_images.html
@@ -366,7 +366,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=111" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_gl_depth_images" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/cl_khr_gl_event.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_gl_event.html
@@ -338,7 +338,7 @@ cl_khr_gl_event
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=59" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_gl_event" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_gl_msaa_sharing.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_gl_msaa_sharing.html
@@ -352,7 +352,7 @@ This extension adds read_image and write_image functions to the
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=113" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_gl_msaa_sharing" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1"><a id="seealso"></a><h2>Also see</h2><a class="citerefentry" href="imageFunctions.html"><span class="citerefentry"><span class="refentrytitle">Image Read and Write Functions</span></span></a>,

--- a/sdk/2.1/docs/man/xhtml/cl_khr_gl_sharing.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_gl_sharing.html
@@ -319,7 +319,7 @@ cl_khr_gl_sharing
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=37" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_gl_sharing" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_global_int32_base_atomics.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_global_int32_base_atomics.html
@@ -260,7 +260,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=292" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_khr_global_int32_base_atomics" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_global_int32_extended_atomics.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_global_int32_extended_atomics.html
@@ -260,7 +260,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=292" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_khr_global_int32_extended_atomics" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_icd.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_icd.html
@@ -445,7 +445,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_icd" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_il_program.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_il_program.html
@@ -261,7 +261,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=180" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_il_program" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_image2d_from_buffer.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_image2d_from_buffer.html
@@ -258,7 +258,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=78" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_khr_image2d_from_buffer" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_initialize_memory.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_initialize_memory.html
@@ -334,7 +334,7 @@ initialize_khr</span>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=120" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_initialize_memory" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" />Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/cl_khr_int64_base_atomics.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_int64_base_atomics.html
@@ -262,7 +262,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=12" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_int64_base_atomics" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_int64_extended_atomics.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_int64_extended_atomics.html
@@ -262,7 +262,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=12" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_int64_extended_atomics" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_local_int32_base_atomics.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_local_int32_base_atomics.html
@@ -260,7 +260,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=292" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_khr_local_int32_base_atomics" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_local_int32_extended_atomics.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_local_int32_extended_atomics.html
@@ -260,7 +260,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=292" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=cl_khr_local_int32_extended_atomics" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_mipmap_image.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_mipmap_image.html
@@ -406,7 +406,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=156" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_mipmap_image" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_priority_hints.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_priority_hints.html
@@ -270,7 +270,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=178" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_priority_hints" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_spir.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_spir.html
@@ -312,7 +312,7 @@ Intermediate Representation (SPIR) instance.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=125" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_spir" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_srgb_image_writes.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_srgb_image_writes.html
@@ -279,7 +279,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=126" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=cl_khr_srgb_image_writes" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_subgroups.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_subgroups.html
@@ -260,7 +260,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=133" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_subgroups" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_terminate_context.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_terminate_context.html
@@ -314,7 +314,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=122" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_terminate_context" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cl_khr_throttle_hints.html
+++ b/sdk/2.1/docs/man/xhtml/cl_khr_throttle_hints.html
@@ -279,7 +279,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=179" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=cl_khr_throttle_hints" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clamp_common.html
+++ b/sdk/2.1/docs/man/xhtml/clamp_common.html
@@ -360,7 +360,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/clamp_integer.html
+++ b/sdk/2.1/docs/man/xhtml/clamp_integer.html
@@ -334,7 +334,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/classDiagram.html
+++ b/sdk/2.1/docs/man/xhtml/classDiagram.html
@@ -259,7 +259,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=1" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=classDiagram" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/clz.html
+++ b/sdk/2.1/docs/man/xhtml/clz.html
@@ -301,7 +301,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/commit_read_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/commit_read_pipe.html
@@ -471,7 +471,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=159" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commit_read_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/commit_write_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/commit_write_pipe.html
@@ -471,7 +471,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=159" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commit_write_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/commonFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/commonFunctions.html
@@ -335,7 +335,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/commonMax.html
+++ b/sdk/2.1/docs/man/xhtml/commonMax.html
@@ -353,7 +353,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/commonMin.html
+++ b/sdk/2.1/docs/man/xhtml/commonMin.html
@@ -353,7 +353,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/constant.html
+++ b/sdk/2.1/docs/man/xhtml/constant.html
@@ -427,7 +427,7 @@ local int * private f() { ... }; // should generate an error.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=34" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=addressSpaceQualifiers" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/convert_T.html
+++ b/sdk/2.1/docs/man/xhtml/convert_T.html
@@ -575,7 +575,7 @@ float4 f = convert_float4_rtp( i );
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=20" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=convert_T" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/copysign.html
+++ b/sdk/2.1/docs/man/xhtml/copysign.html
@@ -315,7 +315,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cos.html
+++ b/sdk/2.1/docs/man/xhtml/cos.html
@@ -412,7 +412,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/create_user_event.html
+++ b/sdk/2.1/docs/man/xhtml/create_user_event.html
@@ -406,7 +406,7 @@ foo(queue_t q, ...)
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=171" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=eventFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/cross.html
+++ b/sdk/2.1/docs/man/xhtml/cross.html
@@ -376,7 +376,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=geometricFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/ctz.html
+++ b/sdk/2.1/docs/man/xhtml/ctz.html
@@ -300,7 +300,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/dataTypes.html
+++ b/sdk/2.1/docs/man/xhtml/dataTypes.html
@@ -414,7 +414,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=6" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=scalarDataTypes" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/degrees.html
+++ b/sdk/2.1/docs/man/xhtml/degrees.html
@@ -289,7 +289,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/deprecated.html
+++ b/sdk/2.1/docs/man/xhtml/deprecated.html
@@ -322,7 +322,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p>
-            <img src="pdficon_small1.gif" /> <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=291" target="OpenCL Spec">OpenCL Specification</a>
+            <img src="pdficon_small1.gif" /> <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=deprecated" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/distance.html
+++ b/sdk/2.1/docs/man/xhtml/distance.html
@@ -328,7 +328,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=geometricFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/divide.html
+++ b/sdk/2.1/docs/man/xhtml/divide.html
@@ -340,7 +340,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/dot.html
+++ b/sdk/2.1/docs/man/xhtml/dot.html
@@ -325,7 +325,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=geometricFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/enqueue_kernel.html
+++ b/sdk/2.1/docs/man/xhtml/enqueue_kernel.html
@@ -769,7 +769,7 @@ foo(global int *a, local int *lptr, …)
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=162" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=enqueueKernelFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/enqueue_marker.html
+++ b/sdk/2.1/docs/man/xhtml/enqueue_marker.html
@@ -331,7 +331,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=170" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=enqueue_marker" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/erf.html
+++ b/sdk/2.1/docs/man/xhtml/erf.html
@@ -332,7 +332,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/eventFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/eventFunctions.html
@@ -301,7 +301,7 @@
         <h2>Specification</h2>
         <p>
             <img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=171" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=eventFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/exp.html
+++ b/sdk/2.1/docs/man/xhtml/exp.html
@@ -497,7 +497,7 @@ implementation-defined range. The maximum error is implementation-defined. </p>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fabs.html
+++ b/sdk/2.1/docs/man/xhtml/fabs.html
@@ -311,7 +311,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fast_distance.html
+++ b/sdk/2.1/docs/man/xhtml/fast_distance.html
@@ -283,7 +283,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=geometricFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fast_length.html
+++ b/sdk/2.1/docs/man/xhtml/fast_length.html
@@ -281,7 +281,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=geometricFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fast_normalize.html
+++ b/sdk/2.1/docs/man/xhtml/fast_normalize.html
@@ -321,7 +321,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=geometricFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fdim.html
+++ b/sdk/2.1/docs/man/xhtml/fdim.html
@@ -319,7 +319,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/floor.html
+++ b/sdk/2.1/docs/man/xhtml/floor.html
@@ -314,7 +314,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fma.html
+++ b/sdk/2.1/docs/man/xhtml/fma.html
@@ -324,7 +324,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fmax.html
+++ b/sdk/2.1/docs/man/xhtml/fmax.html
@@ -383,7 +383,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fmin.html
+++ b/sdk/2.1/docs/man/xhtml/fmin.html
@@ -384,7 +384,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fmod.html
+++ b/sdk/2.1/docs/man/xhtml/fmod.html
@@ -319,7 +319,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/fract.html
+++ b/sdk/2.1/docs/man/xhtml/fract.html
@@ -326,7 +326,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/frexp.html
+++ b/sdk/2.1/docs/man/xhtml/frexp.html
@@ -520,7 +520,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/functionQualifiers.html
+++ b/sdk/2.1/docs/man/xhtml/functionQualifiers.html
@@ -414,7 +414,7 @@ void foo( __global float4 *p ){ .... }
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=47" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=functionQualifiers" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/genericAddressSpace.html
+++ b/sdk/2.1/docs/man/xhtml/genericAddressSpace.html
@@ -439,7 +439,7 @@ pp = p; // compile-time error
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=38" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=genericAddressSpace" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/geometricFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/geometricFunctions.html
@@ -323,7 +323,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p>
-            <img src="pdficon_small1.gif" /> <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <img src="pdficon_small1.gif" /> <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=geometricFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/get_default_queue.html
+++ b/sdk/2.1/docs/man/xhtml/get_default_queue.html
@@ -264,7 +264,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=174" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=helperFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_enqueued_local_size.html
+++ b/sdk/2.1/docs/man/xhtml/get_enqueued_local_size.html
@@ -284,7 +284,7 @@ uniform work-group size.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_global_id.html
+++ b/sdk/2.1/docs/man/xhtml/get_global_id.html
@@ -263,7 +263,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_global_linear_id.html
+++ b/sdk/2.1/docs/man/xhtml/get_global_linear_id.html
@@ -282,7 +282,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_global_offset.html
+++ b/sdk/2.1/docs/man/xhtml/get_global_offset.html
@@ -263,7 +263,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_global_size.html
+++ b/sdk/2.1/docs/man/xhtml/get_global_size.html
@@ -269,7 +269,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_group_id.html
+++ b/sdk/2.1/docs/man/xhtml/get_group_id.html
@@ -263,7 +263,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_image_array_size.html
+++ b/sdk/2.1/docs/man/xhtml/get_image_array_size.html
@@ -330,7 +330,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_image_channel_data_type.html
+++ b/sdk/2.1/docs/man/xhtml/get_image_channel_data_type.html
@@ -503,7 +503,7 @@ CLK_FLOAT</p>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_image_channel_order.html
+++ b/sdk/2.1/docs/man/xhtml/get_image_channel_order.html
@@ -507,7 +507,7 @@ CLK_sBGRA</p>
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_image_depth.html
+++ b/sdk/2.1/docs/man/xhtml/get_image_depth.html
@@ -259,7 +259,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_image_dim.html
+++ b/sdk/2.1/docs/man/xhtml/get_image_dim.html
@@ -424,7 +424,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_image_height.html
+++ b/sdk/2.1/docs/man/xhtml/get_image_height.html
@@ -396,7 +396,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_image_num_mip_levels.html
+++ b/sdk/2.1/docs/man/xhtml/get_image_num_mip_levels.html
@@ -360,7 +360,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=165" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=get_image_num_mip_levels" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_image_num_samples.html
+++ b/sdk/2.1/docs/man/xhtml/get_image_num_samples.html
@@ -319,7 +319,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=119" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=get_image_num_samples" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_image_width.html
+++ b/sdk/2.1/docs/man/xhtml/get_image_width.html
@@ -441,7 +441,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=149" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageQueryFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_kernel_preferred_work_group_size_multiple.html
+++ b/sdk/2.1/docs/man/xhtml/get_kernel_preferred_work_group_size_multiple.html
@@ -307,7 +307,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=169" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=kernelQueryFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_kernel_work_group_size.html
+++ b/sdk/2.1/docs/man/xhtml/get_kernel_work_group_size.html
@@ -305,7 +305,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=169" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=kernelQueryFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_local_id.html
+++ b/sdk/2.1/docs/man/xhtml/get_local_id.html
@@ -263,7 +263,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_local_linear_id.html
+++ b/sdk/2.1/docs/man/xhtml/get_local_linear_id.html
@@ -272,7 +272,7 @@ For 3D work-groups, it is computed as
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_local_size.html
+++ b/sdk/2.1/docs/man/xhtml/get_local_size.html
@@ -278,7 +278,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_num_groups.html
+++ b/sdk/2.1/docs/man/xhtml/get_num_groups.html
@@ -262,7 +262,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_pipe_max_packets.html
+++ b/sdk/2.1/docs/man/xhtml/get_pipe_max_packets.html
@@ -466,7 +466,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=160" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=get_pipe_max_packets" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_pipe_num_packets.html
+++ b/sdk/2.1/docs/man/xhtml/get_pipe_num_packets.html
@@ -468,7 +468,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=160" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=get_pipe_num_packets" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/get_work_dim.html
+++ b/sdk/2.1/docs/man/xhtml/get_work_dim.html
@@ -259,7 +259,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/global.html
+++ b/sdk/2.1/docs/man/xhtml/global.html
@@ -514,7 +514,7 @@ global int *bad_ptr; // Error. No implicit address space
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=34" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=addressSpaceQualifiers" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/hadd.html
+++ b/sdk/2.1/docs/man/xhtml/hadd.html
@@ -330,7 +330,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/helperFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/helperFunctions.html
@@ -265,7 +265,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=174" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=helperFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/hypot.html
+++ b/sdk/2.1/docs/man/xhtml/hypot.html
@@ -318,7 +318,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/ilogb.html
+++ b/sdk/2.1/docs/man/xhtml/ilogb.html
@@ -400,7 +400,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/imageFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/imageFunctions.html
@@ -503,7 +503,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/integerFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/integerFunctions.html
@@ -479,7 +479,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/integerMax.html
+++ b/sdk/2.1/docs/man/xhtml/integerMax.html
@@ -361,7 +361,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/is_valid_event.html
+++ b/sdk/2.1/docs/man/xhtml/is_valid_event.html
@@ -406,7 +406,7 @@ foo(queue_t q, ...)
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=171" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=eventFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/is_valid_reserve_id.html
+++ b/sdk/2.1/docs/man/xhtml/is_valid_reserve_id.html
@@ -260,7 +260,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=159" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=is_valid_reserve_id" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isequal.html
+++ b/sdk/2.1/docs/man/xhtml/isequal.html
@@ -375,7 +375,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isfinite.html
+++ b/sdk/2.1/docs/man/xhtml/isfinite.html
@@ -347,7 +347,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isgreater.html
+++ b/sdk/2.1/docs/man/xhtml/isgreater.html
@@ -375,7 +375,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isgreaterequal.html
+++ b/sdk/2.1/docs/man/xhtml/isgreaterequal.html
@@ -373,7 +373,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isinf.html
+++ b/sdk/2.1/docs/man/xhtml/isinf.html
@@ -347,7 +347,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isless.html
+++ b/sdk/2.1/docs/man/xhtml/isless.html
@@ -373,7 +373,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/islessequal.html
+++ b/sdk/2.1/docs/man/xhtml/islessequal.html
@@ -373,7 +373,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/islessgreater.html
+++ b/sdk/2.1/docs/man/xhtml/islessgreater.html
@@ -374,7 +374,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isnan.html
+++ b/sdk/2.1/docs/man/xhtml/isnan.html
@@ -347,7 +347,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isnormal.html
+++ b/sdk/2.1/docs/man/xhtml/isnormal.html
@@ -347,7 +347,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isnotequal.html
+++ b/sdk/2.1/docs/man/xhtml/isnotequal.html
@@ -379,7 +379,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isordered.html
+++ b/sdk/2.1/docs/man/xhtml/isordered.html
@@ -373,7 +373,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/isunordered.html
+++ b/sdk/2.1/docs/man/xhtml/isunordered.html
@@ -372,7 +372,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/ldexp.html
+++ b/sdk/2.1/docs/man/xhtml/ldexp.html
@@ -485,7 +485,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/length.html
+++ b/sdk/2.1/docs/man/xhtml/length.html
@@ -321,7 +321,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=geometricFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/lgamma.html
+++ b/sdk/2.1/docs/man/xhtml/lgamma.html
@@ -611,7 +611,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/local.html
+++ b/sdk/2.1/docs/man/xhtml/local.html
@@ -460,7 +460,7 @@ local int * private f() { ... }; // should generate an error.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=34" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=addressSpaceQualifiers" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/log.html
+++ b/sdk/2.1/docs/man/xhtml/log.html
@@ -536,7 +536,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/macroLimits.html
+++ b/sdk/2.1/docs/man/xhtml/macroLimits.html
@@ -603,7 +603,7 @@ Macros for math limits.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=80" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=macroLimits" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/mad.html
+++ b/sdk/2.1/docs/man/xhtml/mad.html
@@ -332,7 +332,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/mad24.html
+++ b/sdk/2.1/docs/man/xhtml/mad24.html
@@ -284,7 +284,7 @@ Fast integer function to multiply 24-bit integers and add a 32-bit value.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/mad_hi.html
+++ b/sdk/2.1/docs/man/xhtml/mad_hi.html
@@ -307,7 +307,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/mad_sat.html
+++ b/sdk/2.1/docs/man/xhtml/mad_sat.html
@@ -306,7 +306,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/mag.html
+++ b/sdk/2.1/docs/man/xhtml/mag.html
@@ -345,7 +345,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/mathConstants.html
+++ b/sdk/2.1/docs/man/xhtml/mathConstants.html
@@ -538,7 +538,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=79" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathConstants" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/mathFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/mathFunctions.html
@@ -950,7 +950,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/memory_order.html
+++ b/sdk/2.1/docs/man/xhtml/memory_order.html
@@ -295,7 +295,7 @@ memory_order
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=105" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=memory_order" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/memory_scope.html
+++ b/sdk/2.1/docs/man/xhtml/memory_scope.html
@@ -308,7 +308,7 @@ memory_scope
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=105" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=memory_scope" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/miscVectorFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/miscVectorFunctions.html
@@ -255,7 +255,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=113" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=miscVectorFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/mix.html
+++ b/sdk/2.1/docs/man/xhtml/mix.html
@@ -379,7 +379,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/modf.html
+++ b/sdk/2.1/docs/man/xhtml/modf.html
@@ -331,7 +331,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/mul24.html
+++ b/sdk/2.1/docs/man/xhtml/mul24.html
@@ -284,7 +284,7 @@ Fast integer function to multiply 24-bit integer values.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/mul_hi.html
+++ b/sdk/2.1/docs/man/xhtml/mul_hi.html
@@ -302,7 +302,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/nan.html
+++ b/sdk/2.1/docs/man/xhtml/nan.html
@@ -394,7 +394,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/ndrange.html
+++ b/sdk/2.1/docs/man/xhtml/ndrange.html
@@ -469,7 +469,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=174" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=helperFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/nextafter.html
+++ b/sdk/2.1/docs/man/xhtml/nextafter.html
@@ -320,7 +320,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/normalize.html
+++ b/sdk/2.1/docs/man/xhtml/normalize.html
@@ -315,7 +315,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=88" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=geometricFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/operators.html
+++ b/sdk/2.1/docs/man/xhtml/operators.html
@@ -230,7 +230,7 @@
         <h2></h2>
         <p>
       The following operators are used in OpenCL. For information about the usage of these
-      operators, please refer to the <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=27" target="OpenCL Spec">OpenCL specification</a>.
+      operators, please refer to the <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=operators" target="OpenCL Spec">OpenCL specification</a>.
   </p>
         <div class="informaltable">
           <table class="informaltable" border="1">
@@ -381,7 +381,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p>
-            <img src="pdficon_small1.gif" /> <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=27" target="OpenCL Spec">OpenCL Specification</a>
+            <img src="pdficon_small1.gif" /> <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=operators" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/otherDataTypes.html
+++ b/sdk/2.1/docs/man/xhtml/otherDataTypes.html
@@ -487,7 +487,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=10" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=otherDataTypes" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/pageNumberLookup.rb
+++ b/sdk/2.1/docs/man/xhtml/pageNumberLookup.rb
@@ -45,11 +45,14 @@
 # variable in the opencl-man.xsl file.)
 
 
-# Here are the real spec filenames of the OpenCL 2.0 spec documents (see comments above):
+# Here are the real spec filenames of the OpenCL 2.1 spec documents (see comments above):
+# Note that CLan links to opencl-2.0-openclc.pdf, which is rewritten to the
+# current OpenCL C 2.2 specification - see
+# https://github.com/KhronosGroup/OpenCL-Docs/issues/87
 
 Core = "opencl-2.1.pdf"
 Ext  = "opencl-2.1-extensions.pdf"
-CLan = "opencl-2.1-openclc.pdf"
+CLan = "opencl-2.0-openclc.pdf"
 
 
 ###############################################################################
@@ -248,7 +251,7 @@ Pagenums = {
    "enqueue_marker" =>			  [CLan, 170],	   # 6.13.17.7 - Built-in Functions – Queuing other commands
    "eventFunctions" =>			  [CLan, 171],	   # 6.13.17.8 - Built-in Functions – Event Functions
    "helperFunctions" =>			  [CLan, 174],	   # 6.13.17.9 - built-in helper functions
-   "referenceWong" =>			  [CLan,   1],	   # 11 - [ References (to Wong paper) ] 
+   "referenceWong" =>			  [CLan,   1],	   # 11 - [ References (to Wong paper) ]
    "EXTENSION" =>			  [Ext, 7],	   # 9.1 - Compiler Directives for Optional Extensions
    "clGetExtensionFunctionAddressForPlatform" => [Ext, 9], # 9.2 - Getting OpenCL API Extension Function Pointers
    "cl_khr_int64_base_atomics" =>	  [Ext, 12],	   # 9.3 - 64-bit Atomics
@@ -321,7 +324,11 @@ IO.foreach(ARGV[0]) do |line|
 	 specName = Pagenums.fetch(keyword)[0]
 	 pageNum = Pagenums.fetch(keyword)[1]
 	 #puts "specName=" + specName + ", pageNum=" + pageNum.to_s
-	 puts line.sub(/namedest=[^\s]*\"/, "page=" + pageNum.to_s + '"').sub(/opencl-1.x-latest.pdf/, specName)
+
+	 # We no longer insert the page numbers, because they are not up to date - see
+	 # https://github.com/KhronosGroup/OpenCL-Docs/issues/87
+	 # puts line.sub(/namedest=[^\s]*\"/, "page=" + pageNum.to_s + '"').sub(/opencl-1.x-latest.pdf/, specName)
+	 puts line.sub(/opencl-1.x-latest.pdf/, specName)
       else
 	 abort("Spec page number for keyword \"" + keyword + "\" not found in " + $0) + '"'
       end

--- a/sdk/2.1/docs/man/xhtml/pipeFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/pipeFunctions.html
@@ -379,7 +379,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=160" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=pipeFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/popcount.html
+++ b/sdk/2.1/docs/man/xhtml/popcount.html
@@ -297,7 +297,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/pow.html
+++ b/sdk/2.1/docs/man/xhtml/pow.html
@@ -576,7 +576,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/prefetch.html
+++ b/sdk/2.1/docs/man/xhtml/prefetch.html
@@ -290,7 +290,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=100" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=asyncCopyFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/preprocessorDirectives.html
+++ b/sdk/2.1/docs/man/xhtml/preprocessorDirectives.html
@@ -365,7 +365,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=54" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=preprocessorDirectives" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/printfFunction.html
+++ b/sdk/2.1/docs/man/xhtml/printfFunction.html
@@ -905,7 +905,7 @@ If the vector specifier is used, the length modifiers and their meanings are:
             <img src="pdficon_small1.gif" />
 
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=115" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=printfFunction" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/private.html
+++ b/sdk/2.1/docs/man/xhtml/private.html
@@ -397,7 +397,7 @@ local int * private f() { ... }; // should generate an error.
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=34" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=addressSpaceQualifiers" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/qualifiers.html
+++ b/sdk/2.1/docs/man/xhtml/qualifiers.html
@@ -336,7 +336,7 @@ __attribute__ with work_group_size_hint, reqd_work_group_size, vec_type_hint
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=34" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=addressSpaceQualifiers" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/radians.html
+++ b/sdk/2.1/docs/man/xhtml/radians.html
@@ -291,7 +291,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_imagef1d.html
+++ b/sdk/2.1/docs/man/xhtml/read_imagef1d.html
@@ -792,7 +792,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_imagef2d.html
+++ b/sdk/2.1/docs/man/xhtml/read_imagef2d.html
@@ -1547,7 +1547,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_imagef3d.html
+++ b/sdk/2.1/docs/man/xhtml/read_imagef3d.html
@@ -682,7 +682,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_imageh1d.html
+++ b/sdk/2.1/docs/man/xhtml/read_imageh1d.html
@@ -680,7 +680,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=24" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=imageFunctionsHalf" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_imageh2d.html
+++ b/sdk/2.1/docs/man/xhtml/read_imageh2d.html
@@ -649,7 +649,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=24" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=imageFunctionsHalf" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_imageh3d.html
+++ b/sdk/2.1/docs/man/xhtml/read_imageh3d.html
@@ -555,7 +555,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#page=24" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-extensions.pdf#namedest=imageFunctionsHalf" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_imagei1d.html
+++ b/sdk/2.1/docs/man/xhtml/read_imagei1d.html
@@ -1268,7 +1268,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_imagei2d.html
+++ b/sdk/2.1/docs/man/xhtml/read_imagei2d.html
@@ -1365,7 +1365,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_imagei3d.html
+++ b/sdk/2.1/docs/man/xhtml/read_imagei3d.html
@@ -866,7 +866,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/read_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/read_pipe.html
@@ -509,7 +509,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=158" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=read_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/recip.html
+++ b/sdk/2.1/docs/man/xhtml/recip.html
@@ -328,7 +328,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/relationalFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/relationalFunctions.html
@@ -476,7 +476,7 @@
         <h2>Specification</h2>
         <p>
             <img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/release_event.html
+++ b/sdk/2.1/docs/man/xhtml/release_event.html
@@ -413,7 +413,7 @@ foo(queue_t q, ...)
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=171" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=eventFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/remainder.html
+++ b/sdk/2.1/docs/man/xhtml/remainder.html
@@ -322,7 +322,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/remquo.html
+++ b/sdk/2.1/docs/man/xhtml/remquo.html
@@ -697,7 +697,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/reserve_read_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/reserve_read_pipe.html
@@ -471,7 +471,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=158" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=reserve_read_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/reserve_write_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/reserve_write_pipe.html
@@ -471,7 +471,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=158" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=reserve_write_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/reservedDataTypes.html
+++ b/sdk/2.1/docs/man/xhtml/reservedDataTypes.html
@@ -355,7 +355,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=11" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=reservedDataTypes" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/restrictions.html
+++ b/sdk/2.1/docs/man/xhtml/restrictions.html
@@ -422,7 +422,7 @@
         <a id="specification"></a>
         <h2>Specification</h2>
         <p><img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=51" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=restrictions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/retain_event.html
+++ b/sdk/2.1/docs/man/xhtml/retain_event.html
@@ -408,7 +408,7 @@ foo(queue_t q, ...)
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=171" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=eventFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/rint.html
+++ b/sdk/2.1/docs/man/xhtml/rint.html
@@ -317,7 +317,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/rootn.html
+++ b/sdk/2.1/docs/man/xhtml/rootn.html
@@ -448,7 +448,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/rotate.html
+++ b/sdk/2.1/docs/man/xhtml/rotate.html
@@ -304,7 +304,7 @@
         <p>
             <img src="pdficon_small1.gif" />
                                                  
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/round.html
+++ b/sdk/2.1/docs/man/xhtml/round.html
@@ -313,7 +313,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/sampler_t.html
+++ b/sdk/2.1/docs/man/xhtml/sampler_t.html
@@ -523,7 +523,7 @@ const sampler_t samplerA = CLK_NORMALIZED_COORDS_TRUE |
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=123" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=sampler_t" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/scalarDataTypes.html
+++ b/sdk/2.1/docs/man/xhtml/scalarDataTypes.html
@@ -508,7 +508,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=6" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=scalarDataTypes" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/select.html
+++ b/sdk/2.1/docs/man/xhtml/select.html
@@ -377,7 +377,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/set_user_event_status.html
+++ b/sdk/2.1/docs/man/xhtml/set_user_event_status.html
@@ -414,7 +414,7 @@ foo(queue_t q, ...)
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=171" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=eventFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/sharedVirtualMemory.html
+++ b/sdk/2.1/docs/man/xhtml/sharedVirtualMemory.html
@@ -335,7 +335,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=174" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=sharedVirtualMemory" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/shuffle.html
+++ b/sdk/2.1/docs/man/xhtml/shuffle.html
@@ -380,7 +380,7 @@ b = shuffle(a, mask); // invalid
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=113" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=miscVectorFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/sign.html
+++ b/sdk/2.1/docs/man/xhtml/sign.html
@@ -294,7 +294,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/signbit.html
+++ b/sdk/2.1/docs/man/xhtml/signbit.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>signbit</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="signbit" />
   </head>
   <body>
@@ -295,7 +295,7 @@
         <a id="double"></a>
         <h3></h3>
         <div class="informaltable">
-          <table border="0">
+          <table class="informaltable" border="0">
             <colgroup>
               <col align="left" class="col1" />
             </colgroup>
@@ -363,7 +363,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=90" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=relationalFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/sin.html
+++ b/sdk/2.1/docs/man/xhtml/sin.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>sin, sincos, sinh, sinpi</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="sin, sincos, sinh, sinpi" />
   </head>
   <body>
@@ -450,7 +450,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/smoothstep.html
+++ b/sdk/2.1/docs/man/xhtml/smoothstep.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>smoothstep</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="smoothstep" />
   </head>
   <body>
@@ -304,7 +304,7 @@
         <a id="double"></a>
         <h3></h3>
         <div class="informaltable">
-          <table border="0">
+          <table class="informaltable" border="0">
             <colgroup>
               <col align="left" class="col1" />
             </colgroup>
@@ -392,7 +392,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/sqrt.html
+++ b/sdk/2.1/docs/man/xhtml/sqrt.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>sqrt, rsqrt, half_sqrt, native_sqrt, half_rsqrt, native_rsqrt</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="sqrt, rsqrt, half_sqrt, native_sqrt, half_rsqrt, native_rsqrt" />
   </head>
   <body>
@@ -444,7 +444,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/step.html
+++ b/sdk/2.1/docs/man/xhtml/step.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>step</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="step" />
   </head>
   <body>
@@ -292,7 +292,7 @@
         <a id="double"></a>
         <h3></h3>
         <div class="informaltable">
-          <table border="0">
+          <table class="informaltable" border="0">
             <colgroup>
               <col align="left" class="col1" />
             </colgroup>
@@ -352,7 +352,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=86" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=commonFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/storageSpecifiers.html
+++ b/sdk/2.1/docs/man/xhtml/storageSpecifiers.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>Storage-class Specifiers</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="Storage-class Specifiers" />
   </head>
   <body>
@@ -233,7 +233,7 @@
         <h3>
         </h3>
         <div class="informaltable">
-          <table border="0">
+          <table class="informaltable" border="0">
             <colgroup>
               <col align="left" class="col1" />
             </colgroup>
@@ -274,7 +274,7 @@ static
             Example
         </h3>
         <div class="informaltable">
-          <table border="0">
+          <table class="informaltable" border="0">
             <colgroup>
               <col align="left" class="col1" />
             </colgroup>
@@ -317,7 +317,7 @@ static
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=50" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=storageSpecifiers" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/sub_sat.html
+++ b/sdk/2.1/docs/man/xhtml/sub_sat.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>sub_sat</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="sub_sat" />
   </head>
   <body>
@@ -301,7 +301,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/supportedImageFormats.html
+++ b/sdk/2.1/docs/man/xhtml/supportedImageFormats.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>Supported Image Formats</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="Supported Image Formats" />
   </head>
   <body>
@@ -237,7 +237,7 @@
             kernel but not both) that support images is described in the table below (Table 5.8.a):
       </p>
         <div class="informaltable">
-          <table border="1">
+          <table class="informaltable" border="1">
             <colgroup>
               <col align="left" class="col1" />
               <col align="left" class="col2" />
@@ -389,7 +389,7 @@
         kernel) that support images is described in the table below (Table 5.8.b):
       </p>
         <div class="informaltable">
-          <table border="1">
+          <table class="informaltable" border="1">
             <colgroup>
               <col align="left" class="col1" />
               <col align="left" class="col2" />
@@ -467,7 +467,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#page=137" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1.pdf#namedest=supportedImageFormats" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/syncFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/syncFunctions.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>Synchronization and Memory Fence Functions</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="Synchronization and Memory Fence Functions" />
   </head>
   <body>
@@ -229,7 +229,7 @@
         <a id="springboard"></a>
         <h2></h2>
         <div class="informaltable">
-          <table border="1">
+          <table class="informaltable" border="1">
             <colgroup>
               <col align="left" class="col1" />
               <col align="left" class="col2" />
@@ -265,7 +265,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=97" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=syncFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/tan.html
+++ b/sdk/2.1/docs/man/xhtml/tan.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>tan, tanh, tanpi, half_tan, native_tan</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="tan, tanh, tanpi, half_tan, native_tan" />
   </head>
   <body>
@@ -426,7 +426,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/tgamma.html
+++ b/sdk/2.1/docs/man/xhtml/tgamma.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>tgamma</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="tgamma" />
   </head>
   <body>
@@ -313,7 +313,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/trunc.html
+++ b/sdk/2.1/docs/man/xhtml/trunc.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>trunc</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="trunc" />
   </head>
   <body>
@@ -313,7 +313,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=72" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=mathFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/upsample.html
+++ b/sdk/2.1/docs/man/xhtml/upsample.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>upsample</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="upsample" />
   </head>
   <body>
@@ -523,7 +523,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=82" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=integerFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vec_step.html
+++ b/sdk/2.1/docs/man/xhtml/vec_step.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>vec_step</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="vec_step" />
   </head>
   <body>
@@ -470,7 +470,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=113" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=miscVectorFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vectorDataLoadandStoreFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/vectorDataLoadandStoreFunctions.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>Vector Data Load and Store Functions</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="Vector Data Load and Store Functions" />
   </head>
   <body>
@@ -229,7 +229,7 @@
         <a id="springboard"></a>
         <h2></h2>
         <div class="informaltable">
-          <table border="1">
+          <table class="informaltable" border="1">
             <colgroup>
               <col align="left" class="col1" />
               <col align="left" class="col2" />
@@ -341,7 +341,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataLoadandStoreFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/vectorDataTypes.html
+++ b/sdk/2.1/docs/man/xhtml/vectorDataTypes.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>Vector Data Types</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="Vector Data Types" />
   </head>
   <body>
@@ -248,7 +248,7 @@
         data type available to the application:
       </p>
         <div class="informaltable">
-          <table border="1">
+          <table class="informaltable" border="1">
             <colgroup>
               <col align="left" class="col1" />
               <col align="left" class="col2" />
@@ -385,7 +385,7 @@
         <p>
           </p>
         <div class="informaltable">
-          <table border="1">
+          <table class="informaltable" border="1">
             <colgroup>
               <col align="left" class="col1" />
               <col align="left" class="col2" />
@@ -466,7 +466,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=9" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataTypes" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vload_half.html
+++ b/sdk/2.1/docs/man/xhtml/vload_half.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>vload_half</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="vload_half" />
   </head>
   <body>
@@ -319,7 +319,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataLoadandStoreFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vload_halfn.html
+++ b/sdk/2.1/docs/man/xhtml/vload_halfn.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>vload_halfn</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="vload_halfn" />
   </head>
   <body>
@@ -338,7 +338,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataLoadandStoreFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vloada_halfn.html
+++ b/sdk/2.1/docs/man/xhtml/vloada_halfn.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>vloada_halfn</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="vloada_halfn" />
   </head>
   <body>
@@ -335,7 +335,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataLoadandStoreFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vloadn.html
+++ b/sdk/2.1/docs/man/xhtml/vloadn.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>vload[n]</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="vloadn" />
   </head>
   <body>
@@ -364,7 +364,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataLoadandStoreFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vstore_half.html
+++ b/sdk/2.1/docs/man/xhtml/vstore_half.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>vstore_half</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="vstore_half" />
   </head>
   <body>
@@ -517,7 +517,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataLoadandStoreFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vstore_halfn.html
+++ b/sdk/2.1/docs/man/xhtml/vstore_halfn.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>vstore_halfn</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="vstore_halfn" />
   </head>
   <body>
@@ -535,7 +535,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataLoadandStoreFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vstorea_halfn.html
+++ b/sdk/2.1/docs/man/xhtml/vstorea_halfn.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>vstorea_halfn</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="vstorea_halfn" />
   </head>
   <body>
@@ -539,7 +539,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataLoadandStoreFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/vstoren.html
+++ b/sdk/2.1/docs/man/xhtml/vstoren.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>vstoren</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="vstoren" />
   </head>
   <body>
@@ -343,7 +343,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=93" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=vectorDataLoadandStoreFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/wait_group_events.html
+++ b/sdk/2.1/docs/man/xhtml/wait_group_events.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>wait_group_events</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="wait_group_events" />
   </head>
   <body>
@@ -282,7 +282,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=100" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=asyncCopyFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/workItemFunctions.html
+++ b/sdk/2.1/docs/man/xhtml/workItemFunctions.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>Work-Item Built-In Functions</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="Work-Item Built-In Functions" />
   </head>
   <body>
@@ -229,7 +229,7 @@
         <a id="springboard"></a>
         <h2></h2>
         <div class="informaltable">
-          <table border="1">
+          <table class="informaltable" border="1">
             <colgroup>
               <col align="left" class="col1" />
               <col align="left" class="col2" />
@@ -368,7 +368,7 @@
         <h2>Specification</h2>
         <p>
             <img src="pdficon_small1.gif" />
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=69" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=workItemFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_all.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_all.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_all</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_all" />
   </head>
   <body>
@@ -263,7 +263,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=154" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_all" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_any.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_any.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_any</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_any" />
   </head>
   <body>
@@ -263,7 +263,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=154" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_any" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_barrier.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_barrier.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_barrier</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="Synchronization, work_group_barrier, barrier" />
   </head>
   <body>
@@ -355,7 +355,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=97" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_barrier" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div xmlns="" class="refsect3" lang="en" xml:lang="en"><a xmlns="http://www.w3.org/1999/xhtml" id="Copyright"></a><h4 xmlns="http://www.w3.org/1999/xhtml"></h4><img xmlns="http://www.w3.org/1999/xhtml" src="KhronosLogo.jpg" /><p xmlns="http://www.w3.org/1999/xhtml"></p>Copyright © 2007-2015 The Khronos Group Inc.

--- a/sdk/2.1/docs/man/xhtml/work_group_broadcast.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_broadcast.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_broadcast</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_broadcast" />
   </head>
   <body>
@@ -330,7 +330,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=154" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_broadcast" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_commit_read_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_commit_read_pipe.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_commit_read_pipe</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_commit_read_pipe" />
   </head>
   <body>
@@ -447,7 +447,7 @@
 In the following example
         </p>
           <div class="informaltable">
-            <table border="0">
+            <table class="informaltable" border="0">
               <colgroup>
                 <col align="left" class="col1" />
               </colgroup>
@@ -477,7 +477,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=159" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_commit_read_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_commit_write_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_commit_write_pipe.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_commit_write_pipe</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_commit_write_pipe" />
   </head>
   <body>
@@ -447,7 +447,7 @@
 In the following example
         </p>
           <div class="informaltable">
-            <table border="0">
+            <table class="informaltable" border="0">
               <colgroup>
                 <col align="left" class="col1" />
               </colgroup>
@@ -477,7 +477,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=159" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_commit_write_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_reduce.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_reduce.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_reduce</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_reduce" />
   </head>
   <body>
@@ -351,7 +351,7 @@ void foo(int *p)<br />
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=154" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_reduce" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_reserve_read_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_reserve_read_pipe.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_reserve_read_pipe</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_reserve_read_pipe" />
   </head>
   <body>
@@ -451,7 +451,7 @@
 In the following example
         </p>
           <div class="informaltable">
-            <table border="0">
+            <table class="informaltable" border="0">
               <colgroup>
                 <col align="left" class="col1" />
               </colgroup>
@@ -481,7 +481,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=159" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_reserve_read_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_reserve_write_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_reserve_write_pipe.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_reserve_write_pipe</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_reserve_write_pipe" />
   </head>
   <body>
@@ -451,7 +451,7 @@
 In the following example
         </p>
           <div class="informaltable">
-            <table border="0">
+            <table class="informaltable" border="0">
               <colgroup>
                 <col align="left" class="col1" />
               </colgroup>
@@ -481,7 +481,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=159" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_reserve_write_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_scan_exclusive.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_scan_exclusive.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_scan_exclusive</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_scan_exclusive" />
   </head>
   <body>
@@ -356,7 +356,7 @@ void foo(int *p)<br />
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=154" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_scan_exclusive" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/work_group_scan_inclusive.html
+++ b/sdk/2.1/docs/man/xhtml/work_group_scan_inclusive.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>work_group_scan_inclusive</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="work_group_scan_inclusive" />
   </head>
   <body>
@@ -356,7 +356,7 @@ void foo(int *p)<br />
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=155" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=work_group_scan_inclusive" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/write_image1d.html
+++ b/sdk/2.1/docs/man/xhtml/write_image1d.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>write_image (1D)</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="write_image1d" />
   </head>
   <body>
@@ -1091,7 +1091,7 @@ and <code class="function">write_imageui</code> forms that take <span class="typ
         <p>
     </p>
         <div class="informaltable">
-          <table border="1">
+          <table class="informaltable" border="1">
             <colgroup>
               <col align="center" class="col1" />
               <col align="center" class="col2" />
@@ -1195,7 +1195,7 @@ and <code class="function">write_imageui</code> forms that take <span class="typ
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/write_image2d.html
+++ b/sdk/2.1/docs/man/xhtml/write_image2d.html
@@ -1240,7 +1240,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/write_image3d.html
+++ b/sdk/2.1/docs/man/xhtml/write_image3d.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>write_image (3D)</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="write_image3d" />
   </head>
   <body>
@@ -574,7 +574,7 @@
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=127" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=imageFunctions" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">

--- a/sdk/2.1/docs/man/xhtml/write_pipe.html
+++ b/sdk/2.1/docs/man/xhtml/write_pipe.html
@@ -214,7 +214,7 @@
 
 </style>
     <title>write_pipe</title>
-    <meta name="generator" content="DocBook XSL Stylesheets V1.78.1" />
+    <meta name="generator" content="DocBook XSL Stylesheets V1.79.1" />
     <meta name="keywords" content="write_pipe" />
   </head>
   <body>
@@ -479,7 +479,7 @@
 In the following example
         </p>
           <div class="informaltable">
-            <table border="0">
+            <table class="informaltable" border="0">
               <colgroup>
                 <col align="left" class="col1" />
               </colgroup>
@@ -509,7 +509,7 @@ foo (read_only pipe fooA_t pipeA,
         <p>
             <img src="pdficon_small1.gif" />
 
-            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.1-openclc.pdf#page=158" target="OpenCL Spec">OpenCL Specification</a>
+            <a href="https://www.khronos.org/registry/cl/specs/opencl-2.0-openclc.pdf#namedest=write_pipe" target="OpenCL Spec">OpenCL Specification</a>
         </p>
       </div>
       <div class="refsect1">


### PR DESCRIPTION
 to (a) link C language references to opencl-2.0-openclc.pdf, which in turn links to the current asciidoctor
OpenCL C 2.0 PDF and (b) not rewrite the link to land on specific page
numbers, some of which were out of date.

Regenerate HTML pages accordingly.

Note that the '#namedest=<entry point name>' xrefs are still present in
the PDF hyperlinks, since they're not rewritten - but they do nothing,
since the PDFs / PDF readers don't support the namedest syntax.

Fixes https://github.com/KhronosGroup/OpenCL-Docs/issues/87 .