### PR TITLE
update Intel HTML extension documents

### DIFF
--- a/extensions/intel/cl_intel_required_subgroup_size.html
+++ b/extensions/intel/cl_intel_required_subgroup_size.html
@@ -1,872 +1,874 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.9">
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.8">
 <title>cl_intel_required_subgroup_size</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+<style>
+/*! normalize.css v2.1.2 | MIT License | git.io/normalize */
+/* ========================================================================== HTML5 display definitions ========================================================================== */
+/** Correct `block` display not defined in IE 8/9. */
+article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
 
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
+/** Correct `inline-block` display not defined in IE 8/9. */
+audio, canvas, video { display: inline-block; }
 
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
+/** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
+audio:not([controls]) { display: none; height: 0; }
 
-body {
-  margin: 1em 5% 1em 5%;
-}
+/** Address `[hidden]` styling not present in IE 8/9. Hide the `template` element in IE, Safari, and Firefox < 22. */
+[hidden], template { display: none; }
 
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
+script { display: none !important; }
 
-em {
-  font-style: italic;
-  color: navy;
-}
+/* ========================================================================== Base ========================================================================== */
+/** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
+html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
 
-strong {
-  font-weight: bold;
-  color: #083194;
-}
+/** Remove default margin. */
+body { margin: 0; }
 
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
+/* ========================================================================== Links ========================================================================== */
+/** Remove the gray background color from active links in IE 10. */
+a { background: transparent; }
 
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
+/** Address `outline` inconsistency between Chrome and other browsers. */
+a:focus { outline: thin dotted; }
 
-div.sectionbody {
-  margin-left: 0;
-}
+/** Improve readability when focused and also mouse hovered in all browsers. */
+a:active, a:hover { outline: 0; }
 
-hr {
-  border: 1px solid silver;
-}
+/* ========================================================================== Typography ========================================================================== */
+/** Address variable `h1` font-size and margin within `section` and `article` contexts in Firefox 4+, Safari 5, and Chrome. */
+h1 { font-size: 2em; margin: 0.67em 0; }
 
-p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9, Safari 5, and Chrome. */
+abbr[title] { border-bottom: 1px dotted; }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
+/** Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome. */
+b, strong { font-weight: bold; }
 
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
+/** Address styling not present in Safari 5 and Chrome. */
+dfn { font-style: italic; }
 
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
+/** Address differences between Firefox and other browsers. */
+hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
 
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9. */
+mark { background: #ff0; color: #000; }
 
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
+/** Correct font family set oddly in Safari 5 and Chrome. */
+code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 
-div.content { /* Block element content. */
-  padding: 0;
-}
+/** Improve readability of pre-formatted text in all browsers. */
+pre { white-space: pre-wrap; }
 
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
+/** Set consistent quote types. */
+q { quotes: "\201C" "\201D" "\2018" "\2019"; }
 
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
+/** Address inconsistent and variable font size in all browsers. */
+small { font-size: 80%; }
 
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
+/** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
 
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
+sup { top: -0.5em; }
 
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
+sub { bottom: -0.25em; }
 
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
+/* ========================================================================== Embedded content ========================================================================== */
+/** Remove border when inside `a` element in IE 8/9. */
+img { border: 0; }
 
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
+/** Correct overflow displayed oddly in IE 9. */
+svg:not(:root) { overflow: hidden; }
 
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
+/* ========================================================================== Figures ========================================================================== */
+/** Address margin not present in IE 8/9 and Safari 5. */
+figure { margin: 0; }
 
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
+/* ========================================================================== Forms ========================================================================== */
+/** Define consistent border, margin, and padding. */
+fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
 
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
+/** 1. Correct `color` not being inherited in IE 8/9. 2. Remove padding so people aren't caught out if they zero out fieldsets. */
+legend { border: 0; /* 1 */ padding: 0; /* 2 */ }
 
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
+/** 1. Correct font family not being inherited in all browsers. 2. Correct font size not being inherited in all browsers. 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome. */
+button, input, select, textarea { font-family: inherit; /* 1 */ font-size: 100%; /* 2 */ margin: 0; /* 3 */ }
 
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
+/** Address Firefox 4+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
+button, input { line-height: normal; }
 
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
+/** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+. Correct `select` style inheritance in Firefox 4+ and Opera. */
+button, select { text-transform: none; }
 
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
+/** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. */
+button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
 
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
+/** Re-set default cursor for disabled elements. */
+button[disabled], html input[disabled] { cursor: default; }
 
-.comment {
-  background: yellow;
-}
+/** 1. Address box sizing set to `content-box` in IE 8/9. 2. Remove excess padding in IE 8/9. */
+input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
 
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
+/** 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome. 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome (include `-moz` to future-proof). */
+input[type="search"] { -webkit-appearance: textfield; /* 1 */ -moz-box-sizing: content-box; -webkit-box-sizing: content-box; /* 2 */ box-sizing: content-box; }
 
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
+/** Remove inner padding and search cancel button in Safari 5 and Chrome on OS X. */
+input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
+/** Remove inner padding and border in Firefox 4+. */
+button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
+/** 1. Remove default vertical scrollbar in IE 8/9. 2. Improve readability and alignment in all browsers. */
+textarea { overflow: auto; /* 1 */ vertical-align: top; /* 2 */ }
 
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
+/* ========================================================================== Tables ========================================================================== */
+/** Remove most spacing between table cells. */
+table { border-collapse: collapse; border-spacing: 0; }
 
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
+meta.foundation-mq-small { font-family: "only screen and (min-width: 768px)"; width: 768px; }
 
-@media print {
-  #footer-badges { display: none; }
-}
+meta.foundation-mq-medium { font-family: "only screen and (min-width:1280px)"; width: 1280px; }
 
-#toc {
-  margin-bottom: 2.5em;
-}
+meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; width: 1440px; }
 
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
+*, *:before, *:after { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
 
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
+html, body { font-size: 100%; }
 
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
+body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
+a:hover { cursor: pointer; }
 
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
+img, object, embed { max-width: 100%; height: auto; }
 
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
+object, embed { height: 100%; }
+
+img { -ms-interpolation-mode: bicubic; }
+
+#map_canvas img, #map_canvas embed, #map_canvas object, .map_canvas img, .map_canvas embed, .map_canvas object { max-width: none !important; }
+
+.left { float: left !important; }
+
+.right { float: right !important; }
+
+.text-left { text-align: left !important; }
+
+.text-right { text-align: right !important; }
+
+.text-center { text-align: center !important; }
+
+.text-justify { text-align: justify !important; }
+
+.hide { display: none; }
+
+.antialiased { -webkit-font-smoothing: antialiased; }
+
+img { display: inline-block; vertical-align: middle; }
+
+textarea { height: auto; min-height: 50px; }
+
+select { width: 100%; }
+
+object, svg { display: inline-block; vertical-align: middle; }
+
+.center { margin-left: auto; margin-right: auto; }
+
+.spread { width: 100%; }
+
+p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { font-size: 1.21875em; line-height: 1.6; }
+
+.subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { line-height: 1.4; color: black; font-weight: 300; margin-top: 0.2em; margin-bottom: 0.5em; }
+
+/* Typography resets */
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
+
+/* Default Link Styles */
+a { color: #0068b0; text-decoration: none; line-height: inherit; }
+a:hover, a:focus { color: #333333; }
+a img { border: none; }
+
+/* Default paragraph styles */
+p { font-family: Noto, sans-serif; font-weight: normal; font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; text-rendering: optimizeLegibility; }
+p aside { font-size: 0.875em; line-height: 1.35; font-style: italic; }
+
+/* Default header styles */
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { font-family: Noto, sans-serif; font-weight: normal; font-style: normal; color: black; text-rendering: optimizeLegibility; margin-top: 0.5em; margin-bottom: 0.5em; line-height: 1.2125em; }
+h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small { font-size: 60%; color: #4d4d4d; line-height: 0; }
+
+h1 { font-size: 2.125em; }
+
+h2 { font-size: 1.6875em; }
+
+h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.375em; }
+
+h4 { font-size: 1.125em; }
+
+h5 { font-size: 1.125em; }
+
+h6 { font-size: 1em; }
+
+hr { border: solid #dddddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
+
+/* Helpful Typography Defaults */
+em, i { font-style: italic; line-height: inherit; }
+
+strong, b { font-weight: bold; line-height: inherit; }
+
+small { font-size: 60%; line-height: inherit; }
+
+code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #264357; }
+
+/* Lists */
+ul, ol, dl { font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; list-style-position: outside; font-family: Noto, sans-serif; }
+
+ul, ol { margin-left: 1.5em; }
+ul.no-bullet, ol.no-bullet { margin-left: 1.5em; }
+
+/* Unordered Lists */
+ul li ul, ul li ol { margin-left: 1.25em; margin-bottom: 0; font-size: 1em; /* Override nested font-size change */ }
+ul.square li ul, ul.circle li ul, ul.disc li ul { list-style: inherit; }
+ul.square { list-style-type: square; }
+ul.circle { list-style-type: circle; }
+ul.disc { list-style-type: disc; }
+ul.no-bullet { list-style: none; }
+
+/* Ordered Lists */
+ol li ul, ol li ol { margin-left: 1.25em; margin-bottom: 0; }
+
+/* Definition Lists */
+dl dt { margin-bottom: 0.3em; font-weight: bold; }
+dl dd { margin-bottom: 0.75em; }
+
+/* Abbreviations */
+abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #dddddd; cursor: help; }
+
+abbr { text-transform: none; }
+
+/* Blockquotes */
+blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #dddddd; }
+blockquote cite { display: block; font-size: 0.8125em; color: #5e93b8; }
+blockquote cite:before { content: "\2014 \0020"; }
+blockquote cite a, blockquote cite a:visited { color: #5e93b8; }
+
+blockquote, blockquote p { line-height: 1.6; color: #333333; }
+
+/* Microformats */
+.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #dddddd; padding: 0.625em 0.75em; }
+.vcard li { margin: 0; display: block; }
+.vcard .fn { font-weight: bold; font-size: 0.9375em; }
+
+.vevent .summary { font-weight: bold; }
+.vevent abbr { cursor: auto; text-decoration: none; font-weight: bold; border: none; padding: 0 0.0625em; }
+
+@media only screen and (min-width: 768px) { h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+  h1 { font-size: 2.75em; }
+  h2 { font-size: 2.3125em; }
+  h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
+  h4 { font-size: 1.4375em; } }
+/* Tables */
+table { background: white; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
+table thead, table tfoot { background: -webkit-linear-gradient(top, #add386, #90b66a); font-weight: bold; }
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: white; text-align: left; }
+table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #6d6e71; }
+table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #edf2f2; }
+table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.4; }
+
+body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+
+a:hover, a:focus { text-decoration: underline; }
+
+.clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
+.clearfix:after, .float-group:after { clear: both; }
+
+*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: white; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
+*:not(pre) > code.nobreak { word-wrap: normal; }
+*:not(pre) > code.nowrap { white-space: nowrap; }
+
+pre, pre > code { line-height: 1.6; color: #264357; font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; }
+
+em em { font-style: normal; }
+
+strong strong { font-weight: normal; }
+
+.keyseq { color: #333333; }
+
+kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
+
+.keyseq kbd:first-child { margin-left: 0; }
+
+.keyseq kbd:last-child { margin-right: 0; }
+
+.menuseq, .menuref { color: #000; }
+
+.menuseq b:not(.caret), .menuref { font-weight: inherit; }
+
+.menuseq { word-spacing: -0.02em; }
+.menuseq b.caret { font-size: 1.25em; line-height: 0.8; }
+.menuseq i.caret { font-weight: bold; text-align: center; width: 0.45em; }
+
+b.button:before, b.button:after { position: relative; top: -1px; font-weight: normal; }
+
+b.button:before { content: "["; padding: 0 3px 0 2px; }
+
+b.button:after { content: "]"; padding: 0 2px 0 3px; }
+
+#header, #content, #footnotes, #footer { width: 100%; margin-left: auto; margin-right: auto; margin-top: 0; margin-bottom: 0; max-width: 62.5em; *zoom: 1; position: relative; padding-left: 1.5em; padding-right: 1.5em; }
+#header:before, #header:after, #content:before, #content:after, #footnotes:before, #footnotes:after, #footer:before, #footer:after { content: " "; display: table; }
+#header:after, #content:after, #footnotes:after, #footer:after { clear: both; }
+
+#content { margin-top: 1.25em; }
+
+#content:before { content: none; }
+
+#header > h1:first-child { color: black; margin-top: 2.25rem; margin-bottom: 0; }
+#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #dddddd; }
+#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #dddddd; padding-bottom: 8px; }
+#header .details { border-bottom: 1px solid #dddddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #5e93b8; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
+#header .details span:first-child { margin-left: -0.125em; }
+#header .details span.email a { color: #333333; }
+#header .details br { display: none; }
+#header .details br + span:before { content: "\00a0\2013\00a0"; }
+#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333333; }
+#header .details br + span#revremark:before { content: "\00a0|\00a0"; }
+#header #revnumber { text-transform: capitalize; }
+#header #revnumber:after { content: "\00a0"; }
+
+#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #dddddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
+
+#toc { border-bottom: 0 solid #dddddd; padding-bottom: 0.5em; }
+#toc > ul { margin-left: 0.125em; }
+#toc ul.sectlevel0 > li > a { font-style: italic; }
+#toc ul.sectlevel0 ul.sectlevel1 { margin: 0.5em 0; }
+#toc ul { font-family: Noto, sans-serif; list-style-type: none; }
+#toc li { line-height: 1.3334; margin-top: 0.3334em; }
+#toc a { text-decoration: none; }
+#toc a:active { text-decoration: underline; }
+
+#toctitle { color: black; font-size: 1.2em; }
+
+@media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
+  body.toc2 { padding-left: 15em; padding-right: 0; }
+  #toc.toc2 { margin-top: 0 !important; background-color: white; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #dddddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
+  #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
+  #toc.toc2 > ul { font-size: 0.9em; margin-bottom: 0; }
+  #toc.toc2 ul ul { margin-left: 0; padding-left: 1em; }
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 15em; }
+  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #dddddd; left: auto; right: 0; } }
+@media only screen and (min-width: 1280px) { body.toc2 { padding-left: 20em; padding-right: 0; }
+  #toc.toc2 { width: 20em; }
+  #toc.toc2 #toctitle { font-size: 1.375em; }
+  #toc.toc2 > ul { font-size: 0.95em; }
+  #toc.toc2 ul ul { padding-left: 1.25em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 20em; } }
+#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+#content #toc > :first-child { margin-top: 0; }
+#content #toc > :last-child { margin-bottom: 0; }
+
+#footer { max-width: 100%; background-color: none; padding: 1.25em; }
+
+#footer-text { color: black; line-height: 1.44; }
+
+#content { margin-bottom: 0.625em; }
+
+.sect1 { padding-bottom: 0.625em; }
+
+@media only screen and (min-width: 768px) { #content { margin-bottom: 1.25em; }
+  .sect1 { padding-bottom: 1.25em; } }
+.sect1:last-child { padding-bottom: 0; }
+
+.sect1 + .sect1 { border-top: 0 solid #dddddd; }
+
+#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
+#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
+#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover { visibility: visible; }
+#content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link { color: black; text-decoration: none; }
+#content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover { color: black; }
+
+.audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock { margin-bottom: 1.25em; }
+
+.admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { text-rendering: optimizeLegibility; text-align: left; }
+
+table.tableblock > caption.title { white-space: nowrap; overflow: visible; max-width: 0; }
+
+.paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { color: black; }
+
+table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-size: inherit; }
+
+.admonitionblock > table { border-collapse: separate; border: 0; background: none; width: 100%; }
+.admonitionblock > table td.icon { text-align: center; width: 80px; }
+.admonitionblock > table td.icon img { max-width: initial; }
+.admonitionblock > table td.icon .title { font-weight: bold; font-family: Noto, sans-serif; text-transform: uppercase; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #dddddd; color: #5e93b8; }
+.admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
+
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.exampleblock > .content > :first-child { margin-top: 0; }
+.exampleblock > .content > :last-child { margin-bottom: 0; }
+
+.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.sidebarblock > :first-child { margin-top: 0; }
+.sidebarblock > :last-child { margin-bottom: 0; }
+.sidebarblock > .content > .title { color: black; margin-top: 0; }
+
+.exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
+
+.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eeeeee; }
+.sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
+
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
+.literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
+@media only screen and (min-width: 768px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 0.90625em; } }
+@media only screen and (min-width: 1280px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 1em; } }
+
+.literalblock.output pre { color: #eeeeee; background-color: #264357; }
+
+.listingblock pre.highlightjs { padding: 0; }
+.listingblock pre.highlightjs > code { padding: 1.25em 1.5625em 1.125em 1.5625em; -webkit-border-radius: 0; border-radius: 0; }
+
+.listingblock > .content { position: relative; }
+
+.listingblock code[data-lang]:before { display: none; content: attr(data-lang); position: absolute; font-size: 0.75em; top: 0.425rem; right: 0.5rem; line-height: 1; text-transform: uppercase; color: #999; }
+
+.listingblock:hover code[data-lang]:before { display: block; }
+
+.listingblock.terminal pre .command:before { content: attr(data-prompt); padding-right: 0.5em; color: #999; }
+
+.listingblock.terminal pre .command:not([data-prompt]):before { content: "$"; }
+
+table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
+
+table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; line-height: 1.6; }
+
+table.pyhltable td.code { padding-left: .75em; padding-right: 0; }
+
+pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #dddddd; }
+
+pre.pygments .lineno { display: inline-block; margin-right: .25em; }
+
+table.pyhltable .linenodiv { background: none !important; padding-right: 0 !important; }
+
+.quoteblock { margin: 0 1em 0.75em 1.5em; display: table; }
+.quoteblock > .title { margin-left: -1.5em; margin-bottom: 0.75em; }
+.quoteblock blockquote, .quoteblock blockquote p { color: #333333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
+.quoteblock blockquote { margin: 0; padding: 0; border: 0; }
+.quoteblock blockquote:before { content: "\201c"; float: left; font-size: 2.75em; font-weight: bold; line-height: 0.6em; margin-left: -0.6em; color: black; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
+.quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
+.quoteblock .attribution { margin-top: 0.5em; margin-right: 0.5ex; text-align: right; }
+.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #5e93b8; }
+.quoteblock .quoteblock blockquote { padding: 0 0 0 0.75em; }
+.quoteblock .quoteblock blockquote:before { display: none; }
+
+.verseblock { margin: 0 1em 0.75em 1em; }
+.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333333; font-weight: 300; text-rendering: optimizeLegibility; }
+.verseblock pre strong { font-weight: 400; }
+.verseblock .attribution { margin-top: 1.25rem; margin-left: 0.5ex; }
+
+.quoteblock .attribution, .verseblock .attribution { font-size: 0.8125em; line-height: 1.45; font-style: italic; }
+.quoteblock .attribution br, .verseblock .attribution br { display: none; }
+.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #5e93b8; }
+
+.quoteblock.abstract { margin: 0 0 0.75em 0; display: block; }
+.quoteblock.abstract blockquote, .quoteblock.abstract blockquote p { text-align: left; word-spacing: 0; }
+.quoteblock.abstract blockquote:before, .quoteblock.abstract blockquote p:first-of-type:before { display: none; }
+
+table.tableblock { max-width: 100%; border-collapse: separate; }
+table.tableblock td > .paragraph:last-child p > p:last-child, table.tableblock th > p:last-child, table.tableblock td > p:last-child { margin-bottom: 0; }
+
+table.tableblock, th.tableblock, td.tableblock { border: 0 solid #d8d8ce; }
+
+table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock { border-width: 0 1px 1px 0; }
+
+table.grid-all > tfoot > tr > .tableblock { border-width: 1px 1px 0 0; }
+
+table.grid-cols > * > tr > .tableblock { border-width: 0 1px 0 0; }
+
+table.grid-rows > thead > tr > .tableblock, table.grid-rows > tbody > tr > .tableblock { border-width: 0 0 1px 0; }
+
+table.grid-rows > tfoot > tr > .tableblock { border-width: 1px 0 0 0; }
+
+table.grid-all > * > tr > .tableblock:last-child, table.grid-cols > * > tr > .tableblock:last-child { border-right-width: 0; }
+
+table.grid-all > tbody > tr:last-child > .tableblock, table.grid-all > thead:last-child > tr > .tableblock, table.grid-rows > tbody > tr:last-child > .tableblock, table.grid-rows > thead:last-child > tr > .tableblock { border-bottom-width: 0; }
+
+table.frame-all { border-width: 1px; }
+
+table.frame-sides { border-width: 0 1px; }
+
+table.frame-topbot { border-width: 1px 0; }
+
+th.halign-left, td.halign-left { text-align: left; }
+
+th.halign-right, td.halign-right { text-align: right; }
+
+th.halign-center, td.halign-center { text-align: center; }
+
+th.valign-top, td.valign-top { vertical-align: top; }
+
+th.valign-bottom, td.valign-bottom { vertical-align: bottom; }
+
+th.valign-middle, td.valign-middle { vertical-align: middle; }
+
+table thead th, table tfoot th { font-weight: bold; }
+
+tbody tr th { display: table-cell; line-height: 1.4; background: -webkit-linear-gradient(top, #add386, #90b66a); }
+
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: white; font-weight: bold; }
+
+p.tableblock > code:only-child { background: none; padding: 0; }
+
+p.tableblock { font-size: 1em; }
+
+td > div.verse { white-space: pre; }
+
+ol { margin-left: 1.75em; }
+
+ul li ol { margin-left: 1.5em; }
+
+dl dd { margin-left: 1.125em; }
+
+dl dd:last-child, dl dd:last-child > :last-child { margin-bottom: 0; }
+
+ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .ulist, .ulist .olist, .olist .ulist { margin-bottom: 0.375em; }
+
+ul.checklist, ul.none, ol.none, ul.no-bullet, ol.no-bullet, ol.unnumbered, ul.unstyled, ol.unstyled { list-style-type: none; }
+
+ul.no-bullet, ol.no-bullet, ol.unnumbered { margin-left: 0.625em; }
+
+ul.unstyled, ol.unstyled { margin-left: 0; }
+
+ul.checklist { margin-left: 0.625em; }
+
+ul.checklist li > p:first-child > .fa-square-o:first-child, ul.checklist li > p:first-child > .fa-check-square-o:first-child { width: 1.25em; font-size: 0.8em; position: relative; bottom: 0.125em; }
+
+ul.checklist li > p:first-child > input[type="checkbox"]:first-child { margin-right: 0.25em; }
+
+ul.inline { display: -ms-flexbox; display: -webkit-box; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; list-style: none; margin: 0 0 0.375em -0.75em; }
+
+ul.inline > li { margin-left: 0.75em; }
+
+.unstyled dl dt { font-weight: normal; font-style: normal; }
+
+ol.arabic { list-style-type: decimal; }
+
+ol.decimal { list-style-type: decimal-leading-zero; }
+
+ol.loweralpha { list-style-type: lower-alpha; }
+
+ol.upperalpha { list-style-type: upper-alpha; }
+
+ol.lowerroman { list-style-type: lower-roman; }
+
+ol.upperroman { list-style-type: upper-roman; }
+
+ol.lowergreek { list-style-type: lower-greek; }
+
+.hdlist > table, .colist > table { border: 0; background: none; }
+.hdlist > table > tbody > tr, .colist > table > tbody > tr { background: none; }
+
+td.hdlist1, td.hdlist2 { vertical-align: top; padding: 0 0.625em; }
+
+td.hdlist1 { font-weight: bold; padding-bottom: 0.75em; }
+
+.literalblock + .colist, .listingblock + .colist { margin-top: -0.5em; }
+
+.colist > table tr > td:first-of-type { padding: 0.4em 0.75em 0 0.75em; line-height: 1; vertical-align: top; }
+.colist > table tr > td:first-of-type img { max-width: initial; }
+.colist > table tr > td:last-of-type { padding: 0.25em 0; }
+
+.thumb, .th { line-height: 0; display: inline-block; border: solid 4px white; -webkit-box-shadow: 0 0 0 1px #dddddd; box-shadow: 0 0 0 1px #dddddd; }
+
+.imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
+.imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
+.imageblock > .title { margin-bottom: 0; }
+.imageblock.thumb, .imageblock.th { border-width: 6px; }
+.imageblock.thumb > .title, .imageblock.th > .title { padding: 0 0.125em; }
+
+.image.left, .image.right { margin-top: 0.25em; margin-bottom: 0.25em; display: inline-block; line-height: 0; }
+.image.left { margin-right: 0.625em; }
+.image.right { margin-left: 0.625em; }
+
+a.image { text-decoration: none; display: inline-block; }
+a.image object { pointer-events: none; }
+
+sup.footnote, sup.footnoteref { font-size: 0.875em; position: static; vertical-align: super; }
+sup.footnote a, sup.footnoteref a { text-decoration: none; }
+sup.footnote a:active, sup.footnoteref a:active { text-decoration: underline; }
+
+#footnotes { padding-top: 0.75em; padding-bottom: 0.75em; margin-bottom: 0.625em; }
+#footnotes hr { width: 20%; min-width: 6.25em; margin: -0.25em 0 0.75em 0; border-width: 1px 0 0 0; }
+#footnotes .footnote { padding: 0 0.375em 0 0.225em; line-height: 1.3334; font-size: 0.875em; margin-left: 1.2em; margin-bottom: 0.2em; }
+#footnotes .footnote a:first-of-type { font-weight: bold; text-decoration: none; margin-left: -1.05em; }
+#footnotes .footnote:last-of-type { margin-bottom: 0; }
+#content #footnotes { margin-top: -0.625em; margin-bottom: 0; padding: 0.75em 0; }
+
+.gist .file-data > table { border: 0; background: #fff; width: 100%; margin-bottom: 0; }
+.gist .file-data > table td.line-data { width: 99%; }
 
 div.unbreakable { page-break-inside: avoid; }
 
+.big { font-size: larger; }
 
-/*
- * xhtml11 specific
- *
- * */
+.small { font-size: smaller; }
 
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
+.underline { text-decoration: underline; }
 
+.overline { text-decoration: overline; }
 
-/*
- * html5 specific
- *
- * */
+.line-through { text-decoration: line-through; }
 
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
+.aqua { color: #00bfbf; }
 
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
+.aqua-background { background-color: #00fafa; }
 
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
+.black { color: black; }
 
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
+.black-background { background-color: black; }
 
+.blue { color: #0000bf; }
 
-/*
- * manpage specific
- *
- * */
+.blue-background { background-color: #0000fa; }
 
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
+.fuchsia { color: #bf00bf; }
 
-@media print {
-  body.manpage div#toc { display: none; }
-}
+.fuchsia-background { background-color: #fa00fa; }
 
+.gray { color: #606060; }
 
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
+.gray-background { background-color: #7d7d7d; }
 
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
+.green { color: #006000; }
 
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
+.green-background { background-color: #007d00; }
 
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
+.lime { color: #00bf00; }
 
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
+.lime-background { background-color: #00fa00; }
+
+.maroon { color: #600000; }
+
+.maroon-background { background-color: #7d0000; }
+
+.navy { color: #000060; }
+
+.navy-background { background-color: #00007d; }
+
+.olive { color: #606000; }
+
+.olive-background { background-color: #7d7d00; }
+
+.purple { color: #600060; }
+
+.purple-background { background-color: #7d007d; }
+
+.red { color: #bf0000; }
+
+.red-background { background-color: #fa0000; }
+
+.silver { color: #909090; }
+
+.silver-background { background-color: #bcbcbc; }
+
+.teal { color: #006060; }
+
+.teal-background { background-color: #007d7d; }
+
+.white { color: #bfbfbf; }
+
+.white-background { background-color: #fafafa; }
+
+.yellow { color: #bfbf00; }
+
+.yellow-background { background-color: #fafa00; }
+
+span.icon > .fa { cursor: default; }
+a span.icon > .fa { cursor: inherit; }
+
+.admonitionblock td.icon [class^="fa icon-"] { font-size: 2.5em; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5); cursor: default; }
+.admonitionblock td.icon .icon-note:before { content: "\f05a"; color: #29475c; }
+.admonitionblock td.icon .icon-tip:before { content: "\f0eb"; text-shadow: 1px 1px 2px rgba(155, 155, 0, 0.8); color: #111; }
+.admonitionblock td.icon .icon-warning:before { content: "\f071"; color: #bf6900; }
+.admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #bf3400; }
+.admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
+
+.conum[data-value] { display: inline-block; color: #fff !important; background-color: black; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; font-size: 0.75em; width: 1.67em; height: 1.67em; line-height: 1.67em; font-family: "Open Sans", "DejaVu Sans", sans-serif; font-style: normal; font-weight: bold; }
+.conum[data-value] * { color: #fff !important; }
+.conum[data-value] + b { display: none; }
+.conum[data-value]:after { content: attr(data-value); }
+pre .conum[data-value] { position: relative; top: -0.125em; }
+
+b.conum * { color: inherit !important; }
+
+.conum:not([data-value]):empty { display: none; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #dddddd; }
+
+.sect1 { padding-bottom: 0; }
+
+#toctitle { color: #00406F; font-weight: normal; margin-top: 1.5em; }
+
+.sidebarblock { border-color: #aaa; }
+
+code { -webkit-border-radius: 4px; border-radius: 4px; }
+
+p.tableblock.header { color: #6d6e71; }
+
+.literalblock pre, .listingblock pre { background: #eeeeee; }
+
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
-</head>
-<body class="article">
+<link rel="stylesheet" href="../katex/katex.min.css">
+<script src="../katex/katex.min.js"></script>
+<script src="../katex/contrib/auto-render.min.js"></script>
+    <!-- Use KaTeX to render math once document is loaded, see
+         https://github.com/Khan/KaTeX/tree/master/contrib/auto-render -->
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        renderMathInElement(
+            document.body,
+            {
+                delimiters: [
+                    { left: "$$", right: "$$", display: true},
+                    { left: "\\[", right: "\\]", display: true},
+                    { left: "$", right: "$", display: false},
+                    { left: "\\(", right: "\\)", display: false}
+                ]
+            }
+        );
+    });
+</script></head>
+<body class="book">
 <div id="header">
 <h1>cl_intel_required_subgroup_size</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div class="details">
+<span id="revnumber">version V2.2-11-30-g5ba09e4,</span>
+<span id="revdate">Thu, 24 Oct 2019 22:38:26 +0000</span>
+<br><span id="revremark">from git branch: public_master commit: 5ba09e43bb29a2292d6af0b70148a9f846e1806f</span>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p><span class="monospaced">cl_intel_required_subgroup_size</span></p></div>
+<div class="paragraph">
+<p><code>cl_intel_required_subgroup_size</code></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel (ben <em>dot</em> ashbaugh <em>at</em> intel <em>dot</em> com)</p></div>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel (ben 'dot' ashbaugh 'at' intel 'dot' com)</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel</p></div>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Final Draft</p></div>
+<div class="paragraph">
+<p>Final Draft</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Built On: 2018-11-16<br>
-Revision: 2</p></div>
+<div class="paragraph">
+<p>Built On: 2019-10-23<br>
+Revision: 3</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Support for OpenCL 2.1, <span class="monospaced">cl_khr_subgroups, or `cl_intel_subgroups</span> is required.
-This extension is written against revision 23 of the OpenCL 2.1 API specification, against revision 30 of the OpenCL 2.0 OpenCL C specification, against version 31 of the OpenCL 2.0 Extensions specification, and against version 3 of the <span class="monospaced">cl_intel_subgroups</span> specification.</p></div>
+<div class="paragraph">
+<p>Support for OpenCL 2.1, <code>cl_khr_subgroups</code>, or <code>cl_intel_subgroups</code> is required.
+This extension is written against revision 23 of the OpenCL 2.1 API specification, against revision 30 of the OpenCL 2.0 OpenCL C specification, against version 31 of the OpenCL 2.0 Extensions specification, and against version 3 of the <code>cl_intel_subgroups</code> specification.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>The goal of this extension is to allow programmers to optionally specify the required subgroup size for a kernel function.
-This information is important for the correctness of many subgroup algorithms, and in some cases may be used by the compiler to generate more optimal code.</p></div>
+<div class="paragraph">
+<p>The goal of this extension is to allow programmers to optionally specify the required subgroup size for a kernel function.
+This information is important for the correctness of many subgroup algorithms, and in some cases may be used by the compiler to generate more optimal code.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_functions">New API Functions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_enums">New API Enums</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Accepted as the <em>param_name</em> parameter of <strong>clGetDeviceInfo</strong>:</p></div>
+<div class="paragraph">
+<p>Accepted as the <em>param_name</em> parameter of <strong>clGetDeviceInfo</strong>:</p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt>CL_DEVICE_SUB_GROUP_SIZES_INTEL                 <span style="color: #993399">0x4108</span></tt></pre></div></div>
-<div class="paragraph"><p>Accepted as the <em>param_name</em> parameter of <strong>clGetKernelWorkGroupInfo</strong>:</p></div>
+<div class="content">
+<pre class="highlight"><code>CL_DEVICE_SUB_GROUP_SIZES_INTEL                 0x4108</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Accepted as the <em>param_name</em> parameter of <strong>clGetKernelWorkGroupInfo</strong>:</p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt>CL_KERNEL_SPILL_MEM_SIZE_INTEL                  <span style="color: #993399">0x4109</span></tt></pre></div></div>
-<div class="paragraph"><p>Accepted as the <em>param_name</em> parameter of <strong>clGetKernelSubGroupInfo</strong> and/or
-<strong>clGetKernelSubGroupInfoKHR</strong>:</p></div>
+<div class="content">
+<pre class="highlight"><code>CL_KERNEL_SPILL_MEM_SIZE_INTEL                  0x4109</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Accepted as the <em>param_name</em> parameter of <strong>clGetKernelSubGroupInfo</strong> and/or
+<strong>clGetKernelSubGroupInfoKHR</strong>:</p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt>CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL          <span style="color: #993399">0x410A</span></tt></pre></div></div>
+<div class="content">
+<pre class="highlight"><code>CL_KERNEL_COMPILE_SUB_GROUP_SIZE_INTEL          0x410A</code></pre>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_opencl_c_optional_attribute_qualifiers">New OpenCL C Optional Attribute Qualifiers</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Optional __kernel qualifier:</p></div>
+<div class="paragraph">
+<p>Optional <code>__kernel</code> qualifier:</p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="font-weight: bold"><span style="color: #000000">__attribute__</span></span><span style="color: #990000">((</span><span style="font-weight: bold"><span style="color: #000000">intel_reqd_sub_group_size</span></span><span style="color: #990000">(&lt;</span><span style="color: #009900">int</span><span style="color: #990000">&gt;)))</span></tt></pre></div></div>
+<div class="content">
+<pre class="highlight"><code>__attribute__((intel_reqd_sub_group_size(&lt;int&gt;)))</code></pre>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -874,50 +876,48 @@ http://www.gnu.org/software/src-highlite -->
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_additions_to_table_4_3_opencl_device_queries">Additions to Table 4.3 - "OpenCL Device Queries"</h3>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:30%;">
-<col style="width:20%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 34%;">
+<col style="width: 33%;">
+<col style="width: 33%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>cl_device_info</strong> </th>
-<th class="tableblock halign-left valign-top" > Return Type </th>
-<th class="tableblock halign-left valign-top" > Description</th>
+<th class="tableblock halign-left valign-top"><strong>cl_device_info</strong></th>
+<th class="tableblock halign-left valign-top">Return Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CL_DEVICE_SUB_GROUP_SIZES_INTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><span class="monospaced">size_t[]</span></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the set of subgroup sizes supported by the device.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>CL_&#8203;DEVICE_&#8203;SUB_&#8203;GROUP_&#8203;SIZES_&#8203;INTEL</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size_t[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the set of subgroup sizes supported by the device.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect2">
 <h3 id="_additions_to_table_5_21_clgetkernelworkgroupinfo_parameter_queries">Additions to Table 5.21 - "clGetKernelWorkGroupInfo parameter queries":</h3>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:34%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 34%;">
+<col style="width: 33%;">
+<col style="width: 33%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>cl_kernel_work_group_info</strong> </th>
-<th class="tableblock halign-left valign-top" > Return Type </th>
-<th class="tableblock halign-left valign-top" > Info. returned in <em>param_value</em></th>
+<th class="tableblock halign-left valign-top"><strong>cl_kernel_work_group_info</strong></th>
+<th class="tableblock halign-left valign-top">Return Type</th>
+<th class="tableblock halign-left valign-top">Info. returned in <em>param_value</em></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CL_KERNEL_SPILL_MEM_SIZE_INTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><span class="monospaced">cl_ulong</span></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the amount of spill memory used by a kernel.
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>CL_&#8203;KERNEL_&#8203;SPILL_&#8203;MEM_&#8203;SIZE_&#8203;INTEL</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>cl_ulong</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the amount of spill memory used by a kernel.
 The meaning of this value will vary from implementation-to-implementation, however a return value of 0 will always indicate that compiler was able to compile the kernel to fit into the device&#8217;s register file without spilling registers to memory.</p></td>
 </tr>
 </tbody>
@@ -925,30 +925,30 @@ The meaning of this value will vary from implementation-to-implementation, howev
 </div>
 <div class="sect2">
 <h3 id="_additions_to_clgetkernelsubgroupinfo_parameter_queries">Additions to "clGetKernelSubGroupInfo parameter queries":</h3>
-<div class="paragraph"><p>This is Table 5.22 - "<strong>clGetKernelSubGroupInfo</strong> parameter queries" in the OpenCL 2.1 API spec, in Section 9.17.2.1 for <strong>clGetKernelSubGroupInfoKHR</strong> in the OpenCL 2.0 Extensions spec, and in the section describing the changes to Section 5.9.3 for <strong>clGetKernelSubGroupInfoKHR</strong> in the <span class="monospaced">cl_intel_subgroups</span> spec:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+<div class="paragraph">
+<p>This is Table 5.22 - "<strong>clGetKernelSubGroupInfo</strong> parameter queries" in the OpenCL 2.1 API spec, in Section 9.17.2.1 for <strong>clGetKernelSubGroupInfoKHR</strong> in the OpenCL 2.0 Extensions spec, and in the section describing the changes to Section 5.9.3 for <strong>clGetKernelSubGroupInfoKHR</strong> in the <code>cl_intel_subgroups</code> spec:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>cl_kernel_sub_group_info</strong> </th>
-<th class="tableblock halign-left valign-top" > Input Type </th>
-<th class="tableblock halign-left valign-top" > Return Type </th>
-<th class="tableblock halign-left valign-top" > Info. returned in <em>param_value</em></th>
+<th class="tableblock halign-left valign-top"><strong>cl_kernel_sub_group_info</strong></th>
+<th class="tableblock halign-left valign-top">Input Type</th>
+<th class="tableblock halign-left valign-top">Return Type</th>
+<th class="tableblock halign-left valign-top">Info. returned in <em>param_value</em></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CL_KERNEL_COMPILE_<br>
-SUB_GROUP_SIZE_INTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><span class="monospaced">ignored</span></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><span class="monospaced">size_t</span></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the subgroup size specified by the <span class="monospaced">__attribute__(( intel_reqd_sub_group_size(&lt;int&gt;) ))</span> qualifier.
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>CL_&#8203;KERNEL_&#8203;COMPILE_&#8203;SUB_&#8203;GROUP_&#8203;SIZE_&#8203;INTEL</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>ignored</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size_t</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the subgroup size specified by the <code>__attribute__((intel_reqd_sub_group_size(&lt;int&gt;)))</code> qualifier.
 Refer to section 6.7.2.</p>
 <p class="tableblock">If the subgroup size is not specified using the above attribute qualifier then 0 is returned.</p></td>
 </tr>
@@ -962,65 +962,81 @@ Refer to section 6.7.2.</p>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_additions_to_section_6_7_2_optional_attribute_qualifiers">Additions to Section 6.7.2 - "Optional Attribute Qualifiers"</h3>
-<div class="paragraph"><p>The optional <span class="monospaced">__attribute__((intel_reqd_sub_group_size(&lt;int&gt;)))</span> can be used to indicate that the kernel must be compiled and executed with the specified subgroup size.
+<div class="paragraph">
+<p>The optional <code>__attribute__((intel_reqd_sub_group_size(&lt;int&gt;)))</code> can be used to indicate that the kernel must be compiled and executed with the specified subgroup size.
 When this attribute is present, <strong>get_max_sub_group_size</strong>() is guaranteed to return the specified integer value.
-This is important for the correctness of many subgroup algorithms, and in some cases may be used by the compiler to generate more optimal code.</p></div>
-<div class="paragraph"><p>Note that there is no guarantee for the value of <strong>get_sub_group_size</strong>() even when this attribute is present, particularly when the work-group size is not evenly divisible by the required subgroup size.</p></div>
-<div class="paragraph"><p>Note as well that some devices may support a limited number of subgroup sizes, and that some devices may not support all language constructs with all subgroup sizes.
-This means that some kernels may fail compilation with one required subgroup size and succeed with another required subgroup size, even if both subgroup sizes are supported by the device.</p></div>
-<div class="paragraph"><p>Finally, note that requiring one subgroup size (particularly, a larger subgroup size) may require more spill memory than another subgroup size, and may negatively impact application performance."</p></div>
+This is important for the correctness of many subgroup algorithms, and in some cases may be used by the compiler to generate more optimal code.</p>
+</div>
+<div class="paragraph">
+<p>Note that there is no guarantee for the value of <strong>get_sub_group_size</strong>() even when this attribute is present, particularly when the work-group size is not evenly divisible by the required subgroup size.</p>
+</div>
+<div class="paragraph">
+<p>Note as well that some devices may support a limited number of subgroup sizes, and that some devices may not support all language constructs with all subgroup sizes.
+This means that some kernels may fail compilation with one required subgroup size and succeed with another required subgroup size, even if both subgroup sizes are supported by the device.</p>
+</div>
+<div class="paragraph">
+<p>Finally, note that requiring one subgroup size (particularly, a larger subgroup size) may require more spill memory than another subgroup size, and may negatively impact application performance."</p>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2016-07-14</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>First public revision.</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2016-07-14</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>First public revision.</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-11-15</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Conversion to asciidoc.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-11-15</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Conversion to asciidoc.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-09-17</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Minor formatting fixes for asciidoctor.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
-<div id="footnotes"><hr></div>
 <div id="footer">
 <div id="footer-text">
-Last updated
- 2018-11-16 10:11:35 PST
+Version V2.2-11-30-g5ba09e4<br>
+Last updated 2019-10-23 15:35:34 -0700
 </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 </body>
 </html>

--- a/extensions/intel/cl_intel_spirv_device_side_avc_motion_estimation.html
+++ b/extensions/intel/cl_intel_spirv_device_side_avc_motion_estimation.html
@@ -1,912 +1,924 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.9">
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.8">
 <title>cl_intel_spirv_device_side_avc_motion_estimation</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+<style>
+/*! normalize.css v2.1.2 | MIT License | git.io/normalize */
+/* ========================================================================== HTML5 display definitions ========================================================================== */
+/** Correct `block` display not defined in IE 8/9. */
+article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
 
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
+/** Correct `inline-block` display not defined in IE 8/9. */
+audio, canvas, video { display: inline-block; }
 
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
+/** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
+audio:not([controls]) { display: none; height: 0; }
 
-body {
-  margin: 1em 5% 1em 5%;
-}
+/** Address `[hidden]` styling not present in IE 8/9. Hide the `template` element in IE, Safari, and Firefox < 22. */
+[hidden], template { display: none; }
 
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
+script { display: none !important; }
 
-em {
-  font-style: italic;
-  color: navy;
-}
+/* ========================================================================== Base ========================================================================== */
+/** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
+html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
 
-strong {
-  font-weight: bold;
-  color: #083194;
-}
+/** Remove default margin. */
+body { margin: 0; }
 
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
+/* ========================================================================== Links ========================================================================== */
+/** Remove the gray background color from active links in IE 10. */
+a { background: transparent; }
 
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
+/** Address `outline` inconsistency between Chrome and other browsers. */
+a:focus { outline: thin dotted; }
 
-div.sectionbody {
-  margin-left: 0;
-}
+/** Improve readability when focused and also mouse hovered in all browsers. */
+a:active, a:hover { outline: 0; }
 
-hr {
-  border: 1px solid silver;
-}
+/* ========================================================================== Typography ========================================================================== */
+/** Address variable `h1` font-size and margin within `section` and `article` contexts in Firefox 4+, Safari 5, and Chrome. */
+h1 { font-size: 2em; margin: 0.67em 0; }
 
-p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9, Safari 5, and Chrome. */
+abbr[title] { border-bottom: 1px dotted; }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
+/** Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome. */
+b, strong { font-weight: bold; }
 
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
+/** Address styling not present in Safari 5 and Chrome. */
+dfn { font-style: italic; }
 
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
+/** Address differences between Firefox and other browsers. */
+hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
 
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9. */
+mark { background: #ff0; color: #000; }
 
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
+/** Correct font family set oddly in Safari 5 and Chrome. */
+code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 
-div.content { /* Block element content. */
-  padding: 0;
-}
+/** Improve readability of pre-formatted text in all browsers. */
+pre { white-space: pre-wrap; }
 
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
+/** Set consistent quote types. */
+q { quotes: "\201C" "\201D" "\2018" "\2019"; }
 
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
+/** Address inconsistent and variable font size in all browsers. */
+small { font-size: 80%; }
 
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
+/** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
 
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
+sup { top: -0.5em; }
 
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
+sub { bottom: -0.25em; }
 
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
+/* ========================================================================== Embedded content ========================================================================== */
+/** Remove border when inside `a` element in IE 8/9. */
+img { border: 0; }
 
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
+/** Correct overflow displayed oddly in IE 9. */
+svg:not(:root) { overflow: hidden; }
 
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
+/* ========================================================================== Figures ========================================================================== */
+/** Address margin not present in IE 8/9 and Safari 5. */
+figure { margin: 0; }
 
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
+/* ========================================================================== Forms ========================================================================== */
+/** Define consistent border, margin, and padding. */
+fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
 
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
+/** 1. Correct `color` not being inherited in IE 8/9. 2. Remove padding so people aren't caught out if they zero out fieldsets. */
+legend { border: 0; /* 1 */ padding: 0; /* 2 */ }
 
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
+/** 1. Correct font family not being inherited in all browsers. 2. Correct font size not being inherited in all browsers. 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome. */
+button, input, select, textarea { font-family: inherit; /* 1 */ font-size: 100%; /* 2 */ margin: 0; /* 3 */ }
 
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
+/** Address Firefox 4+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
+button, input { line-height: normal; }
 
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
+/** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+. Correct `select` style inheritance in Firefox 4+ and Opera. */
+button, select { text-transform: none; }
 
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
+/** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. */
+button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
 
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
+/** Re-set default cursor for disabled elements. */
+button[disabled], html input[disabled] { cursor: default; }
 
-.comment {
-  background: yellow;
-}
+/** 1. Address box sizing set to `content-box` in IE 8/9. 2. Remove excess padding in IE 8/9. */
+input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
 
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
+/** 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome. 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome (include `-moz` to future-proof). */
+input[type="search"] { -webkit-appearance: textfield; /* 1 */ -moz-box-sizing: content-box; -webkit-box-sizing: content-box; /* 2 */ box-sizing: content-box; }
 
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
+/** Remove inner padding and search cancel button in Safari 5 and Chrome on OS X. */
+input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
+/** Remove inner padding and border in Firefox 4+. */
+button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
+/** 1. Remove default vertical scrollbar in IE 8/9. 2. Improve readability and alignment in all browsers. */
+textarea { overflow: auto; /* 1 */ vertical-align: top; /* 2 */ }
 
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
+/* ========================================================================== Tables ========================================================================== */
+/** Remove most spacing between table cells. */
+table { border-collapse: collapse; border-spacing: 0; }
 
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
+meta.foundation-mq-small { font-family: "only screen and (min-width: 768px)"; width: 768px; }
 
-@media print {
-  #footer-badges { display: none; }
-}
+meta.foundation-mq-medium { font-family: "only screen and (min-width:1280px)"; width: 1280px; }
 
-#toc {
-  margin-bottom: 2.5em;
-}
+meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; width: 1440px; }
 
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
+*, *:before, *:after { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
 
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
+html, body { font-size: 100%; }
 
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
+body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
+a:hover { cursor: pointer; }
 
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
+img, object, embed { max-width: 100%; height: auto; }
 
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
+object, embed { height: 100%; }
+
+img { -ms-interpolation-mode: bicubic; }
+
+#map_canvas img, #map_canvas embed, #map_canvas object, .map_canvas img, .map_canvas embed, .map_canvas object { max-width: none !important; }
+
+.left { float: left !important; }
+
+.right { float: right !important; }
+
+.text-left { text-align: left !important; }
+
+.text-right { text-align: right !important; }
+
+.text-center { text-align: center !important; }
+
+.text-justify { text-align: justify !important; }
+
+.hide { display: none; }
+
+.antialiased { -webkit-font-smoothing: antialiased; }
+
+img { display: inline-block; vertical-align: middle; }
+
+textarea { height: auto; min-height: 50px; }
+
+select { width: 100%; }
+
+object, svg { display: inline-block; vertical-align: middle; }
+
+.center { margin-left: auto; margin-right: auto; }
+
+.spread { width: 100%; }
+
+p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { font-size: 1.21875em; line-height: 1.6; }
+
+.subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { line-height: 1.4; color: black; font-weight: 300; margin-top: 0.2em; margin-bottom: 0.5em; }
+
+/* Typography resets */
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
+
+/* Default Link Styles */
+a { color: #0068b0; text-decoration: none; line-height: inherit; }
+a:hover, a:focus { color: #333333; }
+a img { border: none; }
+
+/* Default paragraph styles */
+p { font-family: Noto, sans-serif; font-weight: normal; font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; text-rendering: optimizeLegibility; }
+p aside { font-size: 0.875em; line-height: 1.35; font-style: italic; }
+
+/* Default header styles */
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { font-family: Noto, sans-serif; font-weight: normal; font-style: normal; color: black; text-rendering: optimizeLegibility; margin-top: 0.5em; margin-bottom: 0.5em; line-height: 1.2125em; }
+h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small { font-size: 60%; color: #4d4d4d; line-height: 0; }
+
+h1 { font-size: 2.125em; }
+
+h2 { font-size: 1.6875em; }
+
+h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.375em; }
+
+h4 { font-size: 1.125em; }
+
+h5 { font-size: 1.125em; }
+
+h6 { font-size: 1em; }
+
+hr { border: solid #dddddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
+
+/* Helpful Typography Defaults */
+em, i { font-style: italic; line-height: inherit; }
+
+strong, b { font-weight: bold; line-height: inherit; }
+
+small { font-size: 60%; line-height: inherit; }
+
+code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #264357; }
+
+/* Lists */
+ul, ol, dl { font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; list-style-position: outside; font-family: Noto, sans-serif; }
+
+ul, ol { margin-left: 1.5em; }
+ul.no-bullet, ol.no-bullet { margin-left: 1.5em; }
+
+/* Unordered Lists */
+ul li ul, ul li ol { margin-left: 1.25em; margin-bottom: 0; font-size: 1em; /* Override nested font-size change */ }
+ul.square li ul, ul.circle li ul, ul.disc li ul { list-style: inherit; }
+ul.square { list-style-type: square; }
+ul.circle { list-style-type: circle; }
+ul.disc { list-style-type: disc; }
+ul.no-bullet { list-style: none; }
+
+/* Ordered Lists */
+ol li ul, ol li ol { margin-left: 1.25em; margin-bottom: 0; }
+
+/* Definition Lists */
+dl dt { margin-bottom: 0.3em; font-weight: bold; }
+dl dd { margin-bottom: 0.75em; }
+
+/* Abbreviations */
+abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #dddddd; cursor: help; }
+
+abbr { text-transform: none; }
+
+/* Blockquotes */
+blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #dddddd; }
+blockquote cite { display: block; font-size: 0.8125em; color: #5e93b8; }
+blockquote cite:before { content: "\2014 \0020"; }
+blockquote cite a, blockquote cite a:visited { color: #5e93b8; }
+
+blockquote, blockquote p { line-height: 1.6; color: #333333; }
+
+/* Microformats */
+.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #dddddd; padding: 0.625em 0.75em; }
+.vcard li { margin: 0; display: block; }
+.vcard .fn { font-weight: bold; font-size: 0.9375em; }
+
+.vevent .summary { font-weight: bold; }
+.vevent abbr { cursor: auto; text-decoration: none; font-weight: bold; border: none; padding: 0 0.0625em; }
+
+@media only screen and (min-width: 768px) { h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+  h1 { font-size: 2.75em; }
+  h2 { font-size: 2.3125em; }
+  h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
+  h4 { font-size: 1.4375em; } }
+/* Tables */
+table { background: white; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
+table thead, table tfoot { background: -webkit-linear-gradient(top, #add386, #90b66a); font-weight: bold; }
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: white; text-align: left; }
+table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #6d6e71; }
+table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #edf2f2; }
+table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.4; }
+
+body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+
+a:hover, a:focus { text-decoration: underline; }
+
+.clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
+.clearfix:after, .float-group:after { clear: both; }
+
+*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: white; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
+*:not(pre) > code.nobreak { word-wrap: normal; }
+*:not(pre) > code.nowrap { white-space: nowrap; }
+
+pre, pre > code { line-height: 1.6; color: #264357; font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; }
+
+em em { font-style: normal; }
+
+strong strong { font-weight: normal; }
+
+.keyseq { color: #333333; }
+
+kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
+
+.keyseq kbd:first-child { margin-left: 0; }
+
+.keyseq kbd:last-child { margin-right: 0; }
+
+.menuseq, .menuref { color: #000; }
+
+.menuseq b:not(.caret), .menuref { font-weight: inherit; }
+
+.menuseq { word-spacing: -0.02em; }
+.menuseq b.caret { font-size: 1.25em; line-height: 0.8; }
+.menuseq i.caret { font-weight: bold; text-align: center; width: 0.45em; }
+
+b.button:before, b.button:after { position: relative; top: -1px; font-weight: normal; }
+
+b.button:before { content: "["; padding: 0 3px 0 2px; }
+
+b.button:after { content: "]"; padding: 0 2px 0 3px; }
+
+#header, #content, #footnotes, #footer { width: 100%; margin-left: auto; margin-right: auto; margin-top: 0; margin-bottom: 0; max-width: 62.5em; *zoom: 1; position: relative; padding-left: 1.5em; padding-right: 1.5em; }
+#header:before, #header:after, #content:before, #content:after, #footnotes:before, #footnotes:after, #footer:before, #footer:after { content: " "; display: table; }
+#header:after, #content:after, #footnotes:after, #footer:after { clear: both; }
+
+#content { margin-top: 1.25em; }
+
+#content:before { content: none; }
+
+#header > h1:first-child { color: black; margin-top: 2.25rem; margin-bottom: 0; }
+#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #dddddd; }
+#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #dddddd; padding-bottom: 8px; }
+#header .details { border-bottom: 1px solid #dddddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #5e93b8; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
+#header .details span:first-child { margin-left: -0.125em; }
+#header .details span.email a { color: #333333; }
+#header .details br { display: none; }
+#header .details br + span:before { content: "\00a0\2013\00a0"; }
+#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333333; }
+#header .details br + span#revremark:before { content: "\00a0|\00a0"; }
+#header #revnumber { text-transform: capitalize; }
+#header #revnumber:after { content: "\00a0"; }
+
+#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #dddddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
+
+#toc { border-bottom: 0 solid #dddddd; padding-bottom: 0.5em; }
+#toc > ul { margin-left: 0.125em; }
+#toc ul.sectlevel0 > li > a { font-style: italic; }
+#toc ul.sectlevel0 ul.sectlevel1 { margin: 0.5em 0; }
+#toc ul { font-family: Noto, sans-serif; list-style-type: none; }
+#toc li { line-height: 1.3334; margin-top: 0.3334em; }
+#toc a { text-decoration: none; }
+#toc a:active { text-decoration: underline; }
+
+#toctitle { color: black; font-size: 1.2em; }
+
+@media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
+  body.toc2 { padding-left: 15em; padding-right: 0; }
+  #toc.toc2 { margin-top: 0 !important; background-color: white; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #dddddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
+  #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
+  #toc.toc2 > ul { font-size: 0.9em; margin-bottom: 0; }
+  #toc.toc2 ul ul { margin-left: 0; padding-left: 1em; }
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 15em; }
+  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #dddddd; left: auto; right: 0; } }
+@media only screen and (min-width: 1280px) { body.toc2 { padding-left: 20em; padding-right: 0; }
+  #toc.toc2 { width: 20em; }
+  #toc.toc2 #toctitle { font-size: 1.375em; }
+  #toc.toc2 > ul { font-size: 0.95em; }
+  #toc.toc2 ul ul { padding-left: 1.25em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 20em; } }
+#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+#content #toc > :first-child { margin-top: 0; }
+#content #toc > :last-child { margin-bottom: 0; }
+
+#footer { max-width: 100%; background-color: none; padding: 1.25em; }
+
+#footer-text { color: black; line-height: 1.44; }
+
+#content { margin-bottom: 0.625em; }
+
+.sect1 { padding-bottom: 0.625em; }
+
+@media only screen and (min-width: 768px) { #content { margin-bottom: 1.25em; }
+  .sect1 { padding-bottom: 1.25em; } }
+.sect1:last-child { padding-bottom: 0; }
+
+.sect1 + .sect1 { border-top: 0 solid #dddddd; }
+
+#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
+#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
+#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover { visibility: visible; }
+#content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link { color: black; text-decoration: none; }
+#content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover { color: black; }
+
+.audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock { margin-bottom: 1.25em; }
+
+.admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { text-rendering: optimizeLegibility; text-align: left; }
+
+table.tableblock > caption.title { white-space: nowrap; overflow: visible; max-width: 0; }
+
+.paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { color: black; }
+
+table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-size: inherit; }
+
+.admonitionblock > table { border-collapse: separate; border: 0; background: none; width: 100%; }
+.admonitionblock > table td.icon { text-align: center; width: 80px; }
+.admonitionblock > table td.icon img { max-width: initial; }
+.admonitionblock > table td.icon .title { font-weight: bold; font-family: Noto, sans-serif; text-transform: uppercase; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #dddddd; color: #5e93b8; }
+.admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
+
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.exampleblock > .content > :first-child { margin-top: 0; }
+.exampleblock > .content > :last-child { margin-bottom: 0; }
+
+.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.sidebarblock > :first-child { margin-top: 0; }
+.sidebarblock > :last-child { margin-bottom: 0; }
+.sidebarblock > .content > .title { color: black; margin-top: 0; }
+
+.exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
+
+.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eeeeee; }
+.sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
+
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
+.literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
+@media only screen and (min-width: 768px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 0.90625em; } }
+@media only screen and (min-width: 1280px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 1em; } }
+
+.literalblock.output pre { color: #eeeeee; background-color: #264357; }
+
+.listingblock pre.highlightjs { padding: 0; }
+.listingblock pre.highlightjs > code { padding: 1.25em 1.5625em 1.125em 1.5625em; -webkit-border-radius: 0; border-radius: 0; }
+
+.listingblock > .content { position: relative; }
+
+.listingblock code[data-lang]:before { display: none; content: attr(data-lang); position: absolute; font-size: 0.75em; top: 0.425rem; right: 0.5rem; line-height: 1; text-transform: uppercase; color: #999; }
+
+.listingblock:hover code[data-lang]:before { display: block; }
+
+.listingblock.terminal pre .command:before { content: attr(data-prompt); padding-right: 0.5em; color: #999; }
+
+.listingblock.terminal pre .command:not([data-prompt]):before { content: "$"; }
+
+table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
+
+table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; line-height: 1.6; }
+
+table.pyhltable td.code { padding-left: .75em; padding-right: 0; }
+
+pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #dddddd; }
+
+pre.pygments .lineno { display: inline-block; margin-right: .25em; }
+
+table.pyhltable .linenodiv { background: none !important; padding-right: 0 !important; }
+
+.quoteblock { margin: 0 1em 0.75em 1.5em; display: table; }
+.quoteblock > .title { margin-left: -1.5em; margin-bottom: 0.75em; }
+.quoteblock blockquote, .quoteblock blockquote p { color: #333333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
+.quoteblock blockquote { margin: 0; padding: 0; border: 0; }
+.quoteblock blockquote:before { content: "\201c"; float: left; font-size: 2.75em; font-weight: bold; line-height: 0.6em; margin-left: -0.6em; color: black; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
+.quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
+.quoteblock .attribution { margin-top: 0.5em; margin-right: 0.5ex; text-align: right; }
+.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #5e93b8; }
+.quoteblock .quoteblock blockquote { padding: 0 0 0 0.75em; }
+.quoteblock .quoteblock blockquote:before { display: none; }
+
+.verseblock { margin: 0 1em 0.75em 1em; }
+.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333333; font-weight: 300; text-rendering: optimizeLegibility; }
+.verseblock pre strong { font-weight: 400; }
+.verseblock .attribution { margin-top: 1.25rem; margin-left: 0.5ex; }
+
+.quoteblock .attribution, .verseblock .attribution { font-size: 0.8125em; line-height: 1.45; font-style: italic; }
+.quoteblock .attribution br, .verseblock .attribution br { display: none; }
+.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #5e93b8; }
+
+.quoteblock.abstract { margin: 0 0 0.75em 0; display: block; }
+.quoteblock.abstract blockquote, .quoteblock.abstract blockquote p { text-align: left; word-spacing: 0; }
+.quoteblock.abstract blockquote:before, .quoteblock.abstract blockquote p:first-of-type:before { display: none; }
+
+table.tableblock { max-width: 100%; border-collapse: separate; }
+table.tableblock td > .paragraph:last-child p > p:last-child, table.tableblock th > p:last-child, table.tableblock td > p:last-child { margin-bottom: 0; }
+
+table.tableblock, th.tableblock, td.tableblock { border: 0 solid #d8d8ce; }
+
+table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock { border-width: 0 1px 1px 0; }
+
+table.grid-all > tfoot > tr > .tableblock { border-width: 1px 1px 0 0; }
+
+table.grid-cols > * > tr > .tableblock { border-width: 0 1px 0 0; }
+
+table.grid-rows > thead > tr > .tableblock, table.grid-rows > tbody > tr > .tableblock { border-width: 0 0 1px 0; }
+
+table.grid-rows > tfoot > tr > .tableblock { border-width: 1px 0 0 0; }
+
+table.grid-all > * > tr > .tableblock:last-child, table.grid-cols > * > tr > .tableblock:last-child { border-right-width: 0; }
+
+table.grid-all > tbody > tr:last-child > .tableblock, table.grid-all > thead:last-child > tr > .tableblock, table.grid-rows > tbody > tr:last-child > .tableblock, table.grid-rows > thead:last-child > tr > .tableblock { border-bottom-width: 0; }
+
+table.frame-all { border-width: 1px; }
+
+table.frame-sides { border-width: 0 1px; }
+
+table.frame-topbot { border-width: 1px 0; }
+
+th.halign-left, td.halign-left { text-align: left; }
+
+th.halign-right, td.halign-right { text-align: right; }
+
+th.halign-center, td.halign-center { text-align: center; }
+
+th.valign-top, td.valign-top { vertical-align: top; }
+
+th.valign-bottom, td.valign-bottom { vertical-align: bottom; }
+
+th.valign-middle, td.valign-middle { vertical-align: middle; }
+
+table thead th, table tfoot th { font-weight: bold; }
+
+tbody tr th { display: table-cell; line-height: 1.4; background: -webkit-linear-gradient(top, #add386, #90b66a); }
+
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: white; font-weight: bold; }
+
+p.tableblock > code:only-child { background: none; padding: 0; }
+
+p.tableblock { font-size: 1em; }
+
+td > div.verse { white-space: pre; }
+
+ol { margin-left: 1.75em; }
+
+ul li ol { margin-left: 1.5em; }
+
+dl dd { margin-left: 1.125em; }
+
+dl dd:last-child, dl dd:last-child > :last-child { margin-bottom: 0; }
+
+ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .ulist, .ulist .olist, .olist .ulist { margin-bottom: 0.375em; }
+
+ul.checklist, ul.none, ol.none, ul.no-bullet, ol.no-bullet, ol.unnumbered, ul.unstyled, ol.unstyled { list-style-type: none; }
+
+ul.no-bullet, ol.no-bullet, ol.unnumbered { margin-left: 0.625em; }
+
+ul.unstyled, ol.unstyled { margin-left: 0; }
+
+ul.checklist { margin-left: 0.625em; }
+
+ul.checklist li > p:first-child > .fa-square-o:first-child, ul.checklist li > p:first-child > .fa-check-square-o:first-child { width: 1.25em; font-size: 0.8em; position: relative; bottom: 0.125em; }
+
+ul.checklist li > p:first-child > input[type="checkbox"]:first-child { margin-right: 0.25em; }
+
+ul.inline { display: -ms-flexbox; display: -webkit-box; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; list-style: none; margin: 0 0 0.375em -0.75em; }
+
+ul.inline > li { margin-left: 0.75em; }
+
+.unstyled dl dt { font-weight: normal; font-style: normal; }
+
+ol.arabic { list-style-type: decimal; }
+
+ol.decimal { list-style-type: decimal-leading-zero; }
+
+ol.loweralpha { list-style-type: lower-alpha; }
+
+ol.upperalpha { list-style-type: upper-alpha; }
+
+ol.lowerroman { list-style-type: lower-roman; }
+
+ol.upperroman { list-style-type: upper-roman; }
+
+ol.lowergreek { list-style-type: lower-greek; }
+
+.hdlist > table, .colist > table { border: 0; background: none; }
+.hdlist > table > tbody > tr, .colist > table > tbody > tr { background: none; }
+
+td.hdlist1, td.hdlist2 { vertical-align: top; padding: 0 0.625em; }
+
+td.hdlist1 { font-weight: bold; padding-bottom: 0.75em; }
+
+.literalblock + .colist, .listingblock + .colist { margin-top: -0.5em; }
+
+.colist > table tr > td:first-of-type { padding: 0.4em 0.75em 0 0.75em; line-height: 1; vertical-align: top; }
+.colist > table tr > td:first-of-type img { max-width: initial; }
+.colist > table tr > td:last-of-type { padding: 0.25em 0; }
+
+.thumb, .th { line-height: 0; display: inline-block; border: solid 4px white; -webkit-box-shadow: 0 0 0 1px #dddddd; box-shadow: 0 0 0 1px #dddddd; }
+
+.imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
+.imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
+.imageblock > .title { margin-bottom: 0; }
+.imageblock.thumb, .imageblock.th { border-width: 6px; }
+.imageblock.thumb > .title, .imageblock.th > .title { padding: 0 0.125em; }
+
+.image.left, .image.right { margin-top: 0.25em; margin-bottom: 0.25em; display: inline-block; line-height: 0; }
+.image.left { margin-right: 0.625em; }
+.image.right { margin-left: 0.625em; }
+
+a.image { text-decoration: none; display: inline-block; }
+a.image object { pointer-events: none; }
+
+sup.footnote, sup.footnoteref { font-size: 0.875em; position: static; vertical-align: super; }
+sup.footnote a, sup.footnoteref a { text-decoration: none; }
+sup.footnote a:active, sup.footnoteref a:active { text-decoration: underline; }
+
+#footnotes { padding-top: 0.75em; padding-bottom: 0.75em; margin-bottom: 0.625em; }
+#footnotes hr { width: 20%; min-width: 6.25em; margin: -0.25em 0 0.75em 0; border-width: 1px 0 0 0; }
+#footnotes .footnote { padding: 0 0.375em 0 0.225em; line-height: 1.3334; font-size: 0.875em; margin-left: 1.2em; margin-bottom: 0.2em; }
+#footnotes .footnote a:first-of-type { font-weight: bold; text-decoration: none; margin-left: -1.05em; }
+#footnotes .footnote:last-of-type { margin-bottom: 0; }
+#content #footnotes { margin-top: -0.625em; margin-bottom: 0; padding: 0.75em 0; }
+
+.gist .file-data > table { border: 0; background: #fff; width: 100%; margin-bottom: 0; }
+.gist .file-data > table td.line-data { width: 99%; }
 
 div.unbreakable { page-break-inside: avoid; }
 
+.big { font-size: larger; }
 
-/*
- * xhtml11 specific
- *
- * */
+.small { font-size: smaller; }
 
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
+.underline { text-decoration: underline; }
 
+.overline { text-decoration: overline; }
 
-/*
- * html5 specific
- *
- * */
+.line-through { text-decoration: line-through; }
 
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
+.aqua { color: #00bfbf; }
 
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
+.aqua-background { background-color: #00fafa; }
 
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
+.black { color: black; }
 
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
+.black-background { background-color: black; }
 
+.blue { color: #0000bf; }
 
-/*
- * manpage specific
- *
- * */
+.blue-background { background-color: #0000fa; }
 
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
+.fuchsia { color: #bf00bf; }
 
-@media print {
-  body.manpage div#toc { display: none; }
-}
+.fuchsia-background { background-color: #fa00fa; }
 
+.gray { color: #606060; }
 
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
+.gray-background { background-color: #7d7d7d; }
 
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
+.green { color: #006000; }
 
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
+.green-background { background-color: #007d00; }
 
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
+.lime { color: #00bf00; }
 
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
+.lime-background { background-color: #00fa00; }
+
+.maroon { color: #600000; }
+
+.maroon-background { background-color: #7d0000; }
+
+.navy { color: #000060; }
+
+.navy-background { background-color: #00007d; }
+
+.olive { color: #606000; }
+
+.olive-background { background-color: #7d7d00; }
+
+.purple { color: #600060; }
+
+.purple-background { background-color: #7d007d; }
+
+.red { color: #bf0000; }
+
+.red-background { background-color: #fa0000; }
+
+.silver { color: #909090; }
+
+.silver-background { background-color: #bcbcbc; }
+
+.teal { color: #006060; }
+
+.teal-background { background-color: #007d7d; }
+
+.white { color: #bfbfbf; }
+
+.white-background { background-color: #fafafa; }
+
+.yellow { color: #bfbf00; }
+
+.yellow-background { background-color: #fafa00; }
+
+span.icon > .fa { cursor: default; }
+a span.icon > .fa { cursor: inherit; }
+
+.admonitionblock td.icon [class^="fa icon-"] { font-size: 2.5em; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5); cursor: default; }
+.admonitionblock td.icon .icon-note:before { content: "\f05a"; color: #29475c; }
+.admonitionblock td.icon .icon-tip:before { content: "\f0eb"; text-shadow: 1px 1px 2px rgba(155, 155, 0, 0.8); color: #111; }
+.admonitionblock td.icon .icon-warning:before { content: "\f071"; color: #bf6900; }
+.admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #bf3400; }
+.admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
+
+.conum[data-value] { display: inline-block; color: #fff !important; background-color: black; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; font-size: 0.75em; width: 1.67em; height: 1.67em; line-height: 1.67em; font-family: "Open Sans", "DejaVu Sans", sans-serif; font-style: normal; font-weight: bold; }
+.conum[data-value] * { color: #fff !important; }
+.conum[data-value] + b { display: none; }
+.conum[data-value]:after { content: attr(data-value); }
+pre .conum[data-value] { position: relative; top: -0.125em; }
+
+b.conum * { color: inherit !important; }
+
+.conum:not([data-value]):empty { display: none; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #dddddd; }
+
+.sect1 { padding-bottom: 0; }
+
+#toctitle { color: #00406F; font-weight: normal; margin-top: 1.5em; }
+
+.sidebarblock { border-color: #aaa; }
+
+code { -webkit-border-radius: 4px; border-radius: 4px; }
+
+p.tableblock.header { color: #6d6e71; }
+
+.literalblock pre, .listingblock pre { background: #eeeeee; }
+
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
-</head>
-<body class="article">
+<link rel="stylesheet" href="../katex/katex.min.css">
+<script src="../katex/katex.min.js"></script>
+<script src="../katex/contrib/auto-render.min.js"></script>
+    <!-- Use KaTeX to render math once document is loaded, see
+         https://github.com/Khan/KaTeX/tree/master/contrib/auto-render -->
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        renderMathInElement(
+            document.body,
+            {
+                delimiters: [
+                    { left: "$$", right: "$$", display: true},
+                    { left: "\\[", right: "\\]", display: true},
+                    { left: "$", right: "$", display: false},
+                    { left: "\\(", right: "\\)", display: false}
+                ]
+            }
+        );
+    });
+</script></head>
+<body class="book">
 <div id="header">
 <h1>cl_intel_spirv_device_side_avc_motion_estimation</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div class="details">
+<span id="revnumber">version V2.2-11-30-g5ba09e4,</span>
+<span id="revdate">Thu, 24 Oct 2019 22:38:27 +0000</span>
+<br><span id="revremark">from git branch: public_master commit: 5ba09e43bb29a2292d6af0b70148a9f846e1806f</span>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p><span class="monospaced">cl_intel_spirv_device_side_avc_motion_estimation</span></p></div>
+<div class="paragraph">
+<p><code>cl_intel_spirv_device_side_avc_motion_estimation</code></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel (ben <em>dot</em> ashbaugh <em>at</em> intel <em>dot</em> com)</p></div>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel (ben 'dot' ashbaugh 'at' intel 'dot' com)</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel<br>
-Biju George, Intel</p></div>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel<br>
+Biju George, Intel</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Final Draft</p></div>
+<div class="paragraph">
+<p>Final Draft</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Built On: 2018-10-29<br>
-Revision: 1</p></div>
+<div class="paragraph">
+<p>Built On: 2019-10-23<br>
+Revision: 2</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the OpenCL SPIR-V Environment Specification Version 2.2, Revision v2.2-3.</p></div>
-<div class="paragraph"><p>This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the <span class="monospaced">cl_khr_il_program</span> extension, and support for the <span class="monospaced">cl_intel_device_side_avc_motion_estimation</span> extension.</p></div>
+<div class="paragraph">
+<p>This extension is written against the OpenCL SPIR-V Environment Specification Version 2.2, Revision v2.2-3.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the <code>cl_khr_il_program</code> extension, and support for the <code>cl_intel_device_side_avc_motion_estimation</code> extension.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension defines how modules using the SPIR-V extension <span class="monospaced">SPV_INTEL_device_side_avc_motion_estimation</span> may behave in an OpenCL environment.</p></div>
-<div class="paragraph"><p>This extension is a companion to the <span class="monospaced">cl_intel_device_side_avc_motion_estimation</span> OpenCL extension, and the functionality described in this extension and <span class="monospaced">SPV_INTEL_device_side_avc_motion_estimation</span> is sufficient to implement the built-in functions defined in the <span class="monospaced">cl_intel_device_side_avc_motion_estimation</span> extension.</p></div>
+<div class="paragraph">
+<p>This extension defines how modules using the SPIR-V extension <code>SPV_INTEL_device_side_avc_motion_estimation</code> may behave in an OpenCL environment.</p>
+</div>
+<div class="paragraph">
+<p>This extension is a companion to the <code>cl_intel_device_side_avc_motion_estimation</code> OpenCL extension, and the functionality described in this extension and <code>SPV_INTEL_device_side_avc_motion_estimation</code> is sufficient to implement the built-in functions defined in the <code>cl_intel_device_side_avc_motion_estimation</code> extension.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_functions">New API Functions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_enums">New API Enums</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_modifications_to_the_opencl_spir_v_environment_specification">Modifications to the OpenCL SPIR-V Environment Specification</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_add_a_new_section_7_1_x_span_class_monospaced_cl_intel_spirv_device_side_avc_motion_estimation_span">Add a new Section 7.1.X - <span class="monospaced">cl_intel_spirv_device_side_avc_motion_estimation</span></h3>
-<div class="paragraph"><p>If the OpenCL environment supports the extension <span class="monospaced">cl_intel_spirv_device_side_avc_motion_estimation</span>, then the environment must accept SPIR-V modules that declare use of the <span class="monospaced">SPV_INTEL_device_side_avc_motion_estimation</span> extension via <strong>OpExtension</strong>.</p></div>
-<div class="paragraph"><p>If the OpenCL environment supports the extension <span class="monospaced">cl_intel_spirv_device_side_avc_motion_estimation</span> and use of the <span class="monospaced">SPV_INTEL_device_side_avc_motion_estimation</span> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept modules that declare the following SPIR-V capabilities:</p></div>
-<div class="ulist"><ul>
+<h3 id="_add_a_new_section_7_1_x_cl_intel_spirv_device_side_avc_motion_estimation">Add a new Section 7.1.X - <code>cl_intel_spirv_device_side_avc_motion_estimation</code></h3>
+<div class="paragraph">
+<p>If the OpenCL environment supports the extension <code>cl_intel_spirv_device_side_avc_motion_estimation</code>, then the environment must accept SPIR-V modules that declare use of the <code>SPV_INTEL_device_side_avc_motion_estimation</code> extension via <strong>OpExtension</strong>.</p>
+</div>
+<div class="paragraph">
+<p>If the OpenCL environment supports the extension <code>cl_intel_spirv_device_side_avc_motion_estimation</code> and use of the <code>SPV_INTEL_device_side_avc_motion_estimation</code> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept modules that declare the following SPIR-V capabilities:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>SubgroupAvcMotionEstimationINTEL</strong>
-</p>
+<p><strong>SubgroupAvcMotionEstimationINTEL</strong></p>
 </li>
 <li>
-<p>
-<strong>SubgroupAvcMotionEstimationIntraINTEL</strong>
-</p>
+<p><strong>SubgroupAvcMotionEstimationIntraINTEL</strong></p>
 </li>
 <li>
-<p>
-<strong>SubgroupAvcMotionEstimationChromaINTEL</strong>
-</p>
+<p><strong>SubgroupAvcMotionEstimationChromaINTEL</strong></p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-10-29</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>Initial revision</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-10-29</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial revision</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-09-17</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Minor formatting fixes for asciidoctor.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
-<div id="footnotes"><hr></div>
 <div id="footer">
 <div id="footer-text">
-Last updated
- 2018-10-29 11:37:27 PDT
+Version V2.2-11-30-g5ba09e4<br>
+Last updated 2019-10-23 15:35:34 -0700
 </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 </body>
 </html>

--- a/extensions/intel/cl_intel_spirv_media_block_io.html
+++ b/extensions/intel/cl_intel_spirv_media_block_io.html
@@ -1,1080 +1,1101 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.9">
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.8">
 <title>cl_intel_spirv_media_block_io</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+<style>
+/*! normalize.css v2.1.2 | MIT License | git.io/normalize */
+/* ========================================================================== HTML5 display definitions ========================================================================== */
+/** Correct `block` display not defined in IE 8/9. */
+article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
 
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
+/** Correct `inline-block` display not defined in IE 8/9. */
+audio, canvas, video { display: inline-block; }
 
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
+/** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
+audio:not([controls]) { display: none; height: 0; }
 
-body {
-  margin: 1em 5% 1em 5%;
-}
+/** Address `[hidden]` styling not present in IE 8/9. Hide the `template` element in IE, Safari, and Firefox < 22. */
+[hidden], template { display: none; }
 
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
+script { display: none !important; }
 
-em {
-  font-style: italic;
-  color: navy;
-}
+/* ========================================================================== Base ========================================================================== */
+/** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
+html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
 
-strong {
-  font-weight: bold;
-  color: #083194;
-}
+/** Remove default margin. */
+body { margin: 0; }
 
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
+/* ========================================================================== Links ========================================================================== */
+/** Remove the gray background color from active links in IE 10. */
+a { background: transparent; }
 
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
+/** Address `outline` inconsistency between Chrome and other browsers. */
+a:focus { outline: thin dotted; }
 
-div.sectionbody {
-  margin-left: 0;
-}
+/** Improve readability when focused and also mouse hovered in all browsers. */
+a:active, a:hover { outline: 0; }
 
-hr {
-  border: 1px solid silver;
-}
+/* ========================================================================== Typography ========================================================================== */
+/** Address variable `h1` font-size and margin within `section` and `article` contexts in Firefox 4+, Safari 5, and Chrome. */
+h1 { font-size: 2em; margin: 0.67em 0; }
 
-p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9, Safari 5, and Chrome. */
+abbr[title] { border-bottom: 1px dotted; }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
+/** Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome. */
+b, strong { font-weight: bold; }
 
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
+/** Address styling not present in Safari 5 and Chrome. */
+dfn { font-style: italic; }
 
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
+/** Address differences between Firefox and other browsers. */
+hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
 
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9. */
+mark { background: #ff0; color: #000; }
 
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
+/** Correct font family set oddly in Safari 5 and Chrome. */
+code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 
-div.content { /* Block element content. */
-  padding: 0;
-}
+/** Improve readability of pre-formatted text in all browsers. */
+pre { white-space: pre-wrap; }
 
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
+/** Set consistent quote types. */
+q { quotes: "\201C" "\201D" "\2018" "\2019"; }
 
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
+/** Address inconsistent and variable font size in all browsers. */
+small { font-size: 80%; }
 
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
+/** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
 
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
+sup { top: -0.5em; }
 
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
+sub { bottom: -0.25em; }
 
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
+/* ========================================================================== Embedded content ========================================================================== */
+/** Remove border when inside `a` element in IE 8/9. */
+img { border: 0; }
 
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
+/** Correct overflow displayed oddly in IE 9. */
+svg:not(:root) { overflow: hidden; }
 
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
+/* ========================================================================== Figures ========================================================================== */
+/** Address margin not present in IE 8/9 and Safari 5. */
+figure { margin: 0; }
 
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
+/* ========================================================================== Forms ========================================================================== */
+/** Define consistent border, margin, and padding. */
+fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
 
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
+/** 1. Correct `color` not being inherited in IE 8/9. 2. Remove padding so people aren't caught out if they zero out fieldsets. */
+legend { border: 0; /* 1 */ padding: 0; /* 2 */ }
 
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
+/** 1. Correct font family not being inherited in all browsers. 2. Correct font size not being inherited in all browsers. 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome. */
+button, input, select, textarea { font-family: inherit; /* 1 */ font-size: 100%; /* 2 */ margin: 0; /* 3 */ }
 
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
+/** Address Firefox 4+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
+button, input { line-height: normal; }
 
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
+/** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+. Correct `select` style inheritance in Firefox 4+ and Opera. */
+button, select { text-transform: none; }
 
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
+/** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. */
+button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
 
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
+/** Re-set default cursor for disabled elements. */
+button[disabled], html input[disabled] { cursor: default; }
 
-.comment {
-  background: yellow;
-}
+/** 1. Address box sizing set to `content-box` in IE 8/9. 2. Remove excess padding in IE 8/9. */
+input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
 
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
+/** 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome. 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome (include `-moz` to future-proof). */
+input[type="search"] { -webkit-appearance: textfield; /* 1 */ -moz-box-sizing: content-box; -webkit-box-sizing: content-box; /* 2 */ box-sizing: content-box; }
 
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
+/** Remove inner padding and search cancel button in Safari 5 and Chrome on OS X. */
+input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
+/** Remove inner padding and border in Firefox 4+. */
+button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
+/** 1. Remove default vertical scrollbar in IE 8/9. 2. Improve readability and alignment in all browsers. */
+textarea { overflow: auto; /* 1 */ vertical-align: top; /* 2 */ }
 
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
+/* ========================================================================== Tables ========================================================================== */
+/** Remove most spacing between table cells. */
+table { border-collapse: collapse; border-spacing: 0; }
 
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
+meta.foundation-mq-small { font-family: "only screen and (min-width: 768px)"; width: 768px; }
 
-@media print {
-  #footer-badges { display: none; }
-}
+meta.foundation-mq-medium { font-family: "only screen and (min-width:1280px)"; width: 1280px; }
 
-#toc {
-  margin-bottom: 2.5em;
-}
+meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; width: 1440px; }
 
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
+*, *:before, *:after { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
 
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
+html, body { font-size: 100%; }
 
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
+body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
+a:hover { cursor: pointer; }
 
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
+img, object, embed { max-width: 100%; height: auto; }
 
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
+object, embed { height: 100%; }
+
+img { -ms-interpolation-mode: bicubic; }
+
+#map_canvas img, #map_canvas embed, #map_canvas object, .map_canvas img, .map_canvas embed, .map_canvas object { max-width: none !important; }
+
+.left { float: left !important; }
+
+.right { float: right !important; }
+
+.text-left { text-align: left !important; }
+
+.text-right { text-align: right !important; }
+
+.text-center { text-align: center !important; }
+
+.text-justify { text-align: justify !important; }
+
+.hide { display: none; }
+
+.antialiased { -webkit-font-smoothing: antialiased; }
+
+img { display: inline-block; vertical-align: middle; }
+
+textarea { height: auto; min-height: 50px; }
+
+select { width: 100%; }
+
+object, svg { display: inline-block; vertical-align: middle; }
+
+.center { margin-left: auto; margin-right: auto; }
+
+.spread { width: 100%; }
+
+p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { font-size: 1.21875em; line-height: 1.6; }
+
+.subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { line-height: 1.4; color: black; font-weight: 300; margin-top: 0.2em; margin-bottom: 0.5em; }
+
+/* Typography resets */
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
+
+/* Default Link Styles */
+a { color: #0068b0; text-decoration: none; line-height: inherit; }
+a:hover, a:focus { color: #333333; }
+a img { border: none; }
+
+/* Default paragraph styles */
+p { font-family: Noto, sans-serif; font-weight: normal; font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; text-rendering: optimizeLegibility; }
+p aside { font-size: 0.875em; line-height: 1.35; font-style: italic; }
+
+/* Default header styles */
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { font-family: Noto, sans-serif; font-weight: normal; font-style: normal; color: black; text-rendering: optimizeLegibility; margin-top: 0.5em; margin-bottom: 0.5em; line-height: 1.2125em; }
+h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small { font-size: 60%; color: #4d4d4d; line-height: 0; }
+
+h1 { font-size: 2.125em; }
+
+h2 { font-size: 1.6875em; }
+
+h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.375em; }
+
+h4 { font-size: 1.125em; }
+
+h5 { font-size: 1.125em; }
+
+h6 { font-size: 1em; }
+
+hr { border: solid #dddddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
+
+/* Helpful Typography Defaults */
+em, i { font-style: italic; line-height: inherit; }
+
+strong, b { font-weight: bold; line-height: inherit; }
+
+small { font-size: 60%; line-height: inherit; }
+
+code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #264357; }
+
+/* Lists */
+ul, ol, dl { font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; list-style-position: outside; font-family: Noto, sans-serif; }
+
+ul, ol { margin-left: 1.5em; }
+ul.no-bullet, ol.no-bullet { margin-left: 1.5em; }
+
+/* Unordered Lists */
+ul li ul, ul li ol { margin-left: 1.25em; margin-bottom: 0; font-size: 1em; /* Override nested font-size change */ }
+ul.square li ul, ul.circle li ul, ul.disc li ul { list-style: inherit; }
+ul.square { list-style-type: square; }
+ul.circle { list-style-type: circle; }
+ul.disc { list-style-type: disc; }
+ul.no-bullet { list-style: none; }
+
+/* Ordered Lists */
+ol li ul, ol li ol { margin-left: 1.25em; margin-bottom: 0; }
+
+/* Definition Lists */
+dl dt { margin-bottom: 0.3em; font-weight: bold; }
+dl dd { margin-bottom: 0.75em; }
+
+/* Abbreviations */
+abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #dddddd; cursor: help; }
+
+abbr { text-transform: none; }
+
+/* Blockquotes */
+blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #dddddd; }
+blockquote cite { display: block; font-size: 0.8125em; color: #5e93b8; }
+blockquote cite:before { content: "\2014 \0020"; }
+blockquote cite a, blockquote cite a:visited { color: #5e93b8; }
+
+blockquote, blockquote p { line-height: 1.6; color: #333333; }
+
+/* Microformats */
+.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #dddddd; padding: 0.625em 0.75em; }
+.vcard li { margin: 0; display: block; }
+.vcard .fn { font-weight: bold; font-size: 0.9375em; }
+
+.vevent .summary { font-weight: bold; }
+.vevent abbr { cursor: auto; text-decoration: none; font-weight: bold; border: none; padding: 0 0.0625em; }
+
+@media only screen and (min-width: 768px) { h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+  h1 { font-size: 2.75em; }
+  h2 { font-size: 2.3125em; }
+  h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
+  h4 { font-size: 1.4375em; } }
+/* Tables */
+table { background: white; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
+table thead, table tfoot { background: -webkit-linear-gradient(top, #add386, #90b66a); font-weight: bold; }
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: white; text-align: left; }
+table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #6d6e71; }
+table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #edf2f2; }
+table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.4; }
+
+body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+
+a:hover, a:focus { text-decoration: underline; }
+
+.clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
+.clearfix:after, .float-group:after { clear: both; }
+
+*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: white; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
+*:not(pre) > code.nobreak { word-wrap: normal; }
+*:not(pre) > code.nowrap { white-space: nowrap; }
+
+pre, pre > code { line-height: 1.6; color: #264357; font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; }
+
+em em { font-style: normal; }
+
+strong strong { font-weight: normal; }
+
+.keyseq { color: #333333; }
+
+kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
+
+.keyseq kbd:first-child { margin-left: 0; }
+
+.keyseq kbd:last-child { margin-right: 0; }
+
+.menuseq, .menuref { color: #000; }
+
+.menuseq b:not(.caret), .menuref { font-weight: inherit; }
+
+.menuseq { word-spacing: -0.02em; }
+.menuseq b.caret { font-size: 1.25em; line-height: 0.8; }
+.menuseq i.caret { font-weight: bold; text-align: center; width: 0.45em; }
+
+b.button:before, b.button:after { position: relative; top: -1px; font-weight: normal; }
+
+b.button:before { content: "["; padding: 0 3px 0 2px; }
+
+b.button:after { content: "]"; padding: 0 2px 0 3px; }
+
+#header, #content, #footnotes, #footer { width: 100%; margin-left: auto; margin-right: auto; margin-top: 0; margin-bottom: 0; max-width: 62.5em; *zoom: 1; position: relative; padding-left: 1.5em; padding-right: 1.5em; }
+#header:before, #header:after, #content:before, #content:after, #footnotes:before, #footnotes:after, #footer:before, #footer:after { content: " "; display: table; }
+#header:after, #content:after, #footnotes:after, #footer:after { clear: both; }
+
+#content { margin-top: 1.25em; }
+
+#content:before { content: none; }
+
+#header > h1:first-child { color: black; margin-top: 2.25rem; margin-bottom: 0; }
+#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #dddddd; }
+#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #dddddd; padding-bottom: 8px; }
+#header .details { border-bottom: 1px solid #dddddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #5e93b8; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
+#header .details span:first-child { margin-left: -0.125em; }
+#header .details span.email a { color: #333333; }
+#header .details br { display: none; }
+#header .details br + span:before { content: "\00a0\2013\00a0"; }
+#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333333; }
+#header .details br + span#revremark:before { content: "\00a0|\00a0"; }
+#header #revnumber { text-transform: capitalize; }
+#header #revnumber:after { content: "\00a0"; }
+
+#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #dddddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
+
+#toc { border-bottom: 0 solid #dddddd; padding-bottom: 0.5em; }
+#toc > ul { margin-left: 0.125em; }
+#toc ul.sectlevel0 > li > a { font-style: italic; }
+#toc ul.sectlevel0 ul.sectlevel1 { margin: 0.5em 0; }
+#toc ul { font-family: Noto, sans-serif; list-style-type: none; }
+#toc li { line-height: 1.3334; margin-top: 0.3334em; }
+#toc a { text-decoration: none; }
+#toc a:active { text-decoration: underline; }
+
+#toctitle { color: black; font-size: 1.2em; }
+
+@media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
+  body.toc2 { padding-left: 15em; padding-right: 0; }
+  #toc.toc2 { margin-top: 0 !important; background-color: white; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #dddddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
+  #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
+  #toc.toc2 > ul { font-size: 0.9em; margin-bottom: 0; }
+  #toc.toc2 ul ul { margin-left: 0; padding-left: 1em; }
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 15em; }
+  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #dddddd; left: auto; right: 0; } }
+@media only screen and (min-width: 1280px) { body.toc2 { padding-left: 20em; padding-right: 0; }
+  #toc.toc2 { width: 20em; }
+  #toc.toc2 #toctitle { font-size: 1.375em; }
+  #toc.toc2 > ul { font-size: 0.95em; }
+  #toc.toc2 ul ul { padding-left: 1.25em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 20em; } }
+#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+#content #toc > :first-child { margin-top: 0; }
+#content #toc > :last-child { margin-bottom: 0; }
+
+#footer { max-width: 100%; background-color: none; padding: 1.25em; }
+
+#footer-text { color: black; line-height: 1.44; }
+
+#content { margin-bottom: 0.625em; }
+
+.sect1 { padding-bottom: 0.625em; }
+
+@media only screen and (min-width: 768px) { #content { margin-bottom: 1.25em; }
+  .sect1 { padding-bottom: 1.25em; } }
+.sect1:last-child { padding-bottom: 0; }
+
+.sect1 + .sect1 { border-top: 0 solid #dddddd; }
+
+#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
+#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
+#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover { visibility: visible; }
+#content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link { color: black; text-decoration: none; }
+#content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover { color: black; }
+
+.audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock { margin-bottom: 1.25em; }
+
+.admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { text-rendering: optimizeLegibility; text-align: left; }
+
+table.tableblock > caption.title { white-space: nowrap; overflow: visible; max-width: 0; }
+
+.paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { color: black; }
+
+table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-size: inherit; }
+
+.admonitionblock > table { border-collapse: separate; border: 0; background: none; width: 100%; }
+.admonitionblock > table td.icon { text-align: center; width: 80px; }
+.admonitionblock > table td.icon img { max-width: initial; }
+.admonitionblock > table td.icon .title { font-weight: bold; font-family: Noto, sans-serif; text-transform: uppercase; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #dddddd; color: #5e93b8; }
+.admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
+
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.exampleblock > .content > :first-child { margin-top: 0; }
+.exampleblock > .content > :last-child { margin-bottom: 0; }
+
+.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.sidebarblock > :first-child { margin-top: 0; }
+.sidebarblock > :last-child { margin-bottom: 0; }
+.sidebarblock > .content > .title { color: black; margin-top: 0; }
+
+.exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
+
+.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eeeeee; }
+.sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
+
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
+.literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
+@media only screen and (min-width: 768px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 0.90625em; } }
+@media only screen and (min-width: 1280px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 1em; } }
+
+.literalblock.output pre { color: #eeeeee; background-color: #264357; }
+
+.listingblock pre.highlightjs { padding: 0; }
+.listingblock pre.highlightjs > code { padding: 1.25em 1.5625em 1.125em 1.5625em; -webkit-border-radius: 0; border-radius: 0; }
+
+.listingblock > .content { position: relative; }
+
+.listingblock code[data-lang]:before { display: none; content: attr(data-lang); position: absolute; font-size: 0.75em; top: 0.425rem; right: 0.5rem; line-height: 1; text-transform: uppercase; color: #999; }
+
+.listingblock:hover code[data-lang]:before { display: block; }
+
+.listingblock.terminal pre .command:before { content: attr(data-prompt); padding-right: 0.5em; color: #999; }
+
+.listingblock.terminal pre .command:not([data-prompt]):before { content: "$"; }
+
+table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
+
+table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; line-height: 1.6; }
+
+table.pyhltable td.code { padding-left: .75em; padding-right: 0; }
+
+pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #dddddd; }
+
+pre.pygments .lineno { display: inline-block; margin-right: .25em; }
+
+table.pyhltable .linenodiv { background: none !important; padding-right: 0 !important; }
+
+.quoteblock { margin: 0 1em 0.75em 1.5em; display: table; }
+.quoteblock > .title { margin-left: -1.5em; margin-bottom: 0.75em; }
+.quoteblock blockquote, .quoteblock blockquote p { color: #333333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
+.quoteblock blockquote { margin: 0; padding: 0; border: 0; }
+.quoteblock blockquote:before { content: "\201c"; float: left; font-size: 2.75em; font-weight: bold; line-height: 0.6em; margin-left: -0.6em; color: black; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
+.quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
+.quoteblock .attribution { margin-top: 0.5em; margin-right: 0.5ex; text-align: right; }
+.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #5e93b8; }
+.quoteblock .quoteblock blockquote { padding: 0 0 0 0.75em; }
+.quoteblock .quoteblock blockquote:before { display: none; }
+
+.verseblock { margin: 0 1em 0.75em 1em; }
+.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333333; font-weight: 300; text-rendering: optimizeLegibility; }
+.verseblock pre strong { font-weight: 400; }
+.verseblock .attribution { margin-top: 1.25rem; margin-left: 0.5ex; }
+
+.quoteblock .attribution, .verseblock .attribution { font-size: 0.8125em; line-height: 1.45; font-style: italic; }
+.quoteblock .attribution br, .verseblock .attribution br { display: none; }
+.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #5e93b8; }
+
+.quoteblock.abstract { margin: 0 0 0.75em 0; display: block; }
+.quoteblock.abstract blockquote, .quoteblock.abstract blockquote p { text-align: left; word-spacing: 0; }
+.quoteblock.abstract blockquote:before, .quoteblock.abstract blockquote p:first-of-type:before { display: none; }
+
+table.tableblock { max-width: 100%; border-collapse: separate; }
+table.tableblock td > .paragraph:last-child p > p:last-child, table.tableblock th > p:last-child, table.tableblock td > p:last-child { margin-bottom: 0; }
+
+table.tableblock, th.tableblock, td.tableblock { border: 0 solid #d8d8ce; }
+
+table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock { border-width: 0 1px 1px 0; }
+
+table.grid-all > tfoot > tr > .tableblock { border-width: 1px 1px 0 0; }
+
+table.grid-cols > * > tr > .tableblock { border-width: 0 1px 0 0; }
+
+table.grid-rows > thead > tr > .tableblock, table.grid-rows > tbody > tr > .tableblock { border-width: 0 0 1px 0; }
+
+table.grid-rows > tfoot > tr > .tableblock { border-width: 1px 0 0 0; }
+
+table.grid-all > * > tr > .tableblock:last-child, table.grid-cols > * > tr > .tableblock:last-child { border-right-width: 0; }
+
+table.grid-all > tbody > tr:last-child > .tableblock, table.grid-all > thead:last-child > tr > .tableblock, table.grid-rows > tbody > tr:last-child > .tableblock, table.grid-rows > thead:last-child > tr > .tableblock { border-bottom-width: 0; }
+
+table.frame-all { border-width: 1px; }
+
+table.frame-sides { border-width: 0 1px; }
+
+table.frame-topbot { border-width: 1px 0; }
+
+th.halign-left, td.halign-left { text-align: left; }
+
+th.halign-right, td.halign-right { text-align: right; }
+
+th.halign-center, td.halign-center { text-align: center; }
+
+th.valign-top, td.valign-top { vertical-align: top; }
+
+th.valign-bottom, td.valign-bottom { vertical-align: bottom; }
+
+th.valign-middle, td.valign-middle { vertical-align: middle; }
+
+table thead th, table tfoot th { font-weight: bold; }
+
+tbody tr th { display: table-cell; line-height: 1.4; background: -webkit-linear-gradient(top, #add386, #90b66a); }
+
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: white; font-weight: bold; }
+
+p.tableblock > code:only-child { background: none; padding: 0; }
+
+p.tableblock { font-size: 1em; }
+
+td > div.verse { white-space: pre; }
+
+ol { margin-left: 1.75em; }
+
+ul li ol { margin-left: 1.5em; }
+
+dl dd { margin-left: 1.125em; }
+
+dl dd:last-child, dl dd:last-child > :last-child { margin-bottom: 0; }
+
+ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .ulist, .ulist .olist, .olist .ulist { margin-bottom: 0.375em; }
+
+ul.checklist, ul.none, ol.none, ul.no-bullet, ol.no-bullet, ol.unnumbered, ul.unstyled, ol.unstyled { list-style-type: none; }
+
+ul.no-bullet, ol.no-bullet, ol.unnumbered { margin-left: 0.625em; }
+
+ul.unstyled, ol.unstyled { margin-left: 0; }
+
+ul.checklist { margin-left: 0.625em; }
+
+ul.checklist li > p:first-child > .fa-square-o:first-child, ul.checklist li > p:first-child > .fa-check-square-o:first-child { width: 1.25em; font-size: 0.8em; position: relative; bottom: 0.125em; }
+
+ul.checklist li > p:first-child > input[type="checkbox"]:first-child { margin-right: 0.25em; }
+
+ul.inline { display: -ms-flexbox; display: -webkit-box; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; list-style: none; margin: 0 0 0.375em -0.75em; }
+
+ul.inline > li { margin-left: 0.75em; }
+
+.unstyled dl dt { font-weight: normal; font-style: normal; }
+
+ol.arabic { list-style-type: decimal; }
+
+ol.decimal { list-style-type: decimal-leading-zero; }
+
+ol.loweralpha { list-style-type: lower-alpha; }
+
+ol.upperalpha { list-style-type: upper-alpha; }
+
+ol.lowerroman { list-style-type: lower-roman; }
+
+ol.upperroman { list-style-type: upper-roman; }
+
+ol.lowergreek { list-style-type: lower-greek; }
+
+.hdlist > table, .colist > table { border: 0; background: none; }
+.hdlist > table > tbody > tr, .colist > table > tbody > tr { background: none; }
+
+td.hdlist1, td.hdlist2 { vertical-align: top; padding: 0 0.625em; }
+
+td.hdlist1 { font-weight: bold; padding-bottom: 0.75em; }
+
+.literalblock + .colist, .listingblock + .colist { margin-top: -0.5em; }
+
+.colist > table tr > td:first-of-type { padding: 0.4em 0.75em 0 0.75em; line-height: 1; vertical-align: top; }
+.colist > table tr > td:first-of-type img { max-width: initial; }
+.colist > table tr > td:last-of-type { padding: 0.25em 0; }
+
+.thumb, .th { line-height: 0; display: inline-block; border: solid 4px white; -webkit-box-shadow: 0 0 0 1px #dddddd; box-shadow: 0 0 0 1px #dddddd; }
+
+.imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
+.imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
+.imageblock > .title { margin-bottom: 0; }
+.imageblock.thumb, .imageblock.th { border-width: 6px; }
+.imageblock.thumb > .title, .imageblock.th > .title { padding: 0 0.125em; }
+
+.image.left, .image.right { margin-top: 0.25em; margin-bottom: 0.25em; display: inline-block; line-height: 0; }
+.image.left { margin-right: 0.625em; }
+.image.right { margin-left: 0.625em; }
+
+a.image { text-decoration: none; display: inline-block; }
+a.image object { pointer-events: none; }
+
+sup.footnote, sup.footnoteref { font-size: 0.875em; position: static; vertical-align: super; }
+sup.footnote a, sup.footnoteref a { text-decoration: none; }
+sup.footnote a:active, sup.footnoteref a:active { text-decoration: underline; }
+
+#footnotes { padding-top: 0.75em; padding-bottom: 0.75em; margin-bottom: 0.625em; }
+#footnotes hr { width: 20%; min-width: 6.25em; margin: -0.25em 0 0.75em 0; border-width: 1px 0 0 0; }
+#footnotes .footnote { padding: 0 0.375em 0 0.225em; line-height: 1.3334; font-size: 0.875em; margin-left: 1.2em; margin-bottom: 0.2em; }
+#footnotes .footnote a:first-of-type { font-weight: bold; text-decoration: none; margin-left: -1.05em; }
+#footnotes .footnote:last-of-type { margin-bottom: 0; }
+#content #footnotes { margin-top: -0.625em; margin-bottom: 0; padding: 0.75em 0; }
+
+.gist .file-data > table { border: 0; background: #fff; width: 100%; margin-bottom: 0; }
+.gist .file-data > table td.line-data { width: 99%; }
 
 div.unbreakable { page-break-inside: avoid; }
 
+.big { font-size: larger; }
 
-/*
- * xhtml11 specific
- *
- * */
+.small { font-size: smaller; }
 
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
+.underline { text-decoration: underline; }
 
+.overline { text-decoration: overline; }
 
-/*
- * html5 specific
- *
- * */
+.line-through { text-decoration: line-through; }
 
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
+.aqua { color: #00bfbf; }
 
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
+.aqua-background { background-color: #00fafa; }
 
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
+.black { color: black; }
 
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
+.black-background { background-color: black; }
 
+.blue { color: #0000bf; }
 
-/*
- * manpage specific
- *
- * */
+.blue-background { background-color: #0000fa; }
 
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
+.fuchsia { color: #bf00bf; }
 
-@media print {
-  body.manpage div#toc { display: none; }
-}
+.fuchsia-background { background-color: #fa00fa; }
 
+.gray { color: #606060; }
 
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
+.gray-background { background-color: #7d7d7d; }
 
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
+.green { color: #006000; }
 
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
+.green-background { background-color: #007d00; }
 
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
+.lime { color: #00bf00; }
 
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
+.lime-background { background-color: #00fa00; }
+
+.maroon { color: #600000; }
+
+.maroon-background { background-color: #7d0000; }
+
+.navy { color: #000060; }
+
+.navy-background { background-color: #00007d; }
+
+.olive { color: #606000; }
+
+.olive-background { background-color: #7d7d00; }
+
+.purple { color: #600060; }
+
+.purple-background { background-color: #7d007d; }
+
+.red { color: #bf0000; }
+
+.red-background { background-color: #fa0000; }
+
+.silver { color: #909090; }
+
+.silver-background { background-color: #bcbcbc; }
+
+.teal { color: #006060; }
+
+.teal-background { background-color: #007d7d; }
+
+.white { color: #bfbfbf; }
+
+.white-background { background-color: #fafafa; }
+
+.yellow { color: #bfbf00; }
+
+.yellow-background { background-color: #fafa00; }
+
+span.icon > .fa { cursor: default; }
+a span.icon > .fa { cursor: inherit; }
+
+.admonitionblock td.icon [class^="fa icon-"] { font-size: 2.5em; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5); cursor: default; }
+.admonitionblock td.icon .icon-note:before { content: "\f05a"; color: #29475c; }
+.admonitionblock td.icon .icon-tip:before { content: "\f0eb"; text-shadow: 1px 1px 2px rgba(155, 155, 0, 0.8); color: #111; }
+.admonitionblock td.icon .icon-warning:before { content: "\f071"; color: #bf6900; }
+.admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #bf3400; }
+.admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
+
+.conum[data-value] { display: inline-block; color: #fff !important; background-color: black; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; font-size: 0.75em; width: 1.67em; height: 1.67em; line-height: 1.67em; font-family: "Open Sans", "DejaVu Sans", sans-serif; font-style: normal; font-weight: bold; }
+.conum[data-value] * { color: #fff !important; }
+.conum[data-value] + b { display: none; }
+.conum[data-value]:after { content: attr(data-value); }
+pre .conum[data-value] { position: relative; top: -0.125em; }
+
+b.conum * { color: inherit !important; }
+
+.conum:not([data-value]):empty { display: none; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #dddddd; }
+
+.sect1 { padding-bottom: 0; }
+
+#toctitle { color: #00406F; font-weight: normal; margin-top: 1.5em; }
+
+.sidebarblock { border-color: #aaa; }
+
+code { -webkit-border-radius: 4px; border-radius: 4px; }
+
+p.tableblock.header { color: #6d6e71; }
+
+.literalblock pre, .listingblock pre { background: #eeeeee; }
+
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
-</head>
-<body class="article">
+<link rel="stylesheet" href="../katex/katex.min.css">
+<script src="../katex/katex.min.js"></script>
+<script src="../katex/contrib/auto-render.min.js"></script>
+    <!-- Use KaTeX to render math once document is loaded, see
+         https://github.com/Khan/KaTeX/tree/master/contrib/auto-render -->
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        renderMathInElement(
+            document.body,
+            {
+                delimiters: [
+                    { left: "$$", right: "$$", display: true},
+                    { left: "\\[", right: "\\]", display: true},
+                    { left: "$", right: "$", display: false},
+                    { left: "\\(", right: "\\)", display: false}
+                ]
+            }
+        );
+    });
+</script></head>
+<body class="book">
 <div id="header">
 <h1>cl_intel_spirv_media_block_io</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div class="details">
+<span id="revnumber">version V2.2-11-30-g5ba09e4,</span>
+<span id="revdate">Thu, 24 Oct 2019 22:38:29 +0000</span>
+<br><span id="revremark">from git branch: public_master commit: 5ba09e43bb29a2292d6af0b70148a9f846e1806f</span>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p><span class="monospaced">cl_intel_spirv_media_block_io</span></p></div>
+<div class="paragraph">
+<p><code>cl_intel_spirv_media_block_io</code></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel (ben <em>dot</em> ashbaugh <em>at</em> intel <em>dot</em> com)</p></div>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel (ben 'dot' ashbaugh 'at' intel 'dot' com)</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel<br>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel<br>
 Biju George, Intel<br>
-Pawel Jurek, Intel</p></div>
+Pawel Jurek, Intel</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Final Draft</p></div>
+<div class="paragraph">
+<p>Final Draft</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Built On: 2018-10-29<br>
-Revision: 1</p></div>
+<div class="paragraph">
+<p>Built On: 2019-10-23<br>
+Revision: 2</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the OpenCL SPIR-V Environment Specification Version 2.2, Revision v2.2-3.</p></div>
-<div class="paragraph"><p>This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the <span class="monospaced">cl_khr_il_program</span> extension, and support for the <span class="monospaced">cl_intel_media_block_io</span> extension.</p></div>
-<div class="paragraph"><p>This extension interacts with the <span class="monospaced">cl_intel_packed_yuv</span> extension.</p></div>
-<div class="paragraph"><p>This extension interacts with the <span class="monospaced">cl_intel_planar_yuv</span> extension.</p></div>
+<div class="paragraph">
+<p>This extension is written against the OpenCL SPIR-V Environment Specification Version 2.2, Revision v2.2-3.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the <code>cl_khr_il_program</code> extension, and support for the <code>cl_intel_media_block_io</code> extension.</p>
+</div>
+<div class="paragraph">
+<p>This extension interacts with the <code>cl_intel_packed_yuv</code> extension.</p>
+</div>
+<div class="paragraph">
+<p>This extension interacts with the <code>cl_intel_planar_yuv</code> extension.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension defines how modules using the SPIR-V extension <span class="monospaced">SPV_INTEL_media_block_io</span> may behave in an OpenCL environment.</p></div>
-<div class="paragraph"><p>This extension is a companion to the <span class="monospaced">cl_intel_media_block_io</span> OpenCL extension, and the functionality described in this extension and <span class="monospaced">SPV_INTEL_media_block_io</span> is sufficient to implement the built-in functions defined in the <span class="monospaced">cl_intel_media_block_io</span> extension.</p></div>
+<div class="paragraph">
+<p>This extension defines how modules using the SPIR-V extension <code>SPV_INTEL_media_block_io</code> may behave in an OpenCL environment.</p>
+</div>
+<div class="paragraph">
+<p>This extension is a companion to the <code>cl_intel_media_block_io</code> OpenCL extension, and the functionality described in this extension and <code>SPV_INTEL_media_block_io</code> is sufficient to implement the built-in functions defined in the <code>cl_intel_media_block_io</code> extension.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_functions">New API Functions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_enums">New API Enums</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_modifications_to_the_opencl_spir_v_environment_specification">Modifications to the OpenCL SPIR-V Environment Specification</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_add_a_new_section_7_1_x_span_class_monospaced_cl_intel_spirv_media_block_io_span">Add a new Section 7.1.X - <span class="monospaced">cl_intel_spirv_media_block_io</span></h3>
-<div class="paragraph"><p>If the OpenCL environment supports the extension <span class="monospaced">cl_intel_spirv_media_block_io</span>, then the environment must accept SPIR-V modules that declare use of the <span class="monospaced">SPV_INTEL_media_block_io</span> extension via <strong>OpExtension</strong>.</p></div>
-<div class="paragraph"><p>If the OpenCL environment supports the extension <span class="monospaced">cl_intel_spirv_media_block_io</span> and use of the <span class="monospaced">SPV_INTEL_media_block_io</span> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept modules that declare the following SPIR-V capabilities:</p></div>
-<div class="ulist"><ul>
+<h3 id="_add_a_new_section_7_1_x_cl_intel_spirv_media_block_io">Add a new Section 7.1.X - <code>cl_intel_spirv_media_block_io</code></h3>
+<div class="paragraph">
+<p>If the OpenCL environment supports the extension <code>cl_intel_spirv_media_block_io</code>, then the environment must accept SPIR-V modules that declare use of the <code>SPV_INTEL_media_block_io</code> extension via <strong>OpExtension</strong>.</p>
+</div>
+<div class="paragraph">
+<p>If the OpenCL environment supports the extension <code>cl_intel_spirv_media_block_io</code> and use of the <code>SPV_INTEL_media_block_io</code> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept modules that declare the following SPIR-V capabilities:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>SubgroupImageMediaBlockIOINTEL</strong>
-</p>
+<p><strong>SubgroupImageMediaBlockIOINTEL</strong></p>
 </li>
-</ul></div>
-<div class="paragraph"><p>Additionally, the environment must accept the following types for <em>Result Type</em> for <strong>OpSubgroupImageMediaBlockReadINTEL</strong>, and for the type of <em>Data</em> for <strong>OpSubgroupImageMediaBlockWriteINTEL</strong>:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>Additionally, the environment must accept the following types for 'Result Type' for <strong>OpSubgroupImageMediaBlockReadINTEL</strong>, and for the type of 'Data' for <strong>OpSubgroupImageMediaBlockWriteINTEL</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Scalars and <strong>OpTypeVectors</strong> with 2, 4, 8, or 16 <em>Component Count</em> components of the following <em>Component Type</em> types:
-</p>
-<div class="ulist"><ul>
+<p>Scalars and <strong>OpTypeVectors</strong> with 2, 4, 8, or 16 <em>Component Count</em> components of the following <em>Component Type</em> types:</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>OpTypeInt</strong> with a <em>Width</em> of 8 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">char</span> and <span class="monospaced">uchar</span>)
-</p>
-</li>
-<li>
-<p>
-<strong>OpTypeInt</strong> with a <em>Width</em> of 16 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">short</span> and <span class="monospaced">ushort</span>)
-</p>
-</li>
-<li>
-<p>
-<strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">int</span> and <span class="monospaced">uint</span>)
-</p>
-</li>
-</ul></div>
-</li>
-</ul></div>
-<div class="paragraph"><p>For <em>Image</em>:</p></div>
-<div class="ulist"><ul>
-<li>
-<p>
-<em>Dim</em> must be <strong>2D</strong>
-</p>
+<p><strong>OpTypeInt</strong> with a <em>Width</em> of 8 bits and <em>Signedness</em> of 0 (equivalent to <code>char</code> and <code>uchar</code>)</p>
 </li>
 <li>
-<p>
-<em>Depth</em> must be 0 (not a depth image)
-</p>
+<p><strong>OpTypeInt</strong> with a <em>Width</em> of 16 bits and <em>Signedness</em> of 0 (equivalent to <code>short</code> and <code>ushort</code>)</p>
 </li>
 <li>
-<p>
-<em>Arrayed</em> must be 0 (non-arrayed content)
-</p>
+<p><strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <code>int</code> and <code>uint</code>)</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>For <em>Image</em>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><em>Dim</em> must be <strong>2D</strong></p>
 </li>
 <li>
-<p>
-<em>MS</em> must be 0 (single-sampled content)
-</p>
+<p><em>Depth</em> must be 0 (not a depth image)</p>
 </li>
 <li>
-<p>
-(equivalent to <span class="monospaced">image2d_t</span>)
-</p>
+<p><em>Arrayed</em> must be 0 (non-arrayed content)</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>For <em>Coordinate</em>, the following types are supported:</p></div>
-<div class="ulist"><ul>
 <li>
-<p>
-<strong>OpTypeVectors</strong> with 2 <em>Component Count</em> components of <em>Component Type</em> <strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">int2</span>)
-</p>
+<p><em>MS</em> must be 0 (single-sampled content)</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>For <em>Width</em> and <em>Height</em>, the following type is supported:</p></div>
-<div class="ulist"><ul>
 <li>
-<p>
-Scalars of <strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and a <em>Signedness</em> of 0 (equivalent to <span class="monospaced">int</span>)
-</p>
+<p>(equivalent to <code>image2d_t</code>)</p>
 </li>
-</ul></div>
+</ul>
+</div>
+<div class="paragraph">
+<p>For 'Coordinate', the following types are supported:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>OpTypeVectors</strong> with 2 <em>Component Count</em> components of <em>Component Type</em> <strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <code>int2</code>)</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>For 'Width' and 'Height', the following type is supported:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Scalars of <strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and a <em>Signedness</em> of 0 (equivalent to <code>int</code>)</p>
+</li>
+</ul>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_add_a_new_section_7_1_x_1_notes_and_restrictions">Add a new Section 7.1.X.1 - Notes and Restrictions</h3>
-<div class="paragraph"><p>Both <strong>OpSubgroupImageMediaBlockReadINTEL</strong> and <strong>OpSubgroupImageMediaBlockWriteINTEL</strong> must be encountered by all work items in the subgroup executing the kernel, otherwise the behavior is undefined (i.e. they can only be used in convergent control flow where all the work items in the subgroup are enabled).</p></div>
-<div class="paragraph"><p>The block <em>Width</em> determines the maximum <em>Height</em> for <strong>OpSubgroupImageMediaBlockReadINTEL</strong> and <strong>OpSubgroupImageMediaBlockWriteINTEL</strong>, and is summarized in the following table:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<div class="paragraph">
+<p>Both <strong>OpSubgroupImageMediaBlockReadINTEL</strong> and <strong>OpSubgroupImageMediaBlockWriteINTEL</strong> must be encountered by all work items in the subgroup executing the kernel, otherwise the behavior is undefined (i.e. they can only be used in convergent control flow where all the work items in the subgroup are enabled).</p>
+</div>
+<div class="paragraph">
+<p>The block 'Width' determines the maximum 'Height' for <strong>OpSubgroupImageMediaBlockReadINTEL</strong> and <strong>OpSubgroupImageMediaBlockWriteINTEL</strong>, and is summarized in the following table:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" ><strong>Width (bytes)</strong></th>
-<th class="tableblock halign-left valign-top" ><strong>Maximum Height (rows)</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Width (bytes)</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Maximum Height (rows)</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">64</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">64</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">32</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">32</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">12, 16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">12, 16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">16</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">20, 24, 28, 32</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">20, 24, 28, 32</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">8</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>Both the first component of <em>Component</em>, which represents the byte offset into the <em>Image</em>, and the block <em>Width</em> must be four byte aligned.</p></div>
-<div class="paragraph"><p>Both the block <em>Width</em> and <em>Height</em> must be compile time constants.</p></div>
-<div class="paragraph"><p>The <em>Image</em> operand must only be used by other <strong>SubgroupImageMediaBlockIOINTEL</strong> instructions or image query instructions.  They may not be used by any other instructions that read texels from or write texels to the <em>Image</em>.</p></div>
-<div class="paragraph"><p>Behavior is undefined if <em>Image</em> is a planar YUV image, however <em>Image</em> may represent an individual plane of a planar YUV image.</p></div>
-<div class="paragraph"><p>The <em>Image</em> operand must be created such that the image byte width, defined as the image width multiplied by the <em>Image Format</em> size, is a multiple of four bytes.</p></div>
-<div class="paragraph"><p>For <strong>OpSubgroupImageMediaBlockReadINTEL</strong>, if the <em>Image Format</em> size is smaller than the block read <em>Component Type</em>, then an out-of-bounds read will return data replicated from the nearest edge element, otherwise out-of-bound read behavior is undefined.  For example:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>Both the first component of 'Component', which represents the byte offset into the 'Image', and the block 'Width' must be four byte aligned.</p>
+</div>
+<div class="paragraph">
+<p>Both the block 'Width' and 'Height' must be compile time constants.</p>
+</div>
+<div class="paragraph">
+<p>The 'Image' operand must only be used by other <strong>SubgroupImageMediaBlockIOINTEL</strong> instructions or image query instructions.  They may not be used by any other instructions that read texels from or write texels to the 'Image'.</p>
+</div>
+<div class="paragraph">
+<p>Behavior is undefined if 'Image' is a planar YUV image, however 'Image' may represent an individual plane of a planar YUV image.</p>
+</div>
+<div class="paragraph">
+<p>The 'Image' operand must be created such that the image byte width, defined as the image width multiplied by the 'Image Format' size, is a multiple of four bytes.</p>
+</div>
+<div class="paragraph">
+<p>For <strong>OpSubgroupImageMediaBlockReadINTEL</strong>, if the 'Image Format' size is smaller than the block read 'Component Type', then an out-of-bounds read will return data replicated from the nearest edge element, otherwise out-of-bound read behavior is undefined.  For example:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-For an image with <em>Image Format</em> size equal to a single byte (for example <strong>R8</strong>), and a 32-bit boundary value <span class="monospaced">B0B1B2B3</span>, replicating off the left edge may result in the 32-bit value <span class="monospaced">B0B0B0B0</span>, and replicating off the right edge may result in the 32-bit value <span class="monospaced">B3B3B3B3</span>.
-</p>
+<p>For an image with 'Image Format' size equal to a single byte (for example <strong>R8</strong>), and a 32-bit boundary value <code>B0B1B2B3</code>, replicating off the left edge may result in the 32-bit value <code>B0B0B0B0</code>, and replicating off the right edge may result in the 32-bit value <code>B3B3B3B3</code>.</p>
 </li>
 <li>
-<p>
-For an image with an <em>Image Format</em> size equal to two bytes (for example <strong>R16</strong>), replicating off the left edge may result in the 32-bit value <span class="monospaced">B0B1B0B1</span>, and replicating off the right edge may result in the 32-bit value <span class="monospaced">B2B3B2B3</span>.
-</p>
+<p>For an image with an 'Image Format' size equal to two bytes (for example <strong>R16</strong>), replicating off the left edge may result in the 32-bit value <code>B0B1B0B1</code>, and replicating off the right edge may result in the 32-bit value <code>B2B3B2B3</code>.</p>
 </li>
 <li>
-<p>
-For an image with an <em>Image Format</em> size equal to four bytes (for example <strong>Rgba8</strong>), the entire boundary value is replicated, for both the left or right edges.
-</p>
+<p>For an image with an 'Image Format' size equal to four bytes (for example <strong>Rgba8</strong>), the entire boundary value is replicated, for both the left or right edges.</p>
 </li>
 <li>
-<p>
-Because the maximum <em>Component Type</em> is a four byte component type, there is no defined out-of-bounds behavior for images with an <em>Image Format</em> size greater than four bytes.
-</p>
+<p>Because the maximum 'Component Type' is a four byte component type, there is no defined out-of-bounds behavior for images with an 'Image Format' size greater than four bytes.</p>
 </li>
 <li>
-<p>
-As a special case, an image with a packed YUV <em>Image Format</em> (and hence an <em>Image Format</em> size equal to two bytes) behaves as follows:
-</p>
-<div class="ulist"><ul>
+<p>As a special case, an image with a packed YUV 'Image Format' (and hence an 'Image Format' size equal to two bytes) behaves as follows:</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Replicating off of the left edge replicates the UV components and the first Y component, so, for example, replicating the 32-bit boundary value <span class="monospaced">Y0U0Y1V0</span> will result in the 32-bit value <span class="monospaced">Y0U0Y0V0</span>.
-</p>
+<p>Replicating off of the left edge replicates the UV components and the first Y component, so, for example, replicating the 32-bit boundary value <code>Y0U0Y1V0</code> will result in the 32-bit value <code>Y0U0Y0V0</code>.</p>
 </li>
 <li>
-<p>
-Replicating off the right edge replicates the UV components and the second Y component, so, for example, replicating the 32-bit boundary value <span class="monospaced">Y0U0Y1V0</span> will result in the 32-bit value <span class="monospaced">Y1U0Y1V0</span>.
-</p>
+<p>Replicating off the right edge replicates the UV components and the second Y component, so, for example, replicating the 32-bit boundary value <code>Y0U0Y1V0</code> will result in the 32-bit value <code>Y1U0Y1V0</code>.</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </li>
-</ul></div>
-<div class="paragraph"><p>For <strong>OpSubgroupImageMediaBlockWriteINTEL</strong>, if the <em>Image Format</em> size is smaller than the block write <em>Component Type</em>, then out-of-bounds writes will be dropped, otherwise out-of-bounds write behavior is undefined.</p></div>
-<div class="paragraph"><p>When reading or writing a 2D <em>Image</em> created from a buffer:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>For <strong>OpSubgroupImageMediaBlockWriteINTEL</strong>, if the 'Image Format' size is smaller than the block write 'Component Type', then out-of-bounds writes will be dropped, otherwise out-of-bounds write behavior is undefined.</p>
+</div>
+<div class="paragraph">
+<p>When reading or writing a 2D 'Image' created from a buffer:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-The <em>image row pitch</em> is required to be a multiple of 64-bytes, in addition to the <span class="monospaced">CL_DEVICE_IMAGE_PITCH_ALIGNMENT</span> requirements.
-</p>
-</li>
-<li>
-<p>
-If the buffer is a <span class="monospaced">cl_mem</span> that was created with <span class="monospaced">CL_MEM_USE_HOST_PTR</span>, then the <em>host_ptr</em> must be 256-bit (32-byte) aligned.
-</p>
+<p>The 'image row pitch' is required to be a multiple of 64-bytes, in addition to the <code>CL_DEVICE_IMAGE_PITCH_ALIGNMENT</code> requirements.</p>
 </li>
 <li>
-<p>
-If the buffer is a <span class="monospaced">cl_mem</span> that is a sub-buffer, then the <em>origin</em> must be a multiple of 32-bytes.  Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with <span class="monospaced">CL_MEM_USE_HOST_PTR</span>, then the <em>host_ptr</em> for the <em>buffer</em> must be 256-bit (32-byte) aligned.
-</p>
+<p>If the buffer is a <code>cl_mem</code> that was created with <code>CL_MEM_USE_HOST_PTR</code>, then the <em>host_ptr</em> must be 256-bit (32-byte) aligned.</p>
 </li>
 <li>
-<p>
-The maximum <em>Height</em> is further restricted to 16 rows or less.
-</p>
+<p>If the buffer is a <code>cl_mem</code> that is a sub-buffer, then the <em>origin</em> must be a multiple of 32-bytes.  Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with <code>CL_MEM_USE_HOST_PTR</code>, then the <em>host_ptr</em> for the <em>buffer</em> must be 256-bit (32-byte) aligned.</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>Behavior is undefined if the size of the 2D source region (defined by the type of <em>Data</em> and <strong>SubgroupMaxSize</strong>) is smaller than the size of the 2D region to write (defined by <em>Width</em>, <em>Height</em>, and block write <em>Component Type</em>).</p></div>
+<li>
+<p>The maximum 'Height' is further restricted to 16 rows or less.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Behavior is undefined if the size of the 2D source region (defined by the type of 'Data' and <strong>SubgroupMaxSize</strong>) is smaller than the size of the 2D region to write (defined by 'Width', 'Height', and block write 'Component Type').</p>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-10-29</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>Initial revision</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-10-29</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial revision</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-09-17</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Minor formatting fixes for asciidoctor.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
-<div id="footnotes"><hr></div>
 <div id="footer">
 <div id="footer-text">
-Last updated
- 2018-10-29 11:47:08 PDT
+Version V2.2-11-30-g5ba09e4<br>
+Last updated 2019-10-23 15:35:34 -0700
 </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 </body>
 </html>

--- a/extensions/intel/cl_intel_spirv_subgroups.html
+++ b/extensions/intel/cl_intel_spirv_subgroups.html
@@ -1,1247 +1,1255 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.9">
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.8">
 <title>cl_intel_spirv_subgroups</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+<style>
+/*! normalize.css v2.1.2 | MIT License | git.io/normalize */
+/* ========================================================================== HTML5 display definitions ========================================================================== */
+/** Correct `block` display not defined in IE 8/9. */
+article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
 
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
+/** Correct `inline-block` display not defined in IE 8/9. */
+audio, canvas, video { display: inline-block; }
 
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
+/** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
+audio:not([controls]) { display: none; height: 0; }
 
-body {
-  margin: 1em 5% 1em 5%;
-}
+/** Address `[hidden]` styling not present in IE 8/9. Hide the `template` element in IE, Safari, and Firefox < 22. */
+[hidden], template { display: none; }
 
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
+script { display: none !important; }
 
-em {
-  font-style: italic;
-  color: navy;
-}
+/* ========================================================================== Base ========================================================================== */
+/** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
+html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
 
-strong {
-  font-weight: bold;
-  color: #083194;
-}
+/** Remove default margin. */
+body { margin: 0; }
 
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
+/* ========================================================================== Links ========================================================================== */
+/** Remove the gray background color from active links in IE 10. */
+a { background: transparent; }
 
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
+/** Address `outline` inconsistency between Chrome and other browsers. */
+a:focus { outline: thin dotted; }
 
-div.sectionbody {
-  margin-left: 0;
-}
+/** Improve readability when focused and also mouse hovered in all browsers. */
+a:active, a:hover { outline: 0; }
 
-hr {
-  border: 1px solid silver;
-}
+/* ========================================================================== Typography ========================================================================== */
+/** Address variable `h1` font-size and margin within `section` and `article` contexts in Firefox 4+, Safari 5, and Chrome. */
+h1 { font-size: 2em; margin: 0.67em 0; }
 
-p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9, Safari 5, and Chrome. */
+abbr[title] { border-bottom: 1px dotted; }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
+/** Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome. */
+b, strong { font-weight: bold; }
 
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
+/** Address styling not present in Safari 5 and Chrome. */
+dfn { font-style: italic; }
 
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
+/** Address differences between Firefox and other browsers. */
+hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
 
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9. */
+mark { background: #ff0; color: #000; }
 
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
+/** Correct font family set oddly in Safari 5 and Chrome. */
+code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 
-div.content { /* Block element content. */
-  padding: 0;
-}
+/** Improve readability of pre-formatted text in all browsers. */
+pre { white-space: pre-wrap; }
 
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
+/** Set consistent quote types. */
+q { quotes: "\201C" "\201D" "\2018" "\2019"; }
 
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
+/** Address inconsistent and variable font size in all browsers. */
+small { font-size: 80%; }
 
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
+/** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
 
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
+sup { top: -0.5em; }
 
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
+sub { bottom: -0.25em; }
 
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
+/* ========================================================================== Embedded content ========================================================================== */
+/** Remove border when inside `a` element in IE 8/9. */
+img { border: 0; }
 
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
+/** Correct overflow displayed oddly in IE 9. */
+svg:not(:root) { overflow: hidden; }
 
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
+/* ========================================================================== Figures ========================================================================== */
+/** Address margin not present in IE 8/9 and Safari 5. */
+figure { margin: 0; }
 
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
+/* ========================================================================== Forms ========================================================================== */
+/** Define consistent border, margin, and padding. */
+fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
 
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
+/** 1. Correct `color` not being inherited in IE 8/9. 2. Remove padding so people aren't caught out if they zero out fieldsets. */
+legend { border: 0; /* 1 */ padding: 0; /* 2 */ }
 
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
+/** 1. Correct font family not being inherited in all browsers. 2. Correct font size not being inherited in all browsers. 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome. */
+button, input, select, textarea { font-family: inherit; /* 1 */ font-size: 100%; /* 2 */ margin: 0; /* 3 */ }
 
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
+/** Address Firefox 4+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
+button, input { line-height: normal; }
 
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
+/** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+. Correct `select` style inheritance in Firefox 4+ and Opera. */
+button, select { text-transform: none; }
 
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
+/** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. */
+button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
 
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
+/** Re-set default cursor for disabled elements. */
+button[disabled], html input[disabled] { cursor: default; }
 
-.comment {
-  background: yellow;
-}
+/** 1. Address box sizing set to `content-box` in IE 8/9. 2. Remove excess padding in IE 8/9. */
+input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
 
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
+/** 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome. 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome (include `-moz` to future-proof). */
+input[type="search"] { -webkit-appearance: textfield; /* 1 */ -moz-box-sizing: content-box; -webkit-box-sizing: content-box; /* 2 */ box-sizing: content-box; }
 
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
+/** Remove inner padding and search cancel button in Safari 5 and Chrome on OS X. */
+input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
+/** Remove inner padding and border in Firefox 4+. */
+button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
+/** 1. Remove default vertical scrollbar in IE 8/9. 2. Improve readability and alignment in all browsers. */
+textarea { overflow: auto; /* 1 */ vertical-align: top; /* 2 */ }
 
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
+/* ========================================================================== Tables ========================================================================== */
+/** Remove most spacing between table cells. */
+table { border-collapse: collapse; border-spacing: 0; }
 
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
+meta.foundation-mq-small { font-family: "only screen and (min-width: 768px)"; width: 768px; }
 
-@media print {
-  #footer-badges { display: none; }
-}
+meta.foundation-mq-medium { font-family: "only screen and (min-width:1280px)"; width: 1280px; }
 
-#toc {
-  margin-bottom: 2.5em;
-}
+meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; width: 1440px; }
 
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
+*, *:before, *:after { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
 
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
+html, body { font-size: 100%; }
 
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
+body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
+a:hover { cursor: pointer; }
 
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
+img, object, embed { max-width: 100%; height: auto; }
 
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
+object, embed { height: 100%; }
+
+img { -ms-interpolation-mode: bicubic; }
+
+#map_canvas img, #map_canvas embed, #map_canvas object, .map_canvas img, .map_canvas embed, .map_canvas object { max-width: none !important; }
+
+.left { float: left !important; }
+
+.right { float: right !important; }
+
+.text-left { text-align: left !important; }
+
+.text-right { text-align: right !important; }
+
+.text-center { text-align: center !important; }
+
+.text-justify { text-align: justify !important; }
+
+.hide { display: none; }
+
+.antialiased { -webkit-font-smoothing: antialiased; }
+
+img { display: inline-block; vertical-align: middle; }
+
+textarea { height: auto; min-height: 50px; }
+
+select { width: 100%; }
+
+object, svg { display: inline-block; vertical-align: middle; }
+
+.center { margin-left: auto; margin-right: auto; }
+
+.spread { width: 100%; }
+
+p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { font-size: 1.21875em; line-height: 1.6; }
+
+.subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { line-height: 1.4; color: black; font-weight: 300; margin-top: 0.2em; margin-bottom: 0.5em; }
+
+/* Typography resets */
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
+
+/* Default Link Styles */
+a { color: #0068b0; text-decoration: none; line-height: inherit; }
+a:hover, a:focus { color: #333333; }
+a img { border: none; }
+
+/* Default paragraph styles */
+p { font-family: Noto, sans-serif; font-weight: normal; font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; text-rendering: optimizeLegibility; }
+p aside { font-size: 0.875em; line-height: 1.35; font-style: italic; }
+
+/* Default header styles */
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { font-family: Noto, sans-serif; font-weight: normal; font-style: normal; color: black; text-rendering: optimizeLegibility; margin-top: 0.5em; margin-bottom: 0.5em; line-height: 1.2125em; }
+h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small { font-size: 60%; color: #4d4d4d; line-height: 0; }
+
+h1 { font-size: 2.125em; }
+
+h2 { font-size: 1.6875em; }
+
+h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.375em; }
+
+h4 { font-size: 1.125em; }
+
+h5 { font-size: 1.125em; }
+
+h6 { font-size: 1em; }
+
+hr { border: solid #dddddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
+
+/* Helpful Typography Defaults */
+em, i { font-style: italic; line-height: inherit; }
+
+strong, b { font-weight: bold; line-height: inherit; }
+
+small { font-size: 60%; line-height: inherit; }
+
+code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #264357; }
+
+/* Lists */
+ul, ol, dl { font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; list-style-position: outside; font-family: Noto, sans-serif; }
+
+ul, ol { margin-left: 1.5em; }
+ul.no-bullet, ol.no-bullet { margin-left: 1.5em; }
+
+/* Unordered Lists */
+ul li ul, ul li ol { margin-left: 1.25em; margin-bottom: 0; font-size: 1em; /* Override nested font-size change */ }
+ul.square li ul, ul.circle li ul, ul.disc li ul { list-style: inherit; }
+ul.square { list-style-type: square; }
+ul.circle { list-style-type: circle; }
+ul.disc { list-style-type: disc; }
+ul.no-bullet { list-style: none; }
+
+/* Ordered Lists */
+ol li ul, ol li ol { margin-left: 1.25em; margin-bottom: 0; }
+
+/* Definition Lists */
+dl dt { margin-bottom: 0.3em; font-weight: bold; }
+dl dd { margin-bottom: 0.75em; }
+
+/* Abbreviations */
+abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #dddddd; cursor: help; }
+
+abbr { text-transform: none; }
+
+/* Blockquotes */
+blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #dddddd; }
+blockquote cite { display: block; font-size: 0.8125em; color: #5e93b8; }
+blockquote cite:before { content: "\2014 \0020"; }
+blockquote cite a, blockquote cite a:visited { color: #5e93b8; }
+
+blockquote, blockquote p { line-height: 1.6; color: #333333; }
+
+/* Microformats */
+.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #dddddd; padding: 0.625em 0.75em; }
+.vcard li { margin: 0; display: block; }
+.vcard .fn { font-weight: bold; font-size: 0.9375em; }
+
+.vevent .summary { font-weight: bold; }
+.vevent abbr { cursor: auto; text-decoration: none; font-weight: bold; border: none; padding: 0 0.0625em; }
+
+@media only screen and (min-width: 768px) { h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+  h1 { font-size: 2.75em; }
+  h2 { font-size: 2.3125em; }
+  h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
+  h4 { font-size: 1.4375em; } }
+/* Tables */
+table { background: white; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
+table thead, table tfoot { background: -webkit-linear-gradient(top, #add386, #90b66a); font-weight: bold; }
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: white; text-align: left; }
+table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #6d6e71; }
+table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #edf2f2; }
+table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.4; }
+
+body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+
+a:hover, a:focus { text-decoration: underline; }
+
+.clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
+.clearfix:after, .float-group:after { clear: both; }
+
+*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: white; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
+*:not(pre) > code.nobreak { word-wrap: normal; }
+*:not(pre) > code.nowrap { white-space: nowrap; }
+
+pre, pre > code { line-height: 1.6; color: #264357; font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; }
+
+em em { font-style: normal; }
+
+strong strong { font-weight: normal; }
+
+.keyseq { color: #333333; }
+
+kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
+
+.keyseq kbd:first-child { margin-left: 0; }
+
+.keyseq kbd:last-child { margin-right: 0; }
+
+.menuseq, .menuref { color: #000; }
+
+.menuseq b:not(.caret), .menuref { font-weight: inherit; }
+
+.menuseq { word-spacing: -0.02em; }
+.menuseq b.caret { font-size: 1.25em; line-height: 0.8; }
+.menuseq i.caret { font-weight: bold; text-align: center; width: 0.45em; }
+
+b.button:before, b.button:after { position: relative; top: -1px; font-weight: normal; }
+
+b.button:before { content: "["; padding: 0 3px 0 2px; }
+
+b.button:after { content: "]"; padding: 0 2px 0 3px; }
+
+#header, #content, #footnotes, #footer { width: 100%; margin-left: auto; margin-right: auto; margin-top: 0; margin-bottom: 0; max-width: 62.5em; *zoom: 1; position: relative; padding-left: 1.5em; padding-right: 1.5em; }
+#header:before, #header:after, #content:before, #content:after, #footnotes:before, #footnotes:after, #footer:before, #footer:after { content: " "; display: table; }
+#header:after, #content:after, #footnotes:after, #footer:after { clear: both; }
+
+#content { margin-top: 1.25em; }
+
+#content:before { content: none; }
+
+#header > h1:first-child { color: black; margin-top: 2.25rem; margin-bottom: 0; }
+#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #dddddd; }
+#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #dddddd; padding-bottom: 8px; }
+#header .details { border-bottom: 1px solid #dddddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #5e93b8; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
+#header .details span:first-child { margin-left: -0.125em; }
+#header .details span.email a { color: #333333; }
+#header .details br { display: none; }
+#header .details br + span:before { content: "\00a0\2013\00a0"; }
+#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333333; }
+#header .details br + span#revremark:before { content: "\00a0|\00a0"; }
+#header #revnumber { text-transform: capitalize; }
+#header #revnumber:after { content: "\00a0"; }
+
+#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #dddddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
+
+#toc { border-bottom: 0 solid #dddddd; padding-bottom: 0.5em; }
+#toc > ul { margin-left: 0.125em; }
+#toc ul.sectlevel0 > li > a { font-style: italic; }
+#toc ul.sectlevel0 ul.sectlevel1 { margin: 0.5em 0; }
+#toc ul { font-family: Noto, sans-serif; list-style-type: none; }
+#toc li { line-height: 1.3334; margin-top: 0.3334em; }
+#toc a { text-decoration: none; }
+#toc a:active { text-decoration: underline; }
+
+#toctitle { color: black; font-size: 1.2em; }
+
+@media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
+  body.toc2 { padding-left: 15em; padding-right: 0; }
+  #toc.toc2 { margin-top: 0 !important; background-color: white; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #dddddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
+  #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
+  #toc.toc2 > ul { font-size: 0.9em; margin-bottom: 0; }
+  #toc.toc2 ul ul { margin-left: 0; padding-left: 1em; }
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 15em; }
+  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #dddddd; left: auto; right: 0; } }
+@media only screen and (min-width: 1280px) { body.toc2 { padding-left: 20em; padding-right: 0; }
+  #toc.toc2 { width: 20em; }
+  #toc.toc2 #toctitle { font-size: 1.375em; }
+  #toc.toc2 > ul { font-size: 0.95em; }
+  #toc.toc2 ul ul { padding-left: 1.25em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 20em; } }
+#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+#content #toc > :first-child { margin-top: 0; }
+#content #toc > :last-child { margin-bottom: 0; }
+
+#footer { max-width: 100%; background-color: none; padding: 1.25em; }
+
+#footer-text { color: black; line-height: 1.44; }
+
+#content { margin-bottom: 0.625em; }
+
+.sect1 { padding-bottom: 0.625em; }
+
+@media only screen and (min-width: 768px) { #content { margin-bottom: 1.25em; }
+  .sect1 { padding-bottom: 1.25em; } }
+.sect1:last-child { padding-bottom: 0; }
+
+.sect1 + .sect1 { border-top: 0 solid #dddddd; }
+
+#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
+#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
+#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover { visibility: visible; }
+#content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link { color: black; text-decoration: none; }
+#content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover { color: black; }
+
+.audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock { margin-bottom: 1.25em; }
+
+.admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { text-rendering: optimizeLegibility; text-align: left; }
+
+table.tableblock > caption.title { white-space: nowrap; overflow: visible; max-width: 0; }
+
+.paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { color: black; }
+
+table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-size: inherit; }
+
+.admonitionblock > table { border-collapse: separate; border: 0; background: none; width: 100%; }
+.admonitionblock > table td.icon { text-align: center; width: 80px; }
+.admonitionblock > table td.icon img { max-width: initial; }
+.admonitionblock > table td.icon .title { font-weight: bold; font-family: Noto, sans-serif; text-transform: uppercase; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #dddddd; color: #5e93b8; }
+.admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
+
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.exampleblock > .content > :first-child { margin-top: 0; }
+.exampleblock > .content > :last-child { margin-bottom: 0; }
+
+.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.sidebarblock > :first-child { margin-top: 0; }
+.sidebarblock > :last-child { margin-bottom: 0; }
+.sidebarblock > .content > .title { color: black; margin-top: 0; }
+
+.exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
+
+.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eeeeee; }
+.sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
+
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
+.literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
+@media only screen and (min-width: 768px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 0.90625em; } }
+@media only screen and (min-width: 1280px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 1em; } }
+
+.literalblock.output pre { color: #eeeeee; background-color: #264357; }
+
+.listingblock pre.highlightjs { padding: 0; }
+.listingblock pre.highlightjs > code { padding: 1.25em 1.5625em 1.125em 1.5625em; -webkit-border-radius: 0; border-radius: 0; }
+
+.listingblock > .content { position: relative; }
+
+.listingblock code[data-lang]:before { display: none; content: attr(data-lang); position: absolute; font-size: 0.75em; top: 0.425rem; right: 0.5rem; line-height: 1; text-transform: uppercase; color: #999; }
+
+.listingblock:hover code[data-lang]:before { display: block; }
+
+.listingblock.terminal pre .command:before { content: attr(data-prompt); padding-right: 0.5em; color: #999; }
+
+.listingblock.terminal pre .command:not([data-prompt]):before { content: "$"; }
+
+table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
+
+table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; line-height: 1.6; }
+
+table.pyhltable td.code { padding-left: .75em; padding-right: 0; }
+
+pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #dddddd; }
+
+pre.pygments .lineno { display: inline-block; margin-right: .25em; }
+
+table.pyhltable .linenodiv { background: none !important; padding-right: 0 !important; }
+
+.quoteblock { margin: 0 1em 0.75em 1.5em; display: table; }
+.quoteblock > .title { margin-left: -1.5em; margin-bottom: 0.75em; }
+.quoteblock blockquote, .quoteblock blockquote p { color: #333333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
+.quoteblock blockquote { margin: 0; padding: 0; border: 0; }
+.quoteblock blockquote:before { content: "\201c"; float: left; font-size: 2.75em; font-weight: bold; line-height: 0.6em; margin-left: -0.6em; color: black; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
+.quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
+.quoteblock .attribution { margin-top: 0.5em; margin-right: 0.5ex; text-align: right; }
+.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #5e93b8; }
+.quoteblock .quoteblock blockquote { padding: 0 0 0 0.75em; }
+.quoteblock .quoteblock blockquote:before { display: none; }
+
+.verseblock { margin: 0 1em 0.75em 1em; }
+.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333333; font-weight: 300; text-rendering: optimizeLegibility; }
+.verseblock pre strong { font-weight: 400; }
+.verseblock .attribution { margin-top: 1.25rem; margin-left: 0.5ex; }
+
+.quoteblock .attribution, .verseblock .attribution { font-size: 0.8125em; line-height: 1.45; font-style: italic; }
+.quoteblock .attribution br, .verseblock .attribution br { display: none; }
+.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #5e93b8; }
+
+.quoteblock.abstract { margin: 0 0 0.75em 0; display: block; }
+.quoteblock.abstract blockquote, .quoteblock.abstract blockquote p { text-align: left; word-spacing: 0; }
+.quoteblock.abstract blockquote:before, .quoteblock.abstract blockquote p:first-of-type:before { display: none; }
+
+table.tableblock { max-width: 100%; border-collapse: separate; }
+table.tableblock td > .paragraph:last-child p > p:last-child, table.tableblock th > p:last-child, table.tableblock td > p:last-child { margin-bottom: 0; }
+
+table.tableblock, th.tableblock, td.tableblock { border: 0 solid #d8d8ce; }
+
+table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock { border-width: 0 1px 1px 0; }
+
+table.grid-all > tfoot > tr > .tableblock { border-width: 1px 1px 0 0; }
+
+table.grid-cols > * > tr > .tableblock { border-width: 0 1px 0 0; }
+
+table.grid-rows > thead > tr > .tableblock, table.grid-rows > tbody > tr > .tableblock { border-width: 0 0 1px 0; }
+
+table.grid-rows > tfoot > tr > .tableblock { border-width: 1px 0 0 0; }
+
+table.grid-all > * > tr > .tableblock:last-child, table.grid-cols > * > tr > .tableblock:last-child { border-right-width: 0; }
+
+table.grid-all > tbody > tr:last-child > .tableblock, table.grid-all > thead:last-child > tr > .tableblock, table.grid-rows > tbody > tr:last-child > .tableblock, table.grid-rows > thead:last-child > tr > .tableblock { border-bottom-width: 0; }
+
+table.frame-all { border-width: 1px; }
+
+table.frame-sides { border-width: 0 1px; }
+
+table.frame-topbot { border-width: 1px 0; }
+
+th.halign-left, td.halign-left { text-align: left; }
+
+th.halign-right, td.halign-right { text-align: right; }
+
+th.halign-center, td.halign-center { text-align: center; }
+
+th.valign-top, td.valign-top { vertical-align: top; }
+
+th.valign-bottom, td.valign-bottom { vertical-align: bottom; }
+
+th.valign-middle, td.valign-middle { vertical-align: middle; }
+
+table thead th, table tfoot th { font-weight: bold; }
+
+tbody tr th { display: table-cell; line-height: 1.4; background: -webkit-linear-gradient(top, #add386, #90b66a); }
+
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: white; font-weight: bold; }
+
+p.tableblock > code:only-child { background: none; padding: 0; }
+
+p.tableblock { font-size: 1em; }
+
+td > div.verse { white-space: pre; }
+
+ol { margin-left: 1.75em; }
+
+ul li ol { margin-left: 1.5em; }
+
+dl dd { margin-left: 1.125em; }
+
+dl dd:last-child, dl dd:last-child > :last-child { margin-bottom: 0; }
+
+ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .ulist, .ulist .olist, .olist .ulist { margin-bottom: 0.375em; }
+
+ul.checklist, ul.none, ol.none, ul.no-bullet, ol.no-bullet, ol.unnumbered, ul.unstyled, ol.unstyled { list-style-type: none; }
+
+ul.no-bullet, ol.no-bullet, ol.unnumbered { margin-left: 0.625em; }
+
+ul.unstyled, ol.unstyled { margin-left: 0; }
+
+ul.checklist { margin-left: 0.625em; }
+
+ul.checklist li > p:first-child > .fa-square-o:first-child, ul.checklist li > p:first-child > .fa-check-square-o:first-child { width: 1.25em; font-size: 0.8em; position: relative; bottom: 0.125em; }
+
+ul.checklist li > p:first-child > input[type="checkbox"]:first-child { margin-right: 0.25em; }
+
+ul.inline { display: -ms-flexbox; display: -webkit-box; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; list-style: none; margin: 0 0 0.375em -0.75em; }
+
+ul.inline > li { margin-left: 0.75em; }
+
+.unstyled dl dt { font-weight: normal; font-style: normal; }
+
+ol.arabic { list-style-type: decimal; }
+
+ol.decimal { list-style-type: decimal-leading-zero; }
+
+ol.loweralpha { list-style-type: lower-alpha; }
+
+ol.upperalpha { list-style-type: upper-alpha; }
+
+ol.lowerroman { list-style-type: lower-roman; }
+
+ol.upperroman { list-style-type: upper-roman; }
+
+ol.lowergreek { list-style-type: lower-greek; }
+
+.hdlist > table, .colist > table { border: 0; background: none; }
+.hdlist > table > tbody > tr, .colist > table > tbody > tr { background: none; }
+
+td.hdlist1, td.hdlist2 { vertical-align: top; padding: 0 0.625em; }
+
+td.hdlist1 { font-weight: bold; padding-bottom: 0.75em; }
+
+.literalblock + .colist, .listingblock + .colist { margin-top: -0.5em; }
+
+.colist > table tr > td:first-of-type { padding: 0.4em 0.75em 0 0.75em; line-height: 1; vertical-align: top; }
+.colist > table tr > td:first-of-type img { max-width: initial; }
+.colist > table tr > td:last-of-type { padding: 0.25em 0; }
+
+.thumb, .th { line-height: 0; display: inline-block; border: solid 4px white; -webkit-box-shadow: 0 0 0 1px #dddddd; box-shadow: 0 0 0 1px #dddddd; }
+
+.imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
+.imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
+.imageblock > .title { margin-bottom: 0; }
+.imageblock.thumb, .imageblock.th { border-width: 6px; }
+.imageblock.thumb > .title, .imageblock.th > .title { padding: 0 0.125em; }
+
+.image.left, .image.right { margin-top: 0.25em; margin-bottom: 0.25em; display: inline-block; line-height: 0; }
+.image.left { margin-right: 0.625em; }
+.image.right { margin-left: 0.625em; }
+
+a.image { text-decoration: none; display: inline-block; }
+a.image object { pointer-events: none; }
+
+sup.footnote, sup.footnoteref { font-size: 0.875em; position: static; vertical-align: super; }
+sup.footnote a, sup.footnoteref a { text-decoration: none; }
+sup.footnote a:active, sup.footnoteref a:active { text-decoration: underline; }
+
+#footnotes { padding-top: 0.75em; padding-bottom: 0.75em; margin-bottom: 0.625em; }
+#footnotes hr { width: 20%; min-width: 6.25em; margin: -0.25em 0 0.75em 0; border-width: 1px 0 0 0; }
+#footnotes .footnote { padding: 0 0.375em 0 0.225em; line-height: 1.3334; font-size: 0.875em; margin-left: 1.2em; margin-bottom: 0.2em; }
+#footnotes .footnote a:first-of-type { font-weight: bold; text-decoration: none; margin-left: -1.05em; }
+#footnotes .footnote:last-of-type { margin-bottom: 0; }
+#content #footnotes { margin-top: -0.625em; margin-bottom: 0; padding: 0.75em 0; }
+
+.gist .file-data > table { border: 0; background: #fff; width: 100%; margin-bottom: 0; }
+.gist .file-data > table td.line-data { width: 99%; }
 
 div.unbreakable { page-break-inside: avoid; }
 
+.big { font-size: larger; }
 
-/*
- * xhtml11 specific
- *
- * */
+.small { font-size: smaller; }
 
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
+.underline { text-decoration: underline; }
 
+.overline { text-decoration: overline; }
 
-/*
- * html5 specific
- *
- * */
+.line-through { text-decoration: line-through; }
 
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
+.aqua { color: #00bfbf; }
 
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
+.aqua-background { background-color: #00fafa; }
 
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
+.black { color: black; }
 
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
+.black-background { background-color: black; }
 
+.blue { color: #0000bf; }
 
-/*
- * manpage specific
- *
- * */
+.blue-background { background-color: #0000fa; }
 
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
+.fuchsia { color: #bf00bf; }
 
-@media print {
-  body.manpage div#toc { display: none; }
-}
+.fuchsia-background { background-color: #fa00fa; }
 
+.gray { color: #606060; }
 
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
+.gray-background { background-color: #7d7d7d; }
 
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
+.green { color: #006000; }
 
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
+.green-background { background-color: #007d00; }
 
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
+.lime { color: #00bf00; }
 
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
+.lime-background { background-color: #00fa00; }
+
+.maroon { color: #600000; }
+
+.maroon-background { background-color: #7d0000; }
+
+.navy { color: #000060; }
+
+.navy-background { background-color: #00007d; }
+
+.olive { color: #606000; }
+
+.olive-background { background-color: #7d7d00; }
+
+.purple { color: #600060; }
+
+.purple-background { background-color: #7d007d; }
+
+.red { color: #bf0000; }
+
+.red-background { background-color: #fa0000; }
+
+.silver { color: #909090; }
+
+.silver-background { background-color: #bcbcbc; }
+
+.teal { color: #006060; }
+
+.teal-background { background-color: #007d7d; }
+
+.white { color: #bfbfbf; }
+
+.white-background { background-color: #fafafa; }
+
+.yellow { color: #bfbf00; }
+
+.yellow-background { background-color: #fafa00; }
+
+span.icon > .fa { cursor: default; }
+a span.icon > .fa { cursor: inherit; }
+
+.admonitionblock td.icon [class^="fa icon-"] { font-size: 2.5em; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5); cursor: default; }
+.admonitionblock td.icon .icon-note:before { content: "\f05a"; color: #29475c; }
+.admonitionblock td.icon .icon-tip:before { content: "\f0eb"; text-shadow: 1px 1px 2px rgba(155, 155, 0, 0.8); color: #111; }
+.admonitionblock td.icon .icon-warning:before { content: "\f071"; color: #bf6900; }
+.admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #bf3400; }
+.admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
+
+.conum[data-value] { display: inline-block; color: #fff !important; background-color: black; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; font-size: 0.75em; width: 1.67em; height: 1.67em; line-height: 1.67em; font-family: "Open Sans", "DejaVu Sans", sans-serif; font-style: normal; font-weight: bold; }
+.conum[data-value] * { color: #fff !important; }
+.conum[data-value] + b { display: none; }
+.conum[data-value]:after { content: attr(data-value); }
+pre .conum[data-value] { position: relative; top: -0.125em; }
+
+b.conum * { color: inherit !important; }
+
+.conum:not([data-value]):empty { display: none; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #dddddd; }
+
+.sect1 { padding-bottom: 0; }
+
+#toctitle { color: #00406F; font-weight: normal; margin-top: 1.5em; }
+
+.sidebarblock { border-color: #aaa; }
+
+code { -webkit-border-radius: 4px; border-radius: 4px; }
+
+p.tableblock.header { color: #6d6e71; }
+
+.literalblock pre, .listingblock pre { background: #eeeeee; }
+
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
-</head>
-<body class="article">
+<link rel="stylesheet" href="../katex/katex.min.css">
+<script src="../katex/katex.min.js"></script>
+<script src="../katex/contrib/auto-render.min.js"></script>
+    <!-- Use KaTeX to render math once document is loaded, see
+         https://github.com/Khan/KaTeX/tree/master/contrib/auto-render -->
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        renderMathInElement(
+            document.body,
+            {
+                delimiters: [
+                    { left: "$$", right: "$$", display: true},
+                    { left: "\\[", right: "\\]", display: true},
+                    { left: "$", right: "$", display: false},
+                    { left: "\\(", right: "\\)", display: false}
+                ]
+            }
+        );
+    });
+</script></head>
+<body class="book">
 <div id="header">
 <h1>cl_intel_spirv_subgroups</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div class="details">
+<span id="revnumber">version V2.2-11-30-g5ba09e4,</span>
+<span id="revdate">Thu, 24 Oct 2019 22:38:27 +0000</span>
+<br><span id="revremark">from git branch: public_master commit: 5ba09e43bb29a2292d6af0b70148a9f846e1806f</span>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p><span class="monospaced">cl_intel_spirv_subgroups</span></p></div>
+<div class="paragraph">
+<p><code>cl_intel_spirv_subgroups</code></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel (ben <em>dot</em> ashbaugh <em>at</em> intel <em>dot</em> com)</p></div>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel (ben 'dot' ashbaugh 'at' intel 'dot' com)</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel<br>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel<br>
 Biju George, Intel<br>
 Michael Kinsner, Intel<br>
-Mariusz Merecki, Intel</p></div>
+Mariusz Merecki, Intel</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Final Draft</p></div>
+<div class="paragraph">
+<p>Final Draft</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Built On: 2018-10-29<br>
-Revision: 1</p></div>
+<div class="paragraph">
+<p>Built On: 2019-10-23<br>
+Revision: 2</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the OpenCL SPIR-V Environment Specification Version 2.2, Revision v2.2-3.</p></div>
-<div class="paragraph"><p>This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the <span class="monospaced">cl_khr_il_program</span> extension, and support for the <span class="monospaced">cl_intel_subgroups</span> extension.</p></div>
-<div class="paragraph"><p>This extension interacts with the <span class="monospaced">cl_intel_subgroups_short</span> extension.</p></div>
+<div class="paragraph">
+<p>This extension is written against the OpenCL SPIR-V Environment Specification Version 2.2, Revision v2.2-3.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires OpenCL support for SPIR-V, either via OpenCL 2.1 or via the <code>cl_khr_il_program</code> extension, and support for the <code>cl_intel_subgroups</code> extension.</p>
+</div>
+<div class="paragraph">
+<p>This extension interacts with the <code>cl_intel_subgroups_short</code> extension.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension defines how modules using the SPIR-V extension <span class="monospaced">SPV_INTEL_subgroups</span> may behave in an OpenCL environment.</p></div>
-<div class="paragraph"><p>This extension is a companion to the <span class="monospaced">cl_intel_subgroups</span> and <span class="monospaced">cl_intel_subgroups_short</span> OpenCL extensions, and the functionality described in this extension and <span class="monospaced">SPV_INTEL_subgroups</span> is sufficient to implement the built-in functions defined in the <span class="monospaced">cl_intel_subgroups</span> and <span class="monospaced">cl_intel_subgroups_short</span> extensions.</p></div>
+<div class="paragraph">
+<p>This extension defines how modules using the SPIR-V extension <code>SPV_INTEL_subgroups</code> may behave in an OpenCL environment.</p>
+</div>
+<div class="paragraph">
+<p>This extension is a companion to the <code>cl_intel_subgroups</code> and <code>cl_intel_subgroups_short</code> OpenCL extensions, and the functionality described in this extension and <code>SPV_INTEL_subgroups</code> is sufficient to implement the built-in functions defined in the <code>cl_intel_subgroups</code> and <code>cl_intel_subgroups_short</code> extensions.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_functions">New API Functions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_enums">New API Enums</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_modifications_to_the_opencl_spir_v_environment_specification">Modifications to the OpenCL SPIR-V Environment Specification</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_add_a_new_section_7_1_x_span_class_monospaced_cl_intel_spirv_subgroups_span">Add a new Section 7.1.X - <span class="monospaced">cl_intel_spirv_subgroups</span></h3>
-<div class="paragraph"><p>If the OpenCL environment supports the extension <span class="monospaced">cl_intel_spirv_subgroups</span>, then the environment must accept SPIR-V modules that declare use of the <span class="monospaced">SPV_INTEL_subgroups</span> extension via <strong>OpExtension</strong>.</p></div>
-<div class="paragraph"><p>If the OpenCL environment supports the extension <span class="monospaced">cl_intel_spirv_subgroups</span> and use of the <span class="monospaced">SPV_INTEL_subgroups</span> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept modules that declare the following SPIR-V capabilities:</p></div>
-<div class="ulist"><ul>
+<h3 id="_add_a_new_section_7_1_x_cl_intel_spirv_subgroups">Add a new Section 7.1.X - <code>cl_intel_spirv_subgroups</code></h3>
+<div class="paragraph">
+<p>If the OpenCL environment supports the extension <code>cl_intel_spirv_subgroups</code>, then the environment must accept SPIR-V modules that declare use of the <code>SPV_INTEL_subgroups</code> extension via <strong>OpExtension</strong>.</p>
+</div>
+<div class="paragraph">
+<p>If the OpenCL environment supports the extension <code>cl_intel_spirv_subgroups</code> and use of the <code>SPV_INTEL_subgroups</code> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept modules that declare the following SPIR-V capabilities:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>SubgroupShuffleINTEL</strong>
-</p>
+<p><strong>SubgroupShuffleINTEL</strong></p>
 </li>
 <li>
-<p>
-<strong>SubgroupBufferBlockIOINTEL</strong>
-</p>
+<p><strong>SubgroupBufferBlockIOINTEL</strong></p>
 </li>
 <li>
-<p>
-<strong>SubgroupImageBlockIOINTEL</strong>
-</p>
+<p><strong>SubgroupImageBlockIOINTEL</strong></p>
 </li>
-</ul></div>
-<div class="paragraph"><p>Additionally, the environment must accept modules that use the following <strong>BuiltIns</strong>:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>Additionally, the environment must accept modules that use the following <strong>BuiltIns</strong>:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>SubgroupSize</strong>
-</p>
-</li>
-<li>
-<p>
-<strong>SubgroupMaxSize</strong>
-</p>
+<p><strong>SubgroupSize</strong></p>
 </li>
 <li>
-<p>
-<strong>NumSubgroups</strong>
-</p>
+<p><strong>SubgroupMaxSize</strong></p>
 </li>
 <li>
-<p>
-<strong>SubgroupId</strong>
-</p>
+<p><strong>NumSubgroups</strong></p>
 </li>
 <li>
-<p>
-<strong>SubgroupLocalInvocationId</strong>
-</p>
-</li>
-</ul></div>
-<div class="paragraph"><p>For an OpenCL 2.0 or newer environment, the following <strong>BuiltIns</strong> must additionally be accepted:</p></div>
-<div class="ulist"><ul>
-<li>
-<p>
-<strong>NumEnqueuedSubgroups</strong>
-</p>
-</li>
-</ul></div>
-<div class="paragraph"><p>Additionally, the environment must accept the following instruction semantics:</p></div>
-<div class="paragraph"><p>For the control <em>Barrier Instruction</em>:</p></div>
-<div class="ulist"><ul>
-<li>
-<p>
-<strong>OpControlBarrier</strong>:
-</p>
-<div class="ulist"><ul>
-<li>
-<p>
-The <em>Scope</em> for <em>Execution</em> may be <strong>Subgroup</strong>.
-</p>
+<p><strong>SubgroupId</strong></p>
 </li>
 <li>
-<p>
-The <em>Scope</em> for <em>Memory</em> may be <strong>Subgroup</strong>.
-</p>
+<p><strong>SubgroupLocalInvocationId</strong></p>
 </li>
-</ul></div>
-</li>
-</ul></div>
-<div class="paragraph"><p>For the <em>Group Instructions</em>:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>For an OpenCL 2.0 or newer environment, the following <strong>BuiltIns</strong> must additionally be accepted:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>OpGroupAll</strong>
-</p>
+<p><strong>NumEnqueuedSubgroups</strong></p>
 </li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Additionally, the environment must accept the following instruction semantics:</p>
+</div>
+<div class="paragraph">
+<p>For the control <em>Barrier Instruction</em>:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>OpGroupAny</strong>
-</p>
-</li>
+<p><strong>OpControlBarrier</strong>:</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>OpGroupBroadcast</strong>
-</p>
-</li>
-<li>
-<p>
-<strong>OpGroupIAdd</strong>
-</p>
-</li>
-<li>
-<p>
-<strong>OpGroupFAdd</strong>
-</p>
+<p>The <em>Scope</em> for <em>Execution</em> may be <strong>Subgroup</strong>.</p>
 </li>
 <li>
-<p>
-<strong>OpGroupFMin</strong>
-</p>
+<p>The <em>Scope</em> for <em>Memory</em> may be <strong>Subgroup</strong>.</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>For the <em>Group Instructions</em>:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>OpGroupAll</strong></p>
 </li>
 <li>
-<p>
-<strong>OpGroupUMin</strong>
-</p>
+<p><strong>OpGroupAny</strong></p>
 </li>
 <li>
-<p>
-<strong>OpGroupSMin</strong>
-</p>
+<p><strong>OpGroupBroadcast</strong></p>
 </li>
 <li>
-<p>
-<strong>OpGroupFMax</strong>
-</p>
+<p><strong>OpGroupIAdd</strong></p>
 </li>
 <li>
-<p>
-<strong>OpGroupUMax</strong>
-</p>
+<p><strong>OpGroupFAdd</strong></p>
 </li>
 <li>
-<p>
-<strong>OpGroupSMax</strong>
-</p>
-<div class="ulist"><ul>
+<p><strong>OpGroupFMin</strong></p>
+</li>
 <li>
-<p>
-The <em>Scope</em> for <em>Execution</em> may be <strong>Subgroup</strong>.
-</p>
+<p><strong>OpGroupUMin</strong></p>
 </li>
-</ul></div>
+<li>
+<p><strong>OpGroupSMin</strong></p>
 </li>
-</ul></div>
+<li>
+<p><strong>OpGroupFMax</strong></p>
+</li>
+<li>
+<p><strong>OpGroupUMax</strong></p>
+</li>
+<li>
+<p><strong>OpGroupSMax</strong></p>
+<div class="ulist">
+<ul>
+<li>
+<p>The <em>Scope</em> for <em>Execution</em> may be <strong>Subgroup</strong>.</p>
+</li>
+</ul>
+</div>
+</li>
+</ul>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_add_a_new_section_7_1_x_1_shuffle_instructions">Add a new Section 7.1.X.1 - Shuffle Instructions</h3>
-<div class="paragraph"><p>Because support for <span class="monospaced">cl_intel_subgroups</span> is required for <span class="monospaced">cl_intel_spirv_subgroups</span>, if the OpenCL environment supports the extension <span class="monospaced">cl_intel_spirv_subgroups</span> and use of the <span class="monospaced">SPV_INTEL_subgroups</span> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept the following types for <em>Data</em> for the <strong>SubgroupShuffleINTEL</strong> instructions:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>Because support for <code>cl_intel_subgroups</code> is required for <code>cl_intel_spirv_subgroups</code>, if the OpenCL environment supports the extension <code>cl_intel_spirv_subgroups</code> and use of the <code>SPV_INTEL_subgroups</code> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept the following types for 'Data' for the <strong>SubgroupShuffleINTEL</strong> instructions:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Scalars and <strong>OpTypeVectors</strong> with 2, 4, 8, or 16 <em>Component Count</em> components of the following <em>Component Type</em> types:
-</p>
-<div class="ulist"><ul>
+<p>Scalars and <strong>OpTypeVectors</strong> with 2, 3, 4, 8, or 16 <em>Component Count</em> components of the following <em>Component Type</em> types:</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>OpTypeFloat</strong> with a <em>Width</em> of 32 bits (equivalent to <span class="monospaced">float</span>)
-</p>
+<p><strong>OpTypeFloat</strong> with a <em>Width</em> of 32 bits (equivalent to <code>float</code>)</p>
 </li>
 <li>
-<p>
-<strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">int</span> and <span class="monospaced">uint</span>)
-</p>
+<p><strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <code>int</code> and <code>uint</code>)</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </li>
 <li>
-<p>
-Scalars of <strong>OpTypeInt</strong> with a <em>Width</em> of 64 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">long</span> and <span class="monospaced">ulong</span>)
-</p>
+<p>Scalars of <strong>OpTypeInt</strong> with a <em>Width</em> of 64 bits and <em>Signedness</em> of 0 (equivalent to <code>long</code> and <code>ulong</code>)</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>Additionally, if the <strong>Float16</strong> capability is declared and supported:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>Additionally, if the <strong>Float16</strong> capability is declared and supported:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Scalars of <strong>OpTypeFloat</strong> with a <em>Width</em> of 16 bits (equivalent to <span class="monospaced">half</span>)
-</p>
+<p>Scalars of <strong>OpTypeFloat</strong> with a <em>Width</em> of 16 bits (equivalent to <code>half</code>)</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>Additionally, if the <strong>Float64</strong> capability is declared and supported:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>Additionally, if the <strong>Float64</strong> capability is declared and supported:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Scalars of <strong>OpTypeFloat</strong> with a <em>Width</em> of 64 bits (equivalent to <span class="monospaced">double</span>)
-</p>
+<p>Scalars of <strong>OpTypeFloat</strong> with a <em>Width</em> of 64 bits (equivalent to <code>double</code>)</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>Additionally, if the OpenCL environment supports the extension <span class="monospaced">cl_intel_subgroups_short</span>:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>Additionally, if the OpenCL environment supports the extension <code>cl_intel_subgroups_short</code>:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Scalars and <strong>OpTypeVectors</strong> with 2, 4, 8, or 16 <em>Component Count</em> components of the following <em>Component Type</em> types:
-</p>
-<div class="ulist"><ul>
+<p>Scalars and <strong>OpTypeVectors</strong> with 2, 3, 4, 8, or 16 <em>Component Count</em> components of the following <em>Component Type</em> types:</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>OpTypeInt</strong> with a <em>Width</em> of 16 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">short</span> and <span class="monospaced">ushort</span>)
-</p>
+<p><strong>OpTypeInt</strong> with a <em>Width</em> of 16 bits and <em>Signedness</em> of 0 (equivalent to <code>short</code> and <code>ushort</code>)</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_add_a_new_section_7_1_x_2_block_io_instructions">Add a new Section 7.1.X.2 - Block IO Instructions</h3>
-<div class="paragraph"><p>Because support for <span class="monospaced">cl_intel_subgroups</span> is required for <span class="monospaced">cl_intel_spirv_subgroups</span>, if the OpenCL environment supports the extension <span class="monospaced">cl_intel_spirv_subgroups</span> and use of the <span class="monospaced">SPV_INTEL_subgroups</span> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept the following types for <em>Result</em> and <em>Data</em> for the <strong>SubgroupBufferBlockIOINTEL</strong> and <strong>SubgroupImageBlockIOINTEL</strong> instructions:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>Because support for <code>cl_intel_subgroups</code> is required for <code>cl_intel_spirv_subgroups</code>, if the OpenCL environment supports the extension <code>cl_intel_spirv_subgroups</code> and use of the <code>SPV_INTEL_subgroups</code> extension is declared in the module via <strong>OpExtension</strong>, then the environment must accept the following types for <em>Result</em> and <em>Data</em> for the <strong>SubgroupBufferBlockIOINTEL</strong> and <strong>SubgroupImageBlockIOINTEL</strong> instructions:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Scalars and <strong>OpTypeVectors</strong> with 2, 4, or 8 <em>Component Count</em> components of the following <em>Component Type</em> types:
-</p>
-<div class="ulist"><ul>
+<p>Scalars and <strong>OpTypeVectors</strong> with 2, 4, or 8 <em>Component Count</em> components of the following <em>Component Type</em> types:</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">int</span> and <span class="monospaced">uint</span>)
-</p>
+<p><strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <code>int</code> and <code>uint</code>)</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </li>
-</ul></div>
-<div class="paragraph"><p>Additionally, if the OpenCL environment supports the extension <span class="monospaced">cl_intel_subgroups_short</span>:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>Additionally, if the OpenCL environment supports the extension <code>cl_intel_subgroups_short</code>:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Scalars and <strong>OpTypeVectors</strong> with 2, 4, or 8 <em>Component Count</em> components of the following <em>Component Type</em> types:
-</p>
-<div class="ulist"><ul>
+<p>Scalars and <strong>OpTypeVectors</strong> with 2, 4, or 8 <em>Component Count</em> components of the following <em>Component Type</em> types:</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>OpTypeInt</strong> with a <em>Width</em> of 16 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">short</span> and <span class="monospaced">ushort</span>)
-</p>
+<p><strong>OpTypeInt</strong> with a <em>Width</em> of 16 bits and <em>Signedness</em> of 0 (equivalent to <code>short</code> and <code>ushort</code>)</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </li>
-</ul></div>
-<div class="paragraph"><p>For <em>Ptr</em>, valid <em>Storage Classes</em> are:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>For <em>Ptr</em>, valid <em>Storage Classes</em> are:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>CrossWorkGroup</strong> (equivalent to the <span class="monospaced">global</span> address space)
-</p>
+<p><strong>CrossWorkGroup</strong> (equivalent to the <code>global</code> address space)</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>For <em>Image</em>:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>For <em>Image</em>:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<em>Dim</em> must be <strong>2D</strong>
-</p>
-</li>
-<li>
-<p>
-<em>Depth</em> must be 0 (not a depth image)
-</p>
-</li>
-<li>
-<p>
-<em>Arrayed</em> must be 0 (non-arrayed content)
-</p>
+<p><em>Dim</em> must be <strong>2D</strong></p>
 </li>
 <li>
-<p>
-<em>MS</em> must be 0 (single-sampled content)
-</p>
+<p><em>Depth</em> must be 0 (not a depth image)</p>
 </li>
 <li>
-<p>
-(equivalent to <span class="monospaced">image2d_t</span>)
-</p>
+<p><em>Arrayed</em> must be 0 (non-arrayed content)</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>For <em>Coordinate</em>, the following types are supported:</p></div>
-<div class="ulist"><ul>
 <li>
-<p>
-<strong>OpTypeVectors</strong> with 2 <em>Component Count</em> components of <em>Component Type</em> <strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <span class="monospaced">int2</span>)
-</p>
+<p><em>MS</em> must be 0 (single-sampled content)</p>
 </li>
-</ul></div>
+<li>
+<p>(equivalent to <code>image2d_t</code>)</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>For <em>Coordinate</em>, the following types are supported:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>OpTypeVectors</strong> with 2 <em>Component Count</em> components of <em>Component Type</em> <strong>OpTypeInt</strong> with a <em>Width</em> of 32 bits and <em>Signedness</em> of 0 (equivalent to <code>int2</code>)</p>
+</li>
+</ul>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_add_a_new_section_7_1_x_3_notes_and_restrictions">Add a new Section 7.1.X.3 - Notes and Restrictions</h3>
-<div class="paragraph"><p>The <strong>SubgroupShuffleINTEL</strong> instructions may be placed within non-uniform control flow and hence do not have to be encountered by all invocations in the subgroup, however <em>Data</em> may only be shuffled among invocations encountering the <strong>SubgroupShuffleINTEL</strong> instruction.  Shuffling <em>Data</em> from an invocation that does not encounter the <strong>SubgroupShuffleINTEL</strong> instruction will produce undefined results.</p></div>
-<div class="paragraph"><p>There is no defined behavior for out-of-range shuffle indices for the <strong>SubgroupShuffleINTEL</strong> instructions.</p></div>
-<div class="paragraph"><p>The <strong>SubgroupBufferBlockIOINTEL</strong> and <strong>SubgroupImageBlockIOINTEL</strong> instructions are only guaranteed to work correctly if placed strictly within uniform control flow within the subgroup.  This ensures that if any invocation executes it, all invocations will execute it.  If placed elsewhere, behavior is undefined.</p></div>
-<div class="paragraph"><p>There is no defined out-of-range behavior for the <strong>SubgroupBufferBlockIOINTEL</strong> instructions.</p></div>
-<div class="paragraph"><p>The <strong>SubgroupImageBlockIOINTEL</strong> instructions do support bounds checking, however they bounds-check to the image width in units of <span class="monospaced">uints</span>, not in units of image elements.  This means:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>The <strong>SubgroupShuffleINTEL</strong> instructions may be placed within non-uniform control flow and hence do not have to be encountered by all invocations in the subgroup, however <em>Data</em> may only be shuffled among invocations encountering the <strong>SubgroupShuffleINTEL</strong> instruction.  Shuffling <em>Data</em> from an invocation that does not encounter the <strong>SubgroupShuffleINTEL</strong> instruction will produce undefined results.</p>
+</div>
+<div class="paragraph">
+<p>There is no defined behavior for out-of-range shuffle indices for the <strong>SubgroupShuffleINTEL</strong> instructions.</p>
+</div>
+<div class="paragraph">
+<p>The <strong>SubgroupBufferBlockIOINTEL</strong> and <strong>SubgroupImageBlockIOINTEL</strong> instructions are only guaranteed to work correctly if placed strictly within uniform control flow within the subgroup.  This ensures that if any invocation executes it, all invocations will execute it.  If placed elsewhere, behavior is undefined.</p>
+</div>
+<div class="paragraph">
+<p>There is no defined out-of-range behavior for the <strong>SubgroupBufferBlockIOINTEL</strong> instructions.</p>
+</div>
+<div class="paragraph">
+<p>The <strong>SubgroupImageBlockIOINTEL</strong> instructions do support bounds checking, however they bounds-check to the image width in units of <code>uints</code>, not in units of image elements.  This means:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-If the image has an <em>Image Format</em> size equal to the size of a <span class="monospaced">uint</span> (four bytes, for example <strong>Rgba8</strong>), the image will be correctly bounds-checked.  In this case, out-of-bounds reads will return the edge image element (the equivalent of <strong>ClampToEdge</strong>), and out-of-bounds writes will be ignored.
-</p>
+<p>If the image has an <em>Image Format</em> size equal to the size of a <code>uint</code> (four bytes, for example <strong>Rgba8</strong>), the image will be correctly bounds-checked.  In this case, out-of-bounds reads will return the edge image element (the equivalent of <strong>ClampToEdge</strong>), and out-of-bounds writes will be ignored.</p>
 </li>
 <li>
-<p>
-If the image has an <em>Image Format</em> size less than the size of a <span class="monospaced">uint</span> (such as <strong>R8</strong>), the entire image is addressable, however bounds checking will occur too late.  For this reason, extra care should be taken to avoid out-of-bounds reads and writes, since out-of-bounds reads may return invalid data and out-of-bounds writes may corrupt other images or buffers unpredictably.
-</p>
+<p>If the image has an <em>Image Format</em> size less than the size of a <code>uint</code> (such as <strong>R8</strong>), the entire image is addressable, however bounds checking will occur too late.  For this reason, extra care should be taken to avoid out-of-bounds reads and writes, since out-of-bounds reads may return invalid data and out-of-bounds writes may corrupt other images or buffers unpredictably.</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>The following restrictions apply to the <strong>SubgroupBufferBlockIOINTEL</strong> instructions:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>The following restrictions apply to the <strong>SubgroupBufferBlockIOINTEL</strong> instructions:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-The pointer <em>Ptr</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
-</p>
-</li>
-<li>
-<p>
-If the pointer <em>Ptr</em> is computed from a kernel argument that is a <span class="monospaced">cl_mem</span> that was created with <span class="monospaced">CL_MEM_USE_HOST_PTR</span>, then the <em>host_ptr</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
-</p>
+<p>The pointer <em>Ptr</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.</p>
 </li>
 <li>
-<p>
-If the pointer <em>Ptr</em> is computed from a kernel argument that is a <span class="monospaced">cl_mem</span> that is a sub-buffer, then the <em>origin</em> defining the sub-buffer offset into the <em>buffer</em> must be a multiple of 4 bytes for reads, and must be a multiple of 16 bytes for write, in addition to the <span class="monospaced">CL_DEVICE_MEM_BASE_ADDR_ALIGN</span> requirements.  Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with <span class="monospaced">CL_MEM_USE_HOST_PTR</span>, then the <em>host_ptr</em> for the <em>buffer</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
-</p>
+<p>If the pointer <em>Ptr</em> is computed from a kernel argument that is a <code>cl_mem</code> that was created with <code>CL_MEM_USE_HOST_PTR</code>, then the <em>host_ptr</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.</p>
 </li>
 <li>
-<p>
-If the pointer <em>Ptr</em> is computed from an SVM pointer kernel argument, then the SVM pointer kernel argument must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
-</p>
-</li>
-</ul></div>
-<div class="paragraph"><p>The following restrictions apply to the <strong>SubgroupImageBlockIOINTEL</strong> instructions:</p></div>
-<div class="ulist"><ul>
-<li>
-<p>
-The behavior of the <strong>SubgroupImageBlockIOINTEL</strong> instructions is undefined for images with an element size greater than four bytes (such as <strong>Rgba32f</strong>).
-</p>
+<p>If the pointer <em>Ptr</em> is computed from a kernel argument that is a <code>cl_mem</code> that is a sub-buffer, then the <em>origin</em> defining the sub-buffer offset into the <em>buffer</em> must be a multiple of 4 bytes for reads, and must be a multiple of 16 bytes for write, in addition to the <code>CL_DEVICE_MEM_BASE_ADDR_ALIGN</code> requirements.  Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with <code>CL_MEM_USE_HOST_PTR</code>, then the <em>host_ptr</em> for the <em>buffer</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.</p>
 </li>
 <li>
-<p>
-When reading or writing a 2D image created from a buffer with the <strong>SubgroupImageBlockIOINTEL</strong> instructions, the image row pitch is required to be a multiple of 64-bytes, in addition to the <span class="monospaced">CL_DEVICE_IMAGE_PITCH_ALIGNMENT</span> requirements.
-</p>
+<p>If the pointer <em>Ptr</em> is computed from an SVM pointer kernel argument, then the SVM pointer kernel argument must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.</p>
 </li>
 <li>
-<p>
-When reading or writing a 2D image created from a buffer with the <strong>SubgroupImageBlockIOINTEL</strong> instructions, if the buffer is a <span class="monospaced">cl_mem</span> that was created with <span class="monospaced">CL_MEM_USE_HOST_PTR</span>, then the <em>host_ptr</em> must be 256-bit (32-byte) aligned.
-</p>
+<p>Behavior is undefined if the <strong>SubgroupSize</strong> is smaller than <strong>SubgruopMaxSize</strong>; in other words, if this is a partial subgroup.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>The following restrictions apply to the <strong>SubgroupImageBlockIOINTEL</strong> instructions:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>The behavior of the <strong>SubgroupImageBlockIOINTEL</strong> instructions is undefined for images with an element size greater than four bytes (such as <strong>Rgba32f</strong>).</p>
 </li>
 <li>
-<p>
-When reading or writing a 2D image created from a buffer with the <strong>SubgroupImageBlockIOINTEL</strong> instructions, if the buffer is a <span class="monospaced">cl_mem</span> that is a sub-buffer, then the <em>origin</em> must be a multiple of 32-bytes.  Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with <span class="monospaced">CL_MEM_USE_HOST_PTR</span>, then the <em>host_ptr</em> for the <em>buffer</em> must be 256-bit (32-byte) aligned.
-</p>
+<p>When reading or writing a 2D image created from a buffer with the <strong>SubgroupImageBlockIOINTEL</strong> instructions, the image row pitch is required to be a multiple of 64-bytes, in addition to the <code>CL_DEVICE_IMAGE_PITCH_ALIGNMENT</code> requirements.</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>The following restrictions apply to the <strong>OpSubgroupImageBlockWriteINTEL</strong> instruction:</p></div>
-<div class="ulist"><ul>
 <li>
-<p>
-Unlike the image block read instruction, which may read from any arbitrary byte offset, the x-component of the byte coordinate for the image block write instruction must be a multiple of four; in other words, the write must begin at a 32-bit boundary.  There is no restriction on the y-component of the coordinate.
-</p>
+<p>When reading or writing a 2D image created from a buffer with the <strong>SubgroupImageBlockIOINTEL</strong> instructions, if the buffer is a <code>cl_mem</code> that was created with <code>CL_MEM_USE_HOST_PTR</code>, then the <em>host_ptr</em> must be 256-bit (32-byte) aligned.</p>
 </li>
-</ul></div>
+<li>
+<p>When reading or writing a 2D image created from a buffer with the <strong>SubgroupImageBlockIOINTEL</strong> instructions, if the buffer is a <code>cl_mem</code> that is a sub-buffer, then the <em>origin</em> must be a multiple of 32-bytes.  Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with <code>CL_MEM_USE_HOST_PTR</code>, then the <em>host_ptr</em> for the <em>buffer</em> must be 256-bit (32-byte) aligned.</p>
+</li>
+<li>
+<p>Behavior is undefined if the <strong>SubgroupSize</strong> is smaller than <strong>SubgruopMaxSize</strong>; in other words, if this is a partial subgroup.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>The following restrictions apply to the <strong>OpSubgroupImageBlockWriteINTEL</strong> instruction:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Unlike the image block read instruction, which may read from any arbitrary byte offset, the x-component of the byte coordinate for the image block write instruction must be a multiple of four; in other words, the write must begin at a 32-bit boundary.  There is no restriction on the y-component of the coordinate.</p>
+</li>
+</ul>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-10-29</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>Initial revision</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-10-29</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial revision</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-09-17</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Added 3-component vector support for shuffles, restriction for block reads and writes and partial subgroups, and asciidoctor formatting fixes.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
-<div id="footnotes"><hr></div>
 <div id="footer">
 <div id="footer-text">
-Last updated
- 2018-10-29 11:49:46 PDT
+Version V2.2-11-30-g5ba09e4<br>
+Last updated 2019-10-23 15:35:34 -0700
 </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 </body>
 </html>

--- a/extensions/intel/cl_intel_subgroups.html
+++ b/extensions/intel/cl_intel_subgroups.html
@@ -1,1031 +1,1037 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.9">
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.8">
 <title>cl_intel_subgroups</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+<style>
+/*! normalize.css v2.1.2 | MIT License | git.io/normalize */
+/* ========================================================================== HTML5 display definitions ========================================================================== */
+/** Correct `block` display not defined in IE 8/9. */
+article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
 
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
+/** Correct `inline-block` display not defined in IE 8/9. */
+audio, canvas, video { display: inline-block; }
 
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
+/** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
+audio:not([controls]) { display: none; height: 0; }
 
-body {
-  margin: 1em 5% 1em 5%;
-}
+/** Address `[hidden]` styling not present in IE 8/9. Hide the `template` element in IE, Safari, and Firefox < 22. */
+[hidden], template { display: none; }
 
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
+script { display: none !important; }
 
-em {
-  font-style: italic;
-  color: navy;
-}
+/* ========================================================================== Base ========================================================================== */
+/** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
+html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
 
-strong {
-  font-weight: bold;
-  color: #083194;
-}
+/** Remove default margin. */
+body { margin: 0; }
 
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
+/* ========================================================================== Links ========================================================================== */
+/** Remove the gray background color from active links in IE 10. */
+a { background: transparent; }
 
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
+/** Address `outline` inconsistency between Chrome and other browsers. */
+a:focus { outline: thin dotted; }
 
-div.sectionbody {
-  margin-left: 0;
-}
+/** Improve readability when focused and also mouse hovered in all browsers. */
+a:active, a:hover { outline: 0; }
 
-hr {
-  border: 1px solid silver;
-}
+/* ========================================================================== Typography ========================================================================== */
+/** Address variable `h1` font-size and margin within `section` and `article` contexts in Firefox 4+, Safari 5, and Chrome. */
+h1 { font-size: 2em; margin: 0.67em 0; }
 
-p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9, Safari 5, and Chrome. */
+abbr[title] { border-bottom: 1px dotted; }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
+/** Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome. */
+b, strong { font-weight: bold; }
 
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
+/** Address styling not present in Safari 5 and Chrome. */
+dfn { font-style: italic; }
 
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
+/** Address differences between Firefox and other browsers. */
+hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
 
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9. */
+mark { background: #ff0; color: #000; }
 
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
+/** Correct font family set oddly in Safari 5 and Chrome. */
+code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 
-div.content { /* Block element content. */
-  padding: 0;
-}
+/** Improve readability of pre-formatted text in all browsers. */
+pre { white-space: pre-wrap; }
 
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
+/** Set consistent quote types. */
+q { quotes: "\201C" "\201D" "\2018" "\2019"; }
 
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
+/** Address inconsistent and variable font size in all browsers. */
+small { font-size: 80%; }
 
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
+/** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
 
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
+sup { top: -0.5em; }
 
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
+sub { bottom: -0.25em; }
 
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
+/* ========================================================================== Embedded content ========================================================================== */
+/** Remove border when inside `a` element in IE 8/9. */
+img { border: 0; }
 
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
+/** Correct overflow displayed oddly in IE 9. */
+svg:not(:root) { overflow: hidden; }
 
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
+/* ========================================================================== Figures ========================================================================== */
+/** Address margin not present in IE 8/9 and Safari 5. */
+figure { margin: 0; }
 
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
+/* ========================================================================== Forms ========================================================================== */
+/** Define consistent border, margin, and padding. */
+fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
 
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
+/** 1. Correct `color` not being inherited in IE 8/9. 2. Remove padding so people aren't caught out if they zero out fieldsets. */
+legend { border: 0; /* 1 */ padding: 0; /* 2 */ }
 
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
+/** 1. Correct font family not being inherited in all browsers. 2. Correct font size not being inherited in all browsers. 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome. */
+button, input, select, textarea { font-family: inherit; /* 1 */ font-size: 100%; /* 2 */ margin: 0; /* 3 */ }
 
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
+/** Address Firefox 4+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
+button, input { line-height: normal; }
 
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
+/** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+. Correct `select` style inheritance in Firefox 4+ and Opera. */
+button, select { text-transform: none; }
 
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
+/** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. */
+button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
 
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
+/** Re-set default cursor for disabled elements. */
+button[disabled], html input[disabled] { cursor: default; }
 
-.comment {
-  background: yellow;
-}
+/** 1. Address box sizing set to `content-box` in IE 8/9. 2. Remove excess padding in IE 8/9. */
+input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
 
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
+/** 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome. 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome (include `-moz` to future-proof). */
+input[type="search"] { -webkit-appearance: textfield; /* 1 */ -moz-box-sizing: content-box; -webkit-box-sizing: content-box; /* 2 */ box-sizing: content-box; }
 
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
+/** Remove inner padding and search cancel button in Safari 5 and Chrome on OS X. */
+input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
+/** Remove inner padding and border in Firefox 4+. */
+button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
+/** 1. Remove default vertical scrollbar in IE 8/9. 2. Improve readability and alignment in all browsers. */
+textarea { overflow: auto; /* 1 */ vertical-align: top; /* 2 */ }
 
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
+/* ========================================================================== Tables ========================================================================== */
+/** Remove most spacing between table cells. */
+table { border-collapse: collapse; border-spacing: 0; }
 
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
+meta.foundation-mq-small { font-family: "only screen and (min-width: 768px)"; width: 768px; }
 
-@media print {
-  #footer-badges { display: none; }
-}
+meta.foundation-mq-medium { font-family: "only screen and (min-width:1280px)"; width: 1280px; }
 
-#toc {
-  margin-bottom: 2.5em;
-}
+meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; width: 1440px; }
 
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
+*, *:before, *:after { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
 
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
+html, body { font-size: 100%; }
 
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
+body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
+a:hover { cursor: pointer; }
 
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
+img, object, embed { max-width: 100%; height: auto; }
 
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
+object, embed { height: 100%; }
+
+img { -ms-interpolation-mode: bicubic; }
+
+#map_canvas img, #map_canvas embed, #map_canvas object, .map_canvas img, .map_canvas embed, .map_canvas object { max-width: none !important; }
+
+.left { float: left !important; }
+
+.right { float: right !important; }
+
+.text-left { text-align: left !important; }
+
+.text-right { text-align: right !important; }
+
+.text-center { text-align: center !important; }
+
+.text-justify { text-align: justify !important; }
+
+.hide { display: none; }
+
+.antialiased { -webkit-font-smoothing: antialiased; }
+
+img { display: inline-block; vertical-align: middle; }
+
+textarea { height: auto; min-height: 50px; }
+
+select { width: 100%; }
+
+object, svg { display: inline-block; vertical-align: middle; }
+
+.center { margin-left: auto; margin-right: auto; }
+
+.spread { width: 100%; }
+
+p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { font-size: 1.21875em; line-height: 1.6; }
+
+.subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { line-height: 1.4; color: black; font-weight: 300; margin-top: 0.2em; margin-bottom: 0.5em; }
+
+/* Typography resets */
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
+
+/* Default Link Styles */
+a { color: #0068b0; text-decoration: none; line-height: inherit; }
+a:hover, a:focus { color: #333333; }
+a img { border: none; }
+
+/* Default paragraph styles */
+p { font-family: Noto, sans-serif; font-weight: normal; font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; text-rendering: optimizeLegibility; }
+p aside { font-size: 0.875em; line-height: 1.35; font-style: italic; }
+
+/* Default header styles */
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { font-family: Noto, sans-serif; font-weight: normal; font-style: normal; color: black; text-rendering: optimizeLegibility; margin-top: 0.5em; margin-bottom: 0.5em; line-height: 1.2125em; }
+h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small { font-size: 60%; color: #4d4d4d; line-height: 0; }
+
+h1 { font-size: 2.125em; }
+
+h2 { font-size: 1.6875em; }
+
+h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.375em; }
+
+h4 { font-size: 1.125em; }
+
+h5 { font-size: 1.125em; }
+
+h6 { font-size: 1em; }
+
+hr { border: solid #dddddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
+
+/* Helpful Typography Defaults */
+em, i { font-style: italic; line-height: inherit; }
+
+strong, b { font-weight: bold; line-height: inherit; }
+
+small { font-size: 60%; line-height: inherit; }
+
+code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #264357; }
+
+/* Lists */
+ul, ol, dl { font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; list-style-position: outside; font-family: Noto, sans-serif; }
+
+ul, ol { margin-left: 1.5em; }
+ul.no-bullet, ol.no-bullet { margin-left: 1.5em; }
+
+/* Unordered Lists */
+ul li ul, ul li ol { margin-left: 1.25em; margin-bottom: 0; font-size: 1em; /* Override nested font-size change */ }
+ul.square li ul, ul.circle li ul, ul.disc li ul { list-style: inherit; }
+ul.square { list-style-type: square; }
+ul.circle { list-style-type: circle; }
+ul.disc { list-style-type: disc; }
+ul.no-bullet { list-style: none; }
+
+/* Ordered Lists */
+ol li ul, ol li ol { margin-left: 1.25em; margin-bottom: 0; }
+
+/* Definition Lists */
+dl dt { margin-bottom: 0.3em; font-weight: bold; }
+dl dd { margin-bottom: 0.75em; }
+
+/* Abbreviations */
+abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #dddddd; cursor: help; }
+
+abbr { text-transform: none; }
+
+/* Blockquotes */
+blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #dddddd; }
+blockquote cite { display: block; font-size: 0.8125em; color: #5e93b8; }
+blockquote cite:before { content: "\2014 \0020"; }
+blockquote cite a, blockquote cite a:visited { color: #5e93b8; }
+
+blockquote, blockquote p { line-height: 1.6; color: #333333; }
+
+/* Microformats */
+.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #dddddd; padding: 0.625em 0.75em; }
+.vcard li { margin: 0; display: block; }
+.vcard .fn { font-weight: bold; font-size: 0.9375em; }
+
+.vevent .summary { font-weight: bold; }
+.vevent abbr { cursor: auto; text-decoration: none; font-weight: bold; border: none; padding: 0 0.0625em; }
+
+@media only screen and (min-width: 768px) { h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+  h1 { font-size: 2.75em; }
+  h2 { font-size: 2.3125em; }
+  h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
+  h4 { font-size: 1.4375em; } }
+/* Tables */
+table { background: white; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
+table thead, table tfoot { background: -webkit-linear-gradient(top, #add386, #90b66a); font-weight: bold; }
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: white; text-align: left; }
+table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #6d6e71; }
+table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #edf2f2; }
+table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.4; }
+
+body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+
+a:hover, a:focus { text-decoration: underline; }
+
+.clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
+.clearfix:after, .float-group:after { clear: both; }
+
+*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: white; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
+*:not(pre) > code.nobreak { word-wrap: normal; }
+*:not(pre) > code.nowrap { white-space: nowrap; }
+
+pre, pre > code { line-height: 1.6; color: #264357; font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; }
+
+em em { font-style: normal; }
+
+strong strong { font-weight: normal; }
+
+.keyseq { color: #333333; }
+
+kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
+
+.keyseq kbd:first-child { margin-left: 0; }
+
+.keyseq kbd:last-child { margin-right: 0; }
+
+.menuseq, .menuref { color: #000; }
+
+.menuseq b:not(.caret), .menuref { font-weight: inherit; }
+
+.menuseq { word-spacing: -0.02em; }
+.menuseq b.caret { font-size: 1.25em; line-height: 0.8; }
+.menuseq i.caret { font-weight: bold; text-align: center; width: 0.45em; }
+
+b.button:before, b.button:after { position: relative; top: -1px; font-weight: normal; }
+
+b.button:before { content: "["; padding: 0 3px 0 2px; }
+
+b.button:after { content: "]"; padding: 0 2px 0 3px; }
+
+#header, #content, #footnotes, #footer { width: 100%; margin-left: auto; margin-right: auto; margin-top: 0; margin-bottom: 0; max-width: 62.5em; *zoom: 1; position: relative; padding-left: 1.5em; padding-right: 1.5em; }
+#header:before, #header:after, #content:before, #content:after, #footnotes:before, #footnotes:after, #footer:before, #footer:after { content: " "; display: table; }
+#header:after, #content:after, #footnotes:after, #footer:after { clear: both; }
+
+#content { margin-top: 1.25em; }
+
+#content:before { content: none; }
+
+#header > h1:first-child { color: black; margin-top: 2.25rem; margin-bottom: 0; }
+#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #dddddd; }
+#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #dddddd; padding-bottom: 8px; }
+#header .details { border-bottom: 1px solid #dddddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #5e93b8; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
+#header .details span:first-child { margin-left: -0.125em; }
+#header .details span.email a { color: #333333; }
+#header .details br { display: none; }
+#header .details br + span:before { content: "\00a0\2013\00a0"; }
+#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333333; }
+#header .details br + span#revremark:before { content: "\00a0|\00a0"; }
+#header #revnumber { text-transform: capitalize; }
+#header #revnumber:after { content: "\00a0"; }
+
+#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #dddddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
+
+#toc { border-bottom: 0 solid #dddddd; padding-bottom: 0.5em; }
+#toc > ul { margin-left: 0.125em; }
+#toc ul.sectlevel0 > li > a { font-style: italic; }
+#toc ul.sectlevel0 ul.sectlevel1 { margin: 0.5em 0; }
+#toc ul { font-family: Noto, sans-serif; list-style-type: none; }
+#toc li { line-height: 1.3334; margin-top: 0.3334em; }
+#toc a { text-decoration: none; }
+#toc a:active { text-decoration: underline; }
+
+#toctitle { color: black; font-size: 1.2em; }
+
+@media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
+  body.toc2 { padding-left: 15em; padding-right: 0; }
+  #toc.toc2 { margin-top: 0 !important; background-color: white; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #dddddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
+  #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
+  #toc.toc2 > ul { font-size: 0.9em; margin-bottom: 0; }
+  #toc.toc2 ul ul { margin-left: 0; padding-left: 1em; }
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 15em; }
+  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #dddddd; left: auto; right: 0; } }
+@media only screen and (min-width: 1280px) { body.toc2 { padding-left: 20em; padding-right: 0; }
+  #toc.toc2 { width: 20em; }
+  #toc.toc2 #toctitle { font-size: 1.375em; }
+  #toc.toc2 > ul { font-size: 0.95em; }
+  #toc.toc2 ul ul { padding-left: 1.25em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 20em; } }
+#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+#content #toc > :first-child { margin-top: 0; }
+#content #toc > :last-child { margin-bottom: 0; }
+
+#footer { max-width: 100%; background-color: none; padding: 1.25em; }
+
+#footer-text { color: black; line-height: 1.44; }
+
+#content { margin-bottom: 0.625em; }
+
+.sect1 { padding-bottom: 0.625em; }
+
+@media only screen and (min-width: 768px) { #content { margin-bottom: 1.25em; }
+  .sect1 { padding-bottom: 1.25em; } }
+.sect1:last-child { padding-bottom: 0; }
+
+.sect1 + .sect1 { border-top: 0 solid #dddddd; }
+
+#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
+#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
+#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover { visibility: visible; }
+#content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link { color: black; text-decoration: none; }
+#content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover { color: black; }
+
+.audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock { margin-bottom: 1.25em; }
+
+.admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { text-rendering: optimizeLegibility; text-align: left; }
+
+table.tableblock > caption.title { white-space: nowrap; overflow: visible; max-width: 0; }
+
+.paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { color: black; }
+
+table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-size: inherit; }
+
+.admonitionblock > table { border-collapse: separate; border: 0; background: none; width: 100%; }
+.admonitionblock > table td.icon { text-align: center; width: 80px; }
+.admonitionblock > table td.icon img { max-width: initial; }
+.admonitionblock > table td.icon .title { font-weight: bold; font-family: Noto, sans-serif; text-transform: uppercase; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #dddddd; color: #5e93b8; }
+.admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
+
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.exampleblock > .content > :first-child { margin-top: 0; }
+.exampleblock > .content > :last-child { margin-bottom: 0; }
+
+.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.sidebarblock > :first-child { margin-top: 0; }
+.sidebarblock > :last-child { margin-bottom: 0; }
+.sidebarblock > .content > .title { color: black; margin-top: 0; }
+
+.exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
+
+.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eeeeee; }
+.sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
+
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
+.literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
+@media only screen and (min-width: 768px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 0.90625em; } }
+@media only screen and (min-width: 1280px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 1em; } }
+
+.literalblock.output pre { color: #eeeeee; background-color: #264357; }
+
+.listingblock pre.highlightjs { padding: 0; }
+.listingblock pre.highlightjs > code { padding: 1.25em 1.5625em 1.125em 1.5625em; -webkit-border-radius: 0; border-radius: 0; }
+
+.listingblock > .content { position: relative; }
+
+.listingblock code[data-lang]:before { display: none; content: attr(data-lang); position: absolute; font-size: 0.75em; top: 0.425rem; right: 0.5rem; line-height: 1; text-transform: uppercase; color: #999; }
+
+.listingblock:hover code[data-lang]:before { display: block; }
+
+.listingblock.terminal pre .command:before { content: attr(data-prompt); padding-right: 0.5em; color: #999; }
+
+.listingblock.terminal pre .command:not([data-prompt]):before { content: "$"; }
+
+table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
+
+table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; line-height: 1.6; }
+
+table.pyhltable td.code { padding-left: .75em; padding-right: 0; }
+
+pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #dddddd; }
+
+pre.pygments .lineno { display: inline-block; margin-right: .25em; }
+
+table.pyhltable .linenodiv { background: none !important; padding-right: 0 !important; }
+
+.quoteblock { margin: 0 1em 0.75em 1.5em; display: table; }
+.quoteblock > .title { margin-left: -1.5em; margin-bottom: 0.75em; }
+.quoteblock blockquote, .quoteblock blockquote p { color: #333333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
+.quoteblock blockquote { margin: 0; padding: 0; border: 0; }
+.quoteblock blockquote:before { content: "\201c"; float: left; font-size: 2.75em; font-weight: bold; line-height: 0.6em; margin-left: -0.6em; color: black; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
+.quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
+.quoteblock .attribution { margin-top: 0.5em; margin-right: 0.5ex; text-align: right; }
+.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #5e93b8; }
+.quoteblock .quoteblock blockquote { padding: 0 0 0 0.75em; }
+.quoteblock .quoteblock blockquote:before { display: none; }
+
+.verseblock { margin: 0 1em 0.75em 1em; }
+.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333333; font-weight: 300; text-rendering: optimizeLegibility; }
+.verseblock pre strong { font-weight: 400; }
+.verseblock .attribution { margin-top: 1.25rem; margin-left: 0.5ex; }
+
+.quoteblock .attribution, .verseblock .attribution { font-size: 0.8125em; line-height: 1.45; font-style: italic; }
+.quoteblock .attribution br, .verseblock .attribution br { display: none; }
+.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #5e93b8; }
+
+.quoteblock.abstract { margin: 0 0 0.75em 0; display: block; }
+.quoteblock.abstract blockquote, .quoteblock.abstract blockquote p { text-align: left; word-spacing: 0; }
+.quoteblock.abstract blockquote:before, .quoteblock.abstract blockquote p:first-of-type:before { display: none; }
+
+table.tableblock { max-width: 100%; border-collapse: separate; }
+table.tableblock td > .paragraph:last-child p > p:last-child, table.tableblock th > p:last-child, table.tableblock td > p:last-child { margin-bottom: 0; }
+
+table.tableblock, th.tableblock, td.tableblock { border: 0 solid #d8d8ce; }
+
+table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock { border-width: 0 1px 1px 0; }
+
+table.grid-all > tfoot > tr > .tableblock { border-width: 1px 1px 0 0; }
+
+table.grid-cols > * > tr > .tableblock { border-width: 0 1px 0 0; }
+
+table.grid-rows > thead > tr > .tableblock, table.grid-rows > tbody > tr > .tableblock { border-width: 0 0 1px 0; }
+
+table.grid-rows > tfoot > tr > .tableblock { border-width: 1px 0 0 0; }
+
+table.grid-all > * > tr > .tableblock:last-child, table.grid-cols > * > tr > .tableblock:last-child { border-right-width: 0; }
+
+table.grid-all > tbody > tr:last-child > .tableblock, table.grid-all > thead:last-child > tr > .tableblock, table.grid-rows > tbody > tr:last-child > .tableblock, table.grid-rows > thead:last-child > tr > .tableblock { border-bottom-width: 0; }
+
+table.frame-all { border-width: 1px; }
+
+table.frame-sides { border-width: 0 1px; }
+
+table.frame-topbot { border-width: 1px 0; }
+
+th.halign-left, td.halign-left { text-align: left; }
+
+th.halign-right, td.halign-right { text-align: right; }
+
+th.halign-center, td.halign-center { text-align: center; }
+
+th.valign-top, td.valign-top { vertical-align: top; }
+
+th.valign-bottom, td.valign-bottom { vertical-align: bottom; }
+
+th.valign-middle, td.valign-middle { vertical-align: middle; }
+
+table thead th, table tfoot th { font-weight: bold; }
+
+tbody tr th { display: table-cell; line-height: 1.4; background: -webkit-linear-gradient(top, #add386, #90b66a); }
+
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: white; font-weight: bold; }
+
+p.tableblock > code:only-child { background: none; padding: 0; }
+
+p.tableblock { font-size: 1em; }
+
+td > div.verse { white-space: pre; }
+
+ol { margin-left: 1.75em; }
+
+ul li ol { margin-left: 1.5em; }
+
+dl dd { margin-left: 1.125em; }
+
+dl dd:last-child, dl dd:last-child > :last-child { margin-bottom: 0; }
+
+ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .ulist, .ulist .olist, .olist .ulist { margin-bottom: 0.375em; }
+
+ul.checklist, ul.none, ol.none, ul.no-bullet, ol.no-bullet, ol.unnumbered, ul.unstyled, ol.unstyled { list-style-type: none; }
+
+ul.no-bullet, ol.no-bullet, ol.unnumbered { margin-left: 0.625em; }
+
+ul.unstyled, ol.unstyled { margin-left: 0; }
+
+ul.checklist { margin-left: 0.625em; }
+
+ul.checklist li > p:first-child > .fa-square-o:first-child, ul.checklist li > p:first-child > .fa-check-square-o:first-child { width: 1.25em; font-size: 0.8em; position: relative; bottom: 0.125em; }
+
+ul.checklist li > p:first-child > input[type="checkbox"]:first-child { margin-right: 0.25em; }
+
+ul.inline { display: -ms-flexbox; display: -webkit-box; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; list-style: none; margin: 0 0 0.375em -0.75em; }
+
+ul.inline > li { margin-left: 0.75em; }
+
+.unstyled dl dt { font-weight: normal; font-style: normal; }
+
+ol.arabic { list-style-type: decimal; }
+
+ol.decimal { list-style-type: decimal-leading-zero; }
+
+ol.loweralpha { list-style-type: lower-alpha; }
+
+ol.upperalpha { list-style-type: upper-alpha; }
+
+ol.lowerroman { list-style-type: lower-roman; }
+
+ol.upperroman { list-style-type: upper-roman; }
+
+ol.lowergreek { list-style-type: lower-greek; }
+
+.hdlist > table, .colist > table { border: 0; background: none; }
+.hdlist > table > tbody > tr, .colist > table > tbody > tr { background: none; }
+
+td.hdlist1, td.hdlist2 { vertical-align: top; padding: 0 0.625em; }
+
+td.hdlist1 { font-weight: bold; padding-bottom: 0.75em; }
+
+.literalblock + .colist, .listingblock + .colist { margin-top: -0.5em; }
+
+.colist > table tr > td:first-of-type { padding: 0.4em 0.75em 0 0.75em; line-height: 1; vertical-align: top; }
+.colist > table tr > td:first-of-type img { max-width: initial; }
+.colist > table tr > td:last-of-type { padding: 0.25em 0; }
+
+.thumb, .th { line-height: 0; display: inline-block; border: solid 4px white; -webkit-box-shadow: 0 0 0 1px #dddddd; box-shadow: 0 0 0 1px #dddddd; }
+
+.imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
+.imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
+.imageblock > .title { margin-bottom: 0; }
+.imageblock.thumb, .imageblock.th { border-width: 6px; }
+.imageblock.thumb > .title, .imageblock.th > .title { padding: 0 0.125em; }
+
+.image.left, .image.right { margin-top: 0.25em; margin-bottom: 0.25em; display: inline-block; line-height: 0; }
+.image.left { margin-right: 0.625em; }
+.image.right { margin-left: 0.625em; }
+
+a.image { text-decoration: none; display: inline-block; }
+a.image object { pointer-events: none; }
+
+sup.footnote, sup.footnoteref { font-size: 0.875em; position: static; vertical-align: super; }
+sup.footnote a, sup.footnoteref a { text-decoration: none; }
+sup.footnote a:active, sup.footnoteref a:active { text-decoration: underline; }
+
+#footnotes { padding-top: 0.75em; padding-bottom: 0.75em; margin-bottom: 0.625em; }
+#footnotes hr { width: 20%; min-width: 6.25em; margin: -0.25em 0 0.75em 0; border-width: 1px 0 0 0; }
+#footnotes .footnote { padding: 0 0.375em 0 0.225em; line-height: 1.3334; font-size: 0.875em; margin-left: 1.2em; margin-bottom: 0.2em; }
+#footnotes .footnote a:first-of-type { font-weight: bold; text-decoration: none; margin-left: -1.05em; }
+#footnotes .footnote:last-of-type { margin-bottom: 0; }
+#content #footnotes { margin-top: -0.625em; margin-bottom: 0; padding: 0.75em 0; }
+
+.gist .file-data > table { border: 0; background: #fff; width: 100%; margin-bottom: 0; }
+.gist .file-data > table td.line-data { width: 99%; }
 
 div.unbreakable { page-break-inside: avoid; }
 
+.big { font-size: larger; }
 
-/*
- * xhtml11 specific
- *
- * */
+.small { font-size: smaller; }
 
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
+.underline { text-decoration: underline; }
 
+.overline { text-decoration: overline; }
 
-/*
- * html5 specific
- *
- * */
+.line-through { text-decoration: line-through; }
 
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
+.aqua { color: #00bfbf; }
 
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
+.aqua-background { background-color: #00fafa; }
 
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
+.black { color: black; }
 
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
+.black-background { background-color: black; }
 
+.blue { color: #0000bf; }
 
-/*
- * manpage specific
- *
- * */
+.blue-background { background-color: #0000fa; }
 
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
+.fuchsia { color: #bf00bf; }
 
-@media print {
-  body.manpage div#toc { display: none; }
-}
+.fuchsia-background { background-color: #fa00fa; }
 
+.gray { color: #606060; }
 
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
+.gray-background { background-color: #7d7d7d; }
 
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
+.green { color: #006000; }
 
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
+.green-background { background-color: #007d00; }
 
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
+.lime { color: #00bf00; }
 
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
+.lime-background { background-color: #00fa00; }
+
+.maroon { color: #600000; }
+
+.maroon-background { background-color: #7d0000; }
+
+.navy { color: #000060; }
+
+.navy-background { background-color: #00007d; }
+
+.olive { color: #606000; }
+
+.olive-background { background-color: #7d7d00; }
+
+.purple { color: #600060; }
+
+.purple-background { background-color: #7d007d; }
+
+.red { color: #bf0000; }
+
+.red-background { background-color: #fa0000; }
+
+.silver { color: #909090; }
+
+.silver-background { background-color: #bcbcbc; }
+
+.teal { color: #006060; }
+
+.teal-background { background-color: #007d7d; }
+
+.white { color: #bfbfbf; }
+
+.white-background { background-color: #fafafa; }
+
+.yellow { color: #bfbf00; }
+
+.yellow-background { background-color: #fafa00; }
+
+span.icon > .fa { cursor: default; }
+a span.icon > .fa { cursor: inherit; }
+
+.admonitionblock td.icon [class^="fa icon-"] { font-size: 2.5em; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5); cursor: default; }
+.admonitionblock td.icon .icon-note:before { content: "\f05a"; color: #29475c; }
+.admonitionblock td.icon .icon-tip:before { content: "\f0eb"; text-shadow: 1px 1px 2px rgba(155, 155, 0, 0.8); color: #111; }
+.admonitionblock td.icon .icon-warning:before { content: "\f071"; color: #bf6900; }
+.admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #bf3400; }
+.admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
+
+.conum[data-value] { display: inline-block; color: #fff !important; background-color: black; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; font-size: 0.75em; width: 1.67em; height: 1.67em; line-height: 1.67em; font-family: "Open Sans", "DejaVu Sans", sans-serif; font-style: normal; font-weight: bold; }
+.conum[data-value] * { color: #fff !important; }
+.conum[data-value] + b { display: none; }
+.conum[data-value]:after { content: attr(data-value); }
+pre .conum[data-value] { position: relative; top: -0.125em; }
+
+b.conum * { color: inherit !important; }
+
+.conum:not([data-value]):empty { display: none; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #dddddd; }
+
+.sect1 { padding-bottom: 0; }
+
+#toctitle { color: #00406F; font-weight: normal; margin-top: 1.5em; }
+
+.sidebarblock { border-color: #aaa; }
+
+code { -webkit-border-radius: 4px; border-radius: 4px; }
+
+p.tableblock.header { color: #6d6e71; }
+
+.literalblock pre, .listingblock pre { background: #eeeeee; }
+
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
-</head>
-<body class="article">
+<link rel="stylesheet" href="../katex/katex.min.css">
+<script src="../katex/katex.min.js"></script>
+<script src="../katex/contrib/auto-render.min.js"></script>
+    <!-- Use KaTeX to render math once document is loaded, see
+         https://github.com/Khan/KaTeX/tree/master/contrib/auto-render -->
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        renderMathInElement(
+            document.body,
+            {
+                delimiters: [
+                    { left: "$$", right: "$$", display: true},
+                    { left: "\\[", right: "\\]", display: true},
+                    { left: "$", right: "$", display: false},
+                    { left: "\\(", right: "\\)", display: false}
+                ]
+            }
+        );
+    });
+</script></head>
+<body class="book">
 <div id="header">
 <h1>cl_intel_subgroups</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div class="details">
+<span id="revnumber">version V2.2-11-30-g5ba09e4,</span>
+<span id="revdate">Thu, 24 Oct 2019 22:38:28 +0000</span>
+<br><span id="revremark">from git branch: public_master commit: 5ba09e43bb29a2292d6af0b70148a9f846e1806f</span>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p><span class="monospaced">cl_intel_subgroups</span></p></div>
+<div class="paragraph">
+<p><code>cl_intel_subgroups</code></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel (ben <em>dot</em> ashbaugh <em>at</em> intel <em>dot</em> com)</p></div>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel (ben 'dot' ashbaugh 'at' intel 'dot' com)</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel<br>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel<br>
 Allen Hux, Intel<br>
 Pranayini Gudali, Intel<br>
 Dawid Dominiak, Intel<br>
-Biju George, Intel</p></div>
+Biju George, Intel</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2019 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Final Draft</p></div>
+<div class="paragraph">
+<p>Final Draft</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Built On: 2019-01-15<br>
-Revision: 7</p></div>
+<div class="paragraph">
+<p>Built On: 2019-10-23<br>
+Revision: 8</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>OpenCL 1.2 is required.
-Some features (<span class="monospaced">get_num_enqueued_sub_groups()</span> and the <span class="monospaced">sub_group_barrier()</span> function that accept a memory scope) require OpenCL 2.0.</p></div>
-<div class="paragraph"><p>This extension is written against revision 24 of the OpenCL 2.0 API specification, against revision 24 of the OpenCL 2.0 OpenCL C specification, and against revision 24 of the OpenCL 2.0 extension specification.</p></div>
+<div class="paragraph">
+<p>OpenCL 1.2 is required.
+Some features (<code>get_num_enqueued_sub_groups()</code> and the <code>sub_group_barrier()</code> function that accept a memory scope) require OpenCL 2.0.</p>
+</div>
+<div class="paragraph">
+<p>This extension is written against revision 24 of the OpenCL 2.0 API specification, against revision 24 of the OpenCL 2.0 OpenCL C specification, and against revision 24 of the OpenCL 2.0 extension specification.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>The goal of this extension is to allow programmers to improve the performance of their applications by taking advantage of the fact that some work items in a work group execute together as a group (a "subgroup"), and that work items in a subgroup can take advantage of hardware features that are not available to work items in a work group.
-Specifically, this extension is designed to allow work items in a subgroup to share data without the use of local memory and work group barriers, and to utilize specialized hardware to load and store blocks of data.</p></div>
-<div class="paragraph"><p>There is a large amount of overlap between the functionality in this extension and the functionality in the Khronos subgroups extension <span class="monospaced">cl_khr_subgroups</span>, so this extension reuses many of the names, concepts, and functions already described by the <span class="monospaced">cl_khr_subgroups</span> extension.
-The key differences between the Intel subgroups extension and the Khronos subgroups extension are:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>The goal of this extension is to allow programmers to improve the performance of their applications by taking advantage of the fact that some work items in a work group execute together as a group (a "subgroup"), and that work items in a subgroup can take advantage of hardware features that are not available to work items in a work group.
+Specifically, this extension is designed to allow work items in a subgroup to share data without the use of local memory and work group barriers, and to utilize specialized hardware to load and store blocks of data.</p>
+</div>
+<div class="paragraph">
+<p>There is a large amount of overlap between the functionality in this extension and the functionality in the Khronos subgroups extension <code>cl_khr_subgroups</code>, so this extension reuses many of the names, concepts, and functions already described by the <code>cl_khr_subgroups</code> extension.
+The key differences between the Intel subgroups extension and the Khronos subgroups extension are:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-The Khronos subgroups extension requires OpenCL 2.0, but the Intel subgroups extension may be available on OpenCL 1.2 devices.
-</p>
+<p>The Khronos subgroups extension requires OpenCL 2.0, but the Intel subgroups extension may be available on OpenCL 1.2 devices.</p>
 </li>
 <li>
-<p>
-The Khronos subgroups extension guarantees that subgroups in a work group will make independent forward progress, but the Intel extension does not guarantee that subgroups in a work group will make independent forward progress.
-</p>
+<p>The Khronos subgroups extension guarantees that subgroups in a work group will make independent forward progress, but the Intel extension does not guarantee that subgroups in a work group will make independent forward progress.</p>
 </li>
 <li>
-<p>
-The Intel extension adds a rich set of subgroup "shuffle" functions to allow work items within a work group to interchange data without the use of local memory and work group barriers.
-</p>
+<p>The Intel extension adds a rich set of subgroup "shuffle" functions to allow work items within a work group to interchange data without the use of local memory and work group barriers.</p>
 </li>
 <li>
-<p>
-The Intel extension adds a set of subgroup "block read and write" functions to take advantage of specialized hardware to read or write blocks of data from or to buffers or images.
-</p>
+<p>The Intel extension adds a set of subgroup "block read and write" functions to take advantage of specialized hardware to read or write blocks of data from or to buffers or images.</p>
 </li>
 <li>
-<p>
-The Intel subgroups extension does not include the subgroup pipes functions that are included as part of the Khronos subgroups extension.
-</p>
+<p>The Intel subgroups extension does not include the subgroup pipes functions that are included as part of the Khronos subgroups extension.</p>
 </li>
 <li>
-<p>
-The Intel subgroups extension does not include the device-side kernel query functions for subgroups that are included as part of the Khronos subgroups extension.
-</p>
+<p>The Intel subgroups extension does not include the device-side kernel query functions for subgroups that are included as part of the Khronos subgroups extension.</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_functions">New API Functions</h2>
 <div class="sectionbody">
-<div class="dlist"><dl>
-<dt class="hdlist1">
-This function is copied unchanged from the Khronos subgroups extension: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">This function is copied unchanged from the Khronos subgroups extension: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">cl_int</span> <span style="font-weight: bold"><span style="color: #000000">clGetKernelSubGroupInfoKHR</span></span><span style="color: #990000">(</span>
-    <span style="color: #008080">cl_kernel</span> kernel<span style="color: #990000">,</span>
-    <span style="color: #008080">cl_device_id</span> device<span style="color: #990000">,</span>
-    <span style="color: #008080">cl_kernel_sub_group_info</span> param_name<span style="color: #990000">,</span>
-    <span style="color: #008080">size_t</span> input_value_size<span style="color: #990000">,</span>
-    <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #009900">void</span><span style="color: #990000">*</span> input_value<span style="color: #990000">,</span>
-    <span style="color: #008080">size_t</span> param_value_size<span style="color: #990000">,</span>
-    <span style="color: #009900">void</span><span style="color: #990000">*</span> param_value<span style="color: #990000">,</span>
-    size_t<span style="color: #990000">*</span> param_value_size_ret<span style="color: #990000">)</span></tt></pre></div></div>
-</div></div>
+<div class="content">
+<pre class="highlight"><code>cl_int clGetKernelSubGroupInfoKHR(
+    cl_kernel kernel,
+    cl_device_id device,
+    cl_kernel_sub_group_info param_name,
+    size_t input_value_size,
+    const void* input_value,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_value_size_ret)</code></pre>
+</div>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_enums">New API Enums</h2>
 <div class="sectionbody">
-<div class="dlist"><dl>
-<dt class="hdlist1">
-These enums are copied unchanged from the Khronos subgroups extension: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">These enums are copied unchanged from the Khronos subgroups extension: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>Accepted as the <em>param_name</em> parameter of <strong>clGetKernelSubGroupInfoKHR</strong>:</p></div>
+<div class="paragraph">
+<p>Accepted as the <em>param_name</em> parameter of <strong>clGetKernelSubGroupInfoKHR</strong>:</p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt>CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR    <span style="color: #993399">0x2033</span>
-CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR       <span style="color: #993399">0x2034</span></tt></pre></div></div>
-</div></div>
+<div class="content">
+<pre class="highlight"><code>CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR    0x2033
+CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR       0x2034</code></pre>
+</div>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_opencl_c_functions">New OpenCL C Functions</h2>
 <div class="sectionbody">
-<div class="dlist"><dl>
-<dt class="hdlist1">
-These built-in functions are copied unchanged from the Khronos subgroups extension: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">These built-in functions are copied unchanged from the Khronos subgroups extension: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span>    <span style="font-weight: bold"><span style="color: #000000">get_sub_group_size</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">);</span>
-<span style="color: #008080">uint</span>    <span style="font-weight: bold"><span style="color: #000000">get_max_sub_group_size</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">);</span>
-<span style="color: #008080">uint</span>    <span style="font-weight: bold"><span style="color: #000000">get_num_sub_groups</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">);</span>
+<div class="content">
+<pre class="highlight"><code>uint    get_sub_group_size( void );
+uint    get_max_sub_group_size( void );
+uint    get_num_sub_groups( void );
 
-<span style="color: #008080">uint</span>    <span style="font-weight: bold"><span style="color: #000000">get_sub_group_id</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">);</span>
-<span style="color: #008080">uint</span>    <span style="font-weight: bold"><span style="color: #000000">get_sub_group_local_id</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">);</span>
+uint    get_sub_group_id( void );
+uint    get_sub_group_local_id( void );
 
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">sub_group_barrier</span></span><span style="color: #990000">(</span> <span style="color: #008080">cl_mem_fence_flags</span> flags <span style="color: #990000">);</span>
+void    sub_group_barrier( cl_mem_fence_flags flags );
 
-<span style="color: #009900">int</span>     <span style="font-weight: bold"><span style="color: #000000">sub_group_all</span></span><span style="color: #990000">(</span> <span style="color: #009900">int</span> predicate <span style="color: #990000">);</span>
-<span style="color: #009900">int</span>     <span style="font-weight: bold"><span style="color: #000000">sub_group_any</span></span><span style="color: #990000">(</span> <span style="color: #009900">int</span> predicate <span style="color: #990000">);</span></tt></pre></div></div>
-<div class="paragraph"><p>If OpenCL 2.0 is supported:</p></div>
+int     sub_group_all( int predicate );
+int     sub_group_any( int predicate );</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>If OpenCL 2.0 is supported:</p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span>    <span style="font-weight: bold"><span style="color: #000000">get_enqueued_num_sub_groups</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">);</span>
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">sub_group_barrier</span></span><span style="color: #990000">(</span> <span style="color: #008080">cl_mem_fence_flags</span> flags<span style="color: #990000">,</span> <span style="color: #008080">memory_scope</span> scope <span style="color: #990000">);</span></tt></pre></div></div>
-<div class="paragraph"><p>For the sub_group_broadcast functions, <span class="monospaced">gentype</span> is <span class="monospaced">int</span>, <span class="monospaced">uint</span>, <span class="monospaced">long</span>, <span class="monospaced">ulong</span>, or <span class="monospaced">float</span>.</p></div>
-<div class="paragraph"><p>If cl_khr_fp16 is supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">half</span>.</p></div>
-<div class="paragraph"><p>If cl_khr_fp64 or doubles are supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">double</span>.</p></div>
+<div class="content">
+<pre class="highlight"><code>uint    get_enqueued_num_sub_groups( void );
+void    sub_group_barrier( cl_mem_fence_flags flags, memory_scope scope );</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>For the sub_group_broadcast functions, <code>gentype</code> is <code>int</code>, <code>uint</code>, <code>long</code>, <code>ulong</code>, or <code>float</code>.</p>
+</div>
+<div class="paragraph">
+<p>If cl_khr_fp16 is supported, <code>gentype</code> also includes <code>half</code>.</p>
+</div>
+<div class="paragraph">
+<p>If cl_khr_fp64 or doubles are supported, <code>gentype</code> also includes <code>double</code>.</p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_broadcast</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">,</span> <span style="color: #008080">uint</span> sub_group_local_id <span style="color: #990000">);</span></tt></pre></div></div>
-<div class="paragraph"><p>For the sub_group_reduce, sub_group_scan_exclusive, and sub_group_scan_inclusive functions, <span class="monospaced">gentype</span> is <span class="monospaced">int</span>, <span class="monospaced">uint</span>, <span class="monospaced">long</span>, <span class="monospaced">ulong</span>, or <span class="monospaced">float</span>.</p></div>
-<div class="paragraph"><p>If cl_khr_fp16 is supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">half</span>.</p></div>
-<div class="paragraph"><p>If cl_khr_fp64 or doubles are supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">double</span>.</p></div>
+<div class="content">
+<pre class="highlight"><code>gentype sub_group_broadcast( gentype x, uint sub_group_local_id );</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>For the sub_group_reduce, sub_group_scan_exclusive, and sub_group_scan_inclusive functions, <code>gentype</code> is <code>int</code>, <code>uint</code>, <code>long</code>, <code>ulong</code>, or <code>float</code>.</p>
+</div>
+<div class="paragraph">
+<p>If cl_khr_fp16 is supported, <code>gentype</code> also includes <code>half</code>.</p>
+</div>
+<div class="paragraph">
+<p>If cl_khr_fp64 or doubles are supported, <code>gentype</code> also includes <code>double</code>.</p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
+<div class="content">
+<pre class="highlight"><code>gentype sub_group_reduce_add( gentype x )
+gentype sub_group_reduce_min( gentype x )
+gentype sub_group_reduce_max( gentype x )
 
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
+gentype sub_group_scan_exclusive_add( gentype x )
+gentype sub_group_scan_exclusive_min( gentype x )
+gentype sub_group_scan_exclusive_max( gentype x )
 
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span></tt></pre></div></div>
-</div></div>
+gentype sub_group_scan_inclusive_add( gentype x)
+gentype sub_group_scan_inclusive_min( gentype x)
+gentype sub_group_scan_inclusive_max( gentype x)</code></pre>
+</div>
+</div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-These built-in functions are unique to the Intel subgroups extension and are not part of the Khronos subgroups extension: 
-</dt>
+<dt class="hdlist1">These built-in functions are unique to the Intel subgroups extension and are not part of the Khronos subgroups extension: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>For the sub_group_shuffle, sub_group_shuffle_down, sub_group_shuffle_up, and sub_group_shuffle_xor functions, <span class="monospaced">gentype</span> is <span class="monospaced">float</span>, <span class="monospaced">float2</span>, <span class="monospaced">float4</span>, <span class="monospaced">float8</span>, <span class="monospaced">float16</span>, <span class="monospaced">int</span>, <span class="monospaced">int2</span>, <span class="monospaced">int4</span>, <span class="monospaced">int8</span>, <span class="monospaced">int16</span>, <span class="monospaced">uint</span>, <span class="monospaced">uint2</span>,<span class="monospaced">uint4</span>, <span class="monospaced">uint8</span>, <span class="monospaced">uint16</span>, <span class="monospaced">long</span>, or <span class="monospaced">ulong</span>.</p></div>
-<div class="paragraph"><p>If cl_khr_fp16 is supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">half</span>.</p></div>
-<div class="paragraph"><p>If cl_khr_fp64 or doubles are supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">double</span>.</p></div>
+<div class="paragraph">
+<p>For the sub_group_shuffle, sub_group_shuffle_down, sub_group_shuffle_up, and sub_group_shuffle_xor functions, <code>gentype</code> is <code>float</code>, <code>float2</code>, <code>float3</code>, <code>float4</code>, <code>float8</code>, <code>float16</code>, <code>int</code>, <code>int2</code>, <code>int3</code>, <code>int4</code>, <code>int8</code>, <code>int16</code>, <code>uint</code>, <code>uint2</code>, <code>uint3</code>, <code>uint4</code>, <code>uint8</code>, <code>uint16</code>, <code>long</code>, or <code>ulong</code>.</p>
+</div>
+<div class="paragraph">
+<p>If cl_khr_fp16 is supported, <code>gentype</code> also includes <code>half</code>.</p>
+</div>
+<div class="paragraph">
+<p>If cl_khr_fp64 or doubles are supported, <code>gentype</code> also includes <code>double</code>.</p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> data<span style="color: #990000">,</span> <span style="color: #008080">uint</span> c <span style="color: #990000">);</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle_down</span></span><span style="color: #990000">(</span>
-                <span style="color: #008080">gentype</span> current<span style="color: #990000">,</span> <span style="color: #008080">gentype</span> next<span style="color: #990000">,</span> <span style="color: #008080">uint</span> delta <span style="color: #990000">);</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle_up</span></span><span style="color: #990000">(</span>
-                <span style="color: #008080">gentype</span> previous<span style="color: #990000">,</span> <span style="color: #008080">gentype</span> current<span style="color: #990000">,</span> <span style="color: #008080">uint</span> delta <span style="color: #990000">);</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle_xor</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> data<span style="color: #990000">,</span> <span style="color: #008080">uint</span> value <span style="color: #990000">);</span></tt></pre></div></div>
+<div class="content">
+<pre class="highlight"><code>gentype intel_sub_group_shuffle( gentype data, uint c );
+gentype intel_sub_group_shuffle_down(
+                gentype current, gentype next, uint delta );
+gentype intel_sub_group_shuffle_up(
+                gentype previous, gentype current, uint delta );
+gentype intel_sub_group_shuffle_xor( gentype data, uint value );</code></pre>
+</div>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">);</span>
-<span style="color: #008080">uint2</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read2</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">);</span>
-<span style="color: #008080">uint4</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read4</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">);</span>
-<span style="color: #008080">uint8</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read8</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">);</span>
+<div class="content">
+<pre class="highlight"><code>uint    intel_sub_group_block_read( const __global uint* p );
+uint2   intel_sub_group_block_read2( const __global uint* p );
+uint4   intel_sub_group_block_read4( const __global uint* p );
+uint8   intel_sub_group_block_read8( const __global uint* p );
 
-<span style="color: #008080">uint</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">);</span>
-<span style="color: #008080">uint2</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read2</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">);</span>
-<span style="color: #008080">uint4</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read4</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">);</span>
-<span style="color: #008080">uint8</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read8</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">);</span>
+uint    intel_sub_group_block_read( image2d_t image, int2 byte_coord );
+uint2   intel_sub_group_block_read2( image2d_t image, int2 byte_coord );
+uint4   intel_sub_group_block_read4( image2d_t image, int2 byte_coord );
+uint8   intel_sub_group_block_read8( image2d_t image, int2 byte_coord );
 
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">);</span>
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write2</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">);</span>
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write4</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">);</span>
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write8</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">);</span>
+void    intel_sub_group_block_write( __global uint* p, uint data );
+void    intel_sub_group_block_write2( __global uint* p, uint2 data );
+void    intel_sub_group_block_write4( __global uint* p, uint4 data );
+void    intel_sub_group_block_write8( __global uint* p, uint8 data );
 
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">);</span>
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write2</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">);</span>
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write4</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">);</span>
-<span style="color: #009900">void</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write8</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">);</span></tt></pre></div></div>
-</div></div>
+void    intel_sub_group_block_write( image2d_t image, int2 byte_coord, uint data );
+void    intel_sub_group_block_write2( image2d_t image, int2 byte_coord, uint2 data );
+void    intel_sub_group_block_write4( image2d_t image, int2 byte_coord, uint4 data );
+void    intel_sub_group_block_write8( image2d_t image, int2 byte_coord, uint8 data );</code></pre>
+</div>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1033,252 +1039,275 @@ http://www.gnu.org/software/src-highlite -->
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_modifications_to_section_2_glossary">Modifications to Section 2 - "Glossary"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Add memory_scope_sub_group to the description of Memory Scopes: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Add memory_scope_sub_group to the description of Memory Scopes: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Memory Scopes 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Memory Scopes </dt>
 <dd>
-<p>
-Memory scopes define a hierarchy of visibilities when analyzing the ordering constraints of memory operations.
-They are defined by the values of the <span class="monospaced">memory_scope</span> enumeration constant.
-Current values are <span class="monospaced">memory_scope_work_item</span> (memory constraints only apply to a single work item and in practice only apply to image operations), <span class="monospaced">memory_scope_sub_group</span> (memory-ordering constraints only apply to work items executing in a subgroup), <span class="monospaced">memory_scope_work_group</span> &#8230;
-</p>
+<p>Memory scopes define a hierarchy of visibilities when analyzing the ordering constraints of memory operations.
+They are defined by the values of the <code>memory_scope</code> enumeration constant.
+Current values are <code>memory_scope_work_item</code> (memory constraints only apply to a single work item and in practice only apply to image operations), <code>memory_scope_sub_group</code> (memory-ordering constraints only apply to work items executing in a subgroup), <code>memory_scope_work_group</code> &#8230;&#8203;</p>
 </dd>
-</dl></div>
-</div></div>
+</dl>
+</div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-Add memory_scope_sub_group to the description of Scope inclusion: 
-</dt>
+<dt class="hdlist1">Add memory_scope_sub_group to the description of Scope inclusion: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Scope inclusion 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Scope inclusion </dt>
 <dd>
-<p>
-Two actions <strong>A</strong> and <strong>B</strong> are defined to have an inclusive scope if they have the same scope <strong>P</strong> such that: (1) if <strong>P</strong> is <span class="monospaced">memory_scope_sub_group</span>, and <strong>A</strong> and <strong>B</strong> are executed by work items within the same subgroup, or (2) if <strong>P</strong> is <span class="monospaced">memory_scope_work_group</span>, and <strong>A</strong> and <strong>B</strong> are executed by work items within the same workgroup &#8230;
-</p>
+<p>Two actions <strong>A</strong> and <strong>B</strong> are defined to have an inclusive scope if they have the same scope <strong>P</strong> such that: (1) if <strong>P</strong> is <code>memory_scope_sub_group</code>, and <strong>A</strong> and <strong>B</strong> are executed by work items within the same subgroup, or (2) if <strong>P</strong> is <code>memory_scope_work_group</code>, and <strong>A</strong> and <strong>B</strong> are executed by work items within the same workgroup &#8230;&#8203;</p>
 </dd>
-</dl></div>
-</div></div>
+</dl>
+</div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-Change the description for Subgroups to: 
-</dt>
+<dt class="hdlist1">Change the description for Subgroups to: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Subgroup 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Subgroup </dt>
 <dd>
-<p>
-Subgroups are an implementation-dependent grouping of work items within a
+<p>Subgroups are an implementation-dependent grouping of work items within a
 work group.
 The size and number of subgroups is implementation-defined and not exposed in the core OpenCL 2.0 feature set.
 Subgroups execute concurrently within a work group, but are not guaranteed to make independent forward progress.
-Subgroups may synchronize internally using subgroup barrier operations without synchronizing with other subgroups.
-</p>
+Subgroups may synchronize internally using subgroup barrier operations without synchronizing with other subgroups.</p>
 </dd>
-</dl></div>
-</div></div>
+</dl>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_modifications_to_section_3_2_1_execution_model_mapping_work_items_onto_an_ndrange">Modifications to Section 3.2.1 - "Execution Model: Mapping Work Items Onto an NDRange"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Change the paragraph describing subgroups to: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Change the paragraph describing subgroups to: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>An implementation of OpenCL may divide each work group into one or more subgroups.
+<div class="paragraph">
+<p>An implementation of OpenCL may divide each work group into one or more subgroups.
 The size and number of subgroups is implementation-defined and not exposed in the
-core OpenCL 2.0 feature set.</p></div>
-</div></div>
+core OpenCL 2.0 feature set.</p>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_modifications_to_section_3_2_2_execution_model_execution_of_kernel_instances">Modifications to Section 3.2.2 - "Execution Model: Execution of Kernel Instances"</h3>
-<div class="paragraph"><p>Remove the last paragraph describing subgroups and independent forward progress.</p></div>
+<div class="paragraph">
+<p>Remove the last paragraph describing subgroups and independent forward progress.</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_additions_to_section_3_2_execution_model">Additions to Section 3.2 - "Execution Model"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-This text is largely the same as the text in the Khronos subgroups extension. Only the sentence about independent forward progress has been modified: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">This text is largely the same as the text in the Khronos subgroups extension. Only the sentence about independent forward progress has been modified: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>Within a work group, work items may be divided into subgroups in an implementation-
+<div class="paragraph">
+<p>Within a work group, work items may be divided into subgroups in an implementation-
 defined fashion.  The mapping of work items to subgroups is implementation-defined
 and may be queried at runtime.  While subgroups may be used in multi-dimensional
 work groups, each subgroup is 1-dimensional and any given work item may query which
-subgroup it is a member of.</p></div>
-<div class="paragraph"><p>Work items are mapped into subgroups through a combination of compile-time decisions
+subgroup it is a member of.</p>
+</div>
+<div class="paragraph">
+<p>Work items are mapped into subgroups through a combination of compile-time decisions
 and the parameters of the dispatch.  The mapping to subgroups is invariant for the
 duration of a kernel&#8217;s execution, across dispatches of a given kernel with the same
 launch parameters, and from one work group to another within the dispatch (excluding
 the trailing edge work groups in the presence of non-uniform work group sizes).  In
 addition, all subgroups within a work group will be the same size, apart from the
 subgroup with the maximum index, which may be smaller if the size of the work group
-is not evenly divisible by the size of the subgroups.</p></div>
-<div class="paragraph"><p>Subgroups execute concurrently within a given work group.  Similar to work items
+is not evenly divisible by the size of the subgroups.</p>
+</div>
+<div class="paragraph">
+<p>Subgroups execute concurrently within a given work group.  Similar to work items
 within a work group, subgroups executing within a work group are not guaranteed to make
 independent forward progress.  Work items in a subgroup can internally synchronize
-using subgroup barrier operations without synchronizing with other subgroups.</p></div>
-</div></div>
+using subgroup barrier operations without synchronizing with other subgroups.</p>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_additions_to_section_3_3_4_memory_model_memory_consistency_model">Additions to Section 3.3.4 - "Memory Model: Memory Consistency Model"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Add memory_scope_sub_group to the bulleted descriptions of memory scopes: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Add memory_scope_sub_group to the bulleted descriptions of memory scopes: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<span class="monospaced">memory_scope_sub_group</span>: memory-ordering constraints only apply to work items executing within a single subgroup.
-</p>
+<p><code>memory_scope_sub_group</code>: memory-ordering constraints only apply to work items executing within a single subgroup.</p>
 </li>
 <li>
-<p>
-<span class="monospaced">memory_scope_work_group</span>: &#8230;
-</p>
+<p><code>memory_scope_work_group</code>: &#8230;&#8203;</p>
 </li>
-</ul></div>
-</div></div>
+</ul>
+</div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-In the paragraph after the bulleted descriptions of memory scopes, include memory_scope_sub_group as a valid memory scope for local memory: 
-</dt>
+<dt class="hdlist1">In the paragraph after the bulleted descriptions of memory scopes, include memory_scope_sub_group as a valid memory scope for local memory: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>... For local memory, <span class="monospaced">memory_scope_sub_group</span> and <span class="monospaced">memory_scope_work_group</span> are valid, and may constrain visibility to the subgroup or workgroup.</p></div>
-</div></div>
+<div class="paragraph">
+<p>... For local memory, <code>memory_scope_sub_group</code> and <code>memory_scope_work_group</code> are valid, and may constrain visibility to the subgroup or workgroup.</p>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_additions_to_section_3_3_5_memory_model_overview_of_atomic_and_fence_operations">Additions to Section 3.3.5 - "Memory Model: Overview of atomic and fence operations"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Add memory_scope_sub_group to the definition of inclusive scope: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Add memory_scope_sub_group to the definition of inclusive scope: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>P</strong> is <span class="monospaced">memory_scope_sub_group</span> and <strong>A</strong> and <strong>B</strong> are executed by work items within the same subgroup.
-</p>
+<p><strong>P</strong> is <code>memory_scope_sub_group</code> and <strong>A</strong> and <strong>B</strong> are executed by work items within the same subgroup.</p>
 </li>
 <li>
-<p>
-<strong>P</strong> is <span class="monospaced">memory_scope_work_group</span> &#8230;
-</p>
+<p><strong>P</strong> is <code>memory_scope_work_group</code> &#8230;&#8203;</p>
 </li>
-</ul></div>
-</div></div>
+</ul>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_additions_to_section_5_9_3_kernel_object_queries">Additions to Section 5.9.3 - "Kernel Object Queries"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-This addition is copied unchanged from the Khronos subgroups extension: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">This addition is copied unchanged from the Khronos subgroups extension: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>The function</p></div>
-<div class="paragraph"><p></p></div>
+<div class="paragraph">
+<p>The function</p>
+</div>
+<div class="paragraph">
+<p></p>
+</div>
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">cl_int</span> <span style="font-weight: bold"><span style="color: #000000">clGetKernelSubGroupInfoKHR</span></span><span style="color: #990000">(</span><span style="color: #008080">cl_kernel</span> kernel<span style="color: #990000">,</span>
-                                  <span style="color: #008080">cl_device_id</span> device<span style="color: #990000">,</span>
-                                  <span style="color: #008080">cl_kernel_sub_group_info</span> param_name<span style="color: #990000">,</span>
-                                  <span style="color: #008080">size_t</span> input_value_size<span style="color: #990000">,</span>
-                                  <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #009900">void</span> <span style="color: #990000">*</span>input_value<span style="color: #990000">,</span>
-                                  <span style="color: #008080">size_t</span> param_value_size<span style="color: #990000">,</span>
-                                  <span style="color: #009900">void</span> <span style="color: #990000">*</span>param_value<span style="color: #990000">,</span>
-                                  <span style="color: #008080">size_t</span> <span style="color: #990000">*</span>param_value_size_ret<span style="color: #990000">)</span></tt></pre></div></div>
-<div class="paragraph"><p>returns information about the kernel object.</p></div>
-<div class="paragraph"><p><em>kernel</em> specifies the kernel object being queried.</p></div>
-<div class="paragraph"><p><em>device</em> identifies a specific device in the list of devices associated with
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">cl_int clGetKernelSubGroupInfoKHR(cl_kernel kernel,
+                                  cl_device_id device,
+                                  cl_kernel_sub_group_info param_name,
+                                  size_t input_value_size,
+                                  const void *input_value,
+                                  size_t param_value_size,
+                                  void *param_value,
+                                  size_t *param_value_size_ret)</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>returns information about the kernel object.</p>
+</div>
+<div class="paragraph">
+<p><em>kernel</em> specifies the kernel object being queried.</p>
+</div>
+<div class="paragraph">
+<p><em>device</em> identifies a specific device in the list of devices associated with
 <em>kernel</em>.
 The list of devices is the list of devices in the OpenCL context that is
 associated with <em>kernel</em>.
 If the list of devices associated with <em>kernel</em> is a single device, <em>device</em>
-can be a <span class="monospaced">NULL</span> value.</p></div>
-<div class="paragraph"><p><em>param_name</em> specifies the information to query.
+can be a <code>NULL</code> value.</p>
+</div>
+<div class="paragraph">
+<p><em>param_name</em> specifies the information to query.
 The list of supported <em>param_name</em> types and the information returned in
-<em>param_value</em> by <strong>clGetKernelSubGroupInfoKHR</strong> is described in the table below.</p></div>
-<div class="paragraph"><p><em>input_value_size</em> is used to specify the size in bytes of memory pointed to
+<em>param_value</em> by <strong>clGetKernelSubGroupInfoKHR</strong> is described in the table below.</p>
+</div>
+<div class="paragraph">
+<p><em>input_value_size</em> is used to specify the size in bytes of memory pointed to
 by <em>input_value</em>.
-This size must be equal to the size of input type as described in the table below.</p></div>
-<div class="paragraph"><p><em>input_value</em> is a pointer to memory where the appropriate parameterization
+This size must be equal to the size of input type as described in the table below.</p>
+</div>
+<div class="paragraph">
+<p><em>input_value</em> is a pointer to memory where the appropriate parameterization
 of the query is passed from.
-If <em>input_value</em> is <span class="monospaced">NULL</span>, it is ignored.</p></div>
-<div class="paragraph"><p><em>param_value</em> is a pointer to memory where the appropriate result being
+If <em>input_value</em> is <code>NULL</code>, it is ignored.</p>
+</div>
+<div class="paragraph">
+<p><em>param_value</em> is a pointer to memory where the appropriate result being
 queried is returned.
-If <em>param_value</em> is <span class="monospaced">NULL</span>, it is ignored.</p></div>
-<div class="paragraph"><p><em>param_value_size</em> is used to specify the size in bytes of memory pointed to
+If <em>param_value</em> is <code>NULL</code>, it is ignored.</p>
+</div>
+<div class="paragraph">
+<p><em>param_value_size</em> is used to specify the size in bytes of memory pointed to
 by <em>param_value</em>.
 This size must be greater than or equal to the size of the return type as described in the
-table below.</p></div>
-<div class="paragraph"><p><em>param_value_size_ret</em> returns the actual size in bytes of data being
+table below.</p>
+</div>
+<div class="paragraph">
+<p><em>param_value_size_ret</em> returns the actual size in bytes of data being
 queried by <em>param_name</em>.
-If <em>param_value_size_ret</em> is <span class="monospaced">NULL</span>, it is ignored.</p></div>
-<table class="tableblock frame-all grid-all" id="cl_khr_subgroups-kernel-subgroup-info-table"
-style="
-width:100%;
-">
+If <em>param_value_size_ret</em> is <code>NULL</code>, it is ignored.</p>
+</div>
+<table id="cl_khr_subgroups-kernel-subgroup-info-table" class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 1. <strong>clGetKernelSubGroupInfoKHR</strong> parameter queries</caption>
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>cl_kernel_sub_group_info</strong> </th>
-<th class="tableblock halign-left valign-top" > Input Type </th>
-<th class="tableblock halign-left valign-top" > Return Type </th>
-<th class="tableblock halign-left valign-top" > Info. returned in <em>param_value</em></th>
+<th class="tableblock halign-left valign-top"><strong>cl_kernel_sub_group_info</strong></th>
+<th class="tableblock halign-left valign-top">Input Type</th>
+<th class="tableblock halign-left valign-top">Return Type</th>
+<th class="tableblock halign-left valign-top">Info. returned in <em>param_value</em></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE_KHR</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">size_t *</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">size_t</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the maximum sub-group size for this kernel.
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>CL_&#8203;KERNEL_&#8203;MAX_&#8203;SUB_&#8203;GROUP_&#8203;SIZE_&#8203;FOR_&#8203;NDRANGE_&#8203;KHR</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">size_t *</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">size_t</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the maximum sub-group size for this kernel.
             All sub-groups must be the same size, while the last subgroup in
             any work-group (i.e. the subgroup with the maximum index) could
             be the same or smaller size.</p>
@@ -1289,10 +1318,10 @@ width:100%;
             the value specified for <em>input_value_size</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CL_KERNEL_SUB_GROUP_COUNT_FOR_NDRANGE_KHR</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">size_t *</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">size_t</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the number of sub-groups that will be present in each
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>CL_&#8203;KERNEL_&#8203;SUB_&#8203;GROUP_&#8203;COUNT_&#8203;FOR_&#8203;NDRANGE_&#8203;KHR</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">size_t *</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">size_t</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the number of sub-groups that will be present in each
             work-group for a given local work size.
             All workgroups, apart from the last work-group in each dimension
             in the presence of non-uniform work-group sizes, will have the
@@ -1305,52 +1334,46 @@ width:100%;
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>clGetKernelSubGroupInfoKHR</strong> returns CL_SUCCESS if the function is executed
+<div class="paragraph">
+<p><strong>clGetKernelSubGroupInfoKHR</strong> returns CL_SUCCESS if the function is executed
 successfully.
-Otherwise, it returns one of the following errors:</p></div>
-<div class="ulist"><ul>
+Otherwise, it returns one of the following errors:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<span class="monospaced">CL_INVALID_DEVICE</span> if <em>device</em> is not in the list of devices associated
-    with <em>kernel</em> or if <em>device</em> is <span class="monospaced">NULL</span> but there is more than one device
-    associated with <em>kernel</em>.
-</p>
+<p><code>CL_INVALID_DEVICE</code> if <em>device</em> is not in the list of devices associated
+with <em>kernel</em> or if <em>device</em> is <code>NULL</code> but there is more than one device
+associated with <em>kernel</em>.</p>
 </li>
 <li>
-<p>
-<span class="monospaced">CL_INVALID_VALUE</span> if <em>param_name</em> is not valid, or if size in bytes
-    specified by <em>param_value_size</em> is less than the size of return type as described in
-    the table above and <em>param_value</em> is not <span class="monospaced">NULL</span>.
-</p>
+<p><code>CL_INVALID_VALUE</code> if <em>param_name</em> is not valid, or if size in bytes
+specified by <em>param_value_size</em> is less than the size of return type as described in
+the table above and <em>param_value</em> is not <code>NULL</code>.</p>
 </li>
 <li>
-<p>
-<span class="monospaced">CL_INVALID_VALUE</span> if <em>param_name</em> is
-    <span class="monospaced">CL_KERNEL_MAX_SUB_GROUP_SIZE_FOR_NDRANGE</span> and the size in bytes specified by
-    <em>input_value_size</em> is not valid or if <em>input_value</em> is <span class="monospaced">NULL</span>.
-</p>
+<p><code>CL_INVALID_VALUE</code> if <em>param_name</em> is
+<code>CL_&#8203;KERNEL_&#8203;MAX_&#8203;SUB_&#8203;GROUP_&#8203;SIZE_&#8203;FOR_&#8203;NDRANGE_&#8203;KHR</code> and the size in bytes specified by
+<em>input_value_size</em> is not valid or if <em>input_value</em> is <code>NULL</code>.</p>
 </li>
 <li>
-<p>
-<span class="monospaced">CL_INVALID_KERNEL</span> if <em>kernel</em> is a not a valid kernel object.
-</p>
+<p><code>CL_INVALID_KERNEL</code> if <em>kernel</em> is a not a valid kernel object.</p>
 </li>
 <li>
-<p>
-<span class="monospaced">CL_OUT_OF_RESOURCES</span> if there is a failure to allocate resources required
-    by the OpenCL implementation on the device.
-</p>
+<p><code>CL_OUT_OF_RESOURCES</code> if there is a failure to allocate resources required
+by the OpenCL implementation on the device.</p>
 </li>
 <li>
-<p>
-<span class="monospaced">CL_OUT_OF_HOST_MEMORY</span> if there is a failure to allocate resources
-    required by the OpenCL implementation on the host.
-</p>
+<p><code>CL_OUT_OF_HOST_MEMORY</code> if there is a failure to allocate resources
+required by the OpenCL implementation on the host.</p>
 </li>
-</ul></div>
-</div></div>
+</ul>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 </div>
 </div>
@@ -1359,389 +1382,386 @@ Otherwise, it returns one of the following errors:</p></div>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_additions_to_section_6_13_1_work_item_functions">Additions to section 6.13.1 - "Work Item Functions"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-These additions are copied unchanged from the Khronos subgroups extension: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">These additions are copied unchanged from the Khronos subgroups extension: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" > <strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span> <span style="font-weight: bold"><span style="color: #000000">get_sub_group_size</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the number of work items in the subgroup.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint get_sub_group_size( void )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the number of work items in the subgroup.
 This value is no more than the maximum subgroup size and is implementation-defined based on a combination of the compiled kernel and the dispatch dimensions.
 This will be a constant value for the lifetime of the subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span> <span style="font-weight: bold"><span style="color: #000000">get_max_sub_group_size</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the maximum size of a subgroup with the dispatch.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint get_max_sub_group_size( void )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the maximum size of a subgroup with the dispatch.
 This value will be invariant for a given set of dispatch dimensions and a kernel object compiled for a given device.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span> <span style="font-weight: bold"><span style="color: #000000">get_num_sub_groups</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the number of subgroups that the current work group is divided into.</p>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint get_num_sub_groups( void )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the number of subgroups that the current work group is divided into.</p>
 <p class="tableblock">This number will be constant for the duration of a work group&#8217;s execution.
 If the kernel is executed with a non-uniform work group size in any dimension, calls to this built-in may return a different values for some work groups than for other work groups.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span> <span style="font-weight: bold"><span style="color: #000000">get_sub_group_id</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the subgroup ID, which is a number from zero to <strong>get_num_sub_groups</strong> - 1.</p>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint get_sub_group_id( void )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the subgroup ID, which is a number from zero to <strong>get_num_sub_groups</strong> - 1.</p>
 <p class="tableblock">For <strong>clEnqueueTask</strong>, this returns 0.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span> <span style="font-weight: bold"><span style="color: #000000">get_sub_group_local_id</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the unique work item ID within the current subgroup.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint get_sub_group_local_id( void )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the unique work item ID within the current subgroup.
 The mapping from <strong>get_local_id</strong> to <strong>get_sub_group_local_id</strong> will be invariant for the lifetime of the work group.</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>If OpenCL 2.0 is supported:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<div class="paragraph">
+<p>If OpenCL 2.0 is supported:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" > <strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span> <span style="font-weight: bold"><span style="color: #000000">get_enqueued_num_sub_groups</span></span><span style="color: #990000">(</span> <span style="color: #009900">void</span> <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the same value as that returned by <strong>get_num_sub_groups</strong> if the kernel is executed with a uniform work group size.  This value will be constant for the entire NDRange.</p>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint get_enqueued_num_sub_groups( void )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the same value as that returned by <strong>get_num_sub_groups</strong> if the kernel is executed with a uniform work group size.  This value will be constant for the entire NDRange.</p>
 <p class="tableblock">If the kernel is executed with a non-uniform work group size, returns the number of subgroups in a work group that makes up the uniform region of the global NDRange.</p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_additions_to_section_6_13_8_synchronization_functions">Additions to Section 6.13.8 - "Synchronization Functions"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-These additions are mostly unchanged from the Khronos subgroups extension, with only minor edits for clarity: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">These additions are mostly unchanged from the Khronos subgroups extension, with only minor edits for clarity: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" > <strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_barrier</span></span><span style="color: #990000">(</span>
-         <span style="color: #008080">cl_mem_fence_flags</span> flags <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">All work items in a subgroup executing the kernel on a processor must execute this  function before any are allowed to continue execution beyond the subgroup barrier.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">void sub_group_barrier(
+         cl_mem_fence_flags flags )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">All work items in a subgroup executing the kernel on a processor must execute this  function before any are allowed to continue execution beyond the subgroup barrier.
 This function must be encountered by all work items in a subgroup executing the kernel.
 These rules apply to NDRanges implemented with uniform and non-uniform work groups.</p>
 <p class="tableblock">If <strong>sub_group_barrier</strong> is inside a conditional statement then all work items within the subgroup must enter the conditional if any work item in the subgroup enters the conditional statement and executes the <strong>sub_group_barrier</strong>.</p>
 <p class="tableblock">If <strong>sub_group_barrier</strong> is inside a loop, all work items within the subgroup must execute the <strong>sub_group_barrier</strong> for each iteration of the loop before any are allowed to continue execution beyond the <strong>sub_group_barrier</strong>.</p>
 <p class="tableblock">The <strong>sub_group_barrier</strong> function also queues a memory fence (reads and writes) to ensure correct ordering of memory operations to local or global memory.</p>
 <p class="tableblock">The flags argument specifies the memory address space and can be set to a combination of the following values:</p>
-<p class="tableblock"><span class="monospaced">CLK_LOCAL_MEM_FENCE</span> - The <strong>sub_group_barrier</strong> function will either flush any variables stored in local memory or queue a memory fence to ensure correct ordering of memory operations to local memory.</p>
-<p class="tableblock"><span class="monospaced">CLK_GLOBAL_MEM_FENCE</span> - The <strong>sub_group_barrier</strong> function will queue a memory fence to ensure correct ordering of memory operations to global memory.
+<p class="tableblock"><code>CLK_LOCAL_MEM_FENCE</code> - The <strong>sub_group_barrier</strong> function will either flush any variables stored in local memory or queue a memory fence to ensure correct ordering of memory operations to local memory.</p>
+<p class="tableblock"><code>CLK_GLOBAL_MEM_FENCE</code> - The <strong>sub_group_barrier</strong> function will queue a memory fence to ensure correct ordering of memory operations to global memory.
 This can be useful when work items, for example, write to buffer objects and then want to read the updated data from these buffer objects.</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>If OpenCL 2.0 is supported, add the following to the table above:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<div class="paragraph">
+<p>If OpenCL 2.0 is supported, add the following to the table above:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" > <strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">void</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_barrier</span></span><span style="color: #990000">(</span>
-         <span style="color: #008080">cl_mem_fence_flags</span> flags<span style="color: #990000">,</span>
-         <span style="color: #008080">memory_scope</span> scope <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&#8230;</p>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">void sub_group_barrier(
+         cl_mem_fence_flags flags,
+         memory_scope scope )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&#8230;&#8203;</p>
 <p class="tableblock">The <strong>sub_group_barrier</strong> function also supports a variant that specifies the memory scope.
-For the sub_group_barrier variant that does not take a memory scope, the scope is <span class="monospaced">memory_scope_sub_group</span>.</p>
+For the sub_group_barrier variant that does not take a memory scope, the scope is <code>memory_scope_sub_group</code>.</p>
 <p class="tableblock">The scope argument specifies whether the memory accesses of work items in the subgroup to memory address space(s) identified by flags become visible to all  work items in the subgroup, the work group, the device, or all SVM devices.</p>
-<p class="tableblock">&#8230;</p>
-<p class="tableblock"><span class="monospaced">CLK_IMAGE_MEM_FENCE</span> - The <strong>sub_group_barrier</strong> function will queue a memory fence to ensure correct ordering of memory operations to image objects.  This can be useful when work items, for example, write to image objects and then want to read the updated data from these image objects.</p></td>
+<p class="tableblock">&#8230;&#8203;</p>
+<p class="tableblock"><code>CLK_IMAGE_MEM_FENCE</code> - The <strong>sub_group_barrier</strong> function will queue a memory fence to ensure correct ordering of memory operations to image objects.  This can be useful when work items, for example, write to image objects and then want to read the updated data from these image objects.</p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_additions_to_section_6_13_11_atomic_functions">Additions to Section 6.13.11 - "Atomic Functions"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Modify the bullet describing behavior for functions that do not have a memory_scope argument to say: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Modify the bullet describing behavior for functions that do not have a memory_scope argument to say: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-The subgroup functions that do not have a <em>memory_scope</em> argument have the same semantics as the corresponding functions with the <em>memory_scope</em> argument set to <span class="monospaced">memory_scope_sub_group</span>.
-Other functions that do not have a <em>memory_scope</em> argument have the same semantics as the corresponding functions with the <em>memory_scope</em> argument set to <span class="monospaced">memory_scope_device</span>.
-</p>
+<p>The subgroup functions that do not have a <em>memory_scope</em> argument have the same semantics as the corresponding functions with the <em>memory_scope</em> argument set to <code>memory_scope_sub_group</code>.
+Other functions that do not have a <em>memory_scope</em> argument have the same semantics as the corresponding functions with the <em>memory_scope</em> argument set to <code>memory_scope_device</code>.</p>
 </li>
-</ul></div>
-</div></div>
+</ul>
+</div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-The following addition is copied unchanged from the Khronos subgroups extension: 
-</dt>
-<dt class="hdlist1">
-Add the following new value to the enumerated type memory_scope defined in Section 6.13.11.4: 
-</dt>
+<dt class="hdlist1">The following addition is copied unchanged from the Khronos subgroups extension: </dt>
+<dt class="hdlist1">Add the following new value to the enumerated type memory_scope defined in Section 6.13.11.4: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>memory_scope_sub_group</pre>
-</div></div>
-<div class="paragraph"><p>The <span class="monospaced">memory_scope_sub_group</span> specifies that the memory ordering constraints
-given by <span class="monospaced">memory_order</span> apply to work items in a subgroup.
+</div>
+</div>
+<div class="paragraph">
+<p>The <code>memory_scope_sub_group</code> specifies that the memory ordering constraints
+given by <code>memory_order</code> apply to work items in a subgroup.
 This memory scope can be used when performing atomic operations to global or
-local memory.</p></div>
-</div></div>
+local memory.</p>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_additions_to_section_6_13_15_work_group_functions">Additions to Section 6.13.15 - "Work Group Functions"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-These additions are copied from the Khronos subgroups extension: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">These additions are copied from the Khronos subgroups extension: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>The OpenCL C programming language implements the following built-in
+<div class="paragraph">
+<p>The OpenCL C programming language implements the following built-in
 functions that operate on a subgroup level.
 These built-in functions must be encountered by all work items in a subgroup
 executing the kernel.
-We use the generic type name <span class="monospaced">gentype</span> to indicate the built-in data types
-<span class="monospaced">int</span>, <span class="monospaced">uint</span>, <span class="monospaced">long</span>, <span class="monospaced">ulong</span>, or <span class="monospaced">float</span> as the type for the arguments.</p></div>
-<div class="paragraph"><p>If <span class="monospaced">cl_khr_fp16</span> is supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">half</span>.</p></div>
-<div class="paragraph"><p>If <span class="monospaced">cl_khr_fp64</span> or doubles are supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">double</span>.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:66%;">
-<col style="width:33%;">
+We use the generic type name <code>gentype</code> to indicate the built-in data types
+<code>int</code>, <code>uint</code>, <code>long</code>, <code>ulong</code>, or <code>float</code> as the type for the arguments.</p>
+</div>
+<div class="paragraph">
+<p>If <code>cl_khr_fp16</code> is supported, <code>gentype</code> also includes <code>half</code>.</p>
+</div>
+<div class="paragraph">
+<p>If <code>cl_khr_fp64</code> or doubles are supported, <code>gentype</code> also includes <code>double</code>.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 66.6666%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" > <strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">int</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_all</span></span><span style="color: #990000">(</span> <span style="color: #009900">int</span> predicate <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Evaluates <em>predicate</em> for all work items in the subgroup and returns a
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">int sub_group_all( int predicate )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Evaluates <em>predicate</em> for all work items in the subgroup and returns a
   non-zero value if <em>predicate</em> evaluates to non-zero for all work items in
   the subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">int</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_any</span></span><span style="color: #990000">(</span> <span style="color: #009900">int</span> predicate <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Evaluates <em>predicate</em> for all work items in the subgroup and returns a
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">int sub_group_any( int predicate )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Evaluates <em>predicate</em> for all work items in the subgroup and returns a
   non-zero value if <em>predicate</em> evaluates to non-zero for any work items in
   the subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_broadcast</span></span><span style="color: #990000">(</span>
-          <span style="color: #008080">gentype</span> x<span style="color: #990000">,</span>
-          <span style="color: #008080">uint</span> sub_group_local_id <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Broadcasts the value of <em>x</em> for work item identified by <em>sub_group_local_id</em> (value returned by  <strong>get_sub_group_local_id</strong>) to all work items in the subgroup.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_broadcast(
+          gentype x,
+          uint sub_group_local_id )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Broadcasts the value of <em>x</em> for work item identified by <em>sub_group_local_id</em> (value returned by  <strong>get_sub_group_local_id</strong>) to all work items in the subgroup.
 <em>sub_group_local_id</em> must be the same value for all work items in the subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the result of the specified reduction operation for all values of <em>x</em> specified by work items in a subgroup.</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_reduce_add( gentype x )
+gentype sub_group_reduce_min( gentype x )
+gentype sub_group_reduce_max( gentype x )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the result of the specified reduction operation for all values of <em>x</em> specified by work items in a subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Performs the specified exclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_scan_exclusive_add( gentype x )
+gentype sub_group_scan_exclusive_min( gentype x )
+gentype sub_group_scan_exclusive_max( gentype x )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Performs the specified exclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
 The scan results are returned for each work item.</p>
 <p class="tableblock">The scan order is defined by increasing subgroup local ID within the subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Performs the specified inclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_scan_inclusive_add( gentype x)
+gentype sub_group_scan_inclusive_min( gentype x)
+gentype sub_group_scan_inclusive_max( gentype x)</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Performs the specified inclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
 The scan results are returned for each work item.</p>
 <p class="tableblock">The scan order is defined by increasing subgroup local ID within the subgroup.</p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_add_a_new_section_6_13_x_sub_group_shuffle_functions">Add a new Section 6.13.X - "Sub Group Shuffle Functions"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-These are new functions: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">These are new functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
+<div class="paragraph">
+<p>The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
 These built-in functions need not be encountered by all work items in a subgroup executing the kernel, however, data may only be shuffled among work items encountering the subgroup shuffle function.
 Shuffling data from a work item that does not encounter the subgroup shuffle function will produce undefined results.
-For these functions, <span class="monospaced">gentype</span> is <span class="monospaced">float</span>, <span class="monospaced">float2</span>, <span class="monospaced">float4</span>, <span class="monospaced">float8</span>, <span class="monospaced">float16</span>, <span class="monospaced">int</span>, <span class="monospaced">int2</span>, <span class="monospaced">int4</span>, <span class="monospaced">int8</span>, <span class="monospaced">int16</span>, <span class="monospaced">uint</span>, <span class="monospaced">uint2</span>, <span class="monospaced">uint4</span>, <span class="monospaced">uint8</span>, <span class="monospaced">uint16</span>, <span class="monospaced">long</span>, or <span class="monospaced">ulong</span>.</p></div>
-<div class="paragraph"><p>If <span class="monospaced">cl_khr_fp16</span> is supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">half</span>.</p></div>
-<div class="paragraph"><p>If <span class="monospaced">cl_khr_fp64</span> or doubles are supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">double</span>.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+For these functions, <code>gentype</code> is <code>float</code>, <code>float2</code>, <code>float3</code>, <code>float4</code>, <code>float8</code>, <code>float16</code>, <code>int</code>, <code>int2</code>, <code>int3</code>, <code>int4</code>, <code>int8</code>, <code>int16</code>, <code>uint</code>, <code>uint2</code>, <code>uint3</code>, <code>uint4</code>, <code>uint8</code>, <code>uint16</code>, <code>long</code>, or <code>ulong</code>.</p>
+</div>
+<div class="paragraph">
+<p>If <code>cl_khr_fp16</code> is supported, <code>gentype</code> also includes <code>half</code>.</p>
+</div>
+<div class="paragraph">
+<p>If <code>cl_khr_fp64</code> or doubles are supported, <code>gentype</code> also includes <code>double</code>.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" > <strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle</span></span><span style="color: #990000">(</span>
-              <span style="color: #008080">gentype</span> data<span style="color: #990000">,</span>
-              <span style="color: #008080">uint</span> sub_group_local_id <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Allows data to be arbitrarily transferred between work items in a subgroup.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype intel_sub_group_shuffle(
+              gentype data,
+              uint sub_group_local_id )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Allows data to be arbitrarily transferred between work items in a subgroup.
 The data that is returned for this work item is the value of <em>data</em> for the work item identified by <em>sub_group_local_id</em>.</p>
 <p class="tableblock"><em>sub_group_local_id</em> need not be the same value for all work items in the subgroup.
 There is no defined behavior for out-of-range <em>sub_group_local_ids</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle_down</span></span><span style="color: #990000">(</span>
-              <span style="color: #008080">gentype</span> current<span style="color: #990000">,</span>
-              <span style="color: #008080">gentype</span> next<span style="color: #990000">,</span>
-              <span style="color: #008080">uint</span> delta <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Allows data to be transferred from a work item in the subgroup with a higher sub_group_local_id down to a work item in the subgroup with a lower sub_group_local_id.</p>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype intel_sub_group_shuffle_down(
+              gentype current,
+              gentype next,
+              uint delta )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Allows data to be transferred from a work item in the subgroup with a higher sub_group_local_id down to a work item in the subgroup with a lower sub_group_local_id.</p>
 <p class="tableblock">There are two data sources to this built-in function: <em>current</em> and <em>next</em>.
 To determine the result of this built-in function, first let the unsigned shuffle index be equivalent to the sum of this work item&#8217;s sub_group_local_id plus the specified <em>delta</em>:</p>
 <p class="tableblock">If the shuffle index is less than the max_sub_group_size, the result of this built-in function is the value of the <em>current</em> data source for the work item with sub_group_local_id equal to the shuffle index.</p>
@@ -1751,16 +1771,15 @@ There is no defined behavior for out-of-range indices.</p>
 <p class="tableblock"><em>delta</em> need not be the same value for all work items in the subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle_up</span></span><span style="color: #990000">(</span>
-              <span style="color: #008080">gentype</span> previous<span style="color: #990000">,</span>
-              <span style="color: #008080">gentype</span> current<span style="color: #990000">,</span>
-              <span style="color: #008080">uint</span> delta <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Allows data to be transferred from a work item in the subgroup with a lower sub_group_local_id up to a work item in the subgroup with a higher sub_group_local_id.</p>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype intel_sub_group_shuffle_up(
+              gentype previous,
+              gentype current,
+              uint delta )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Allows data to be transferred from a work item in the subgroup with a lower sub_group_local_id up to a work item in the subgroup with a higher sub_group_local_id.</p>
 <p class="tableblock">There are two data sources to this built-in function: <em>previous</em> and <em>current</em>.
 To determine the result of this built-in function, first let the signed shuffle index be equivalent to this work item&#8217;s sub_group_local_id minus the specified <em>delta</em>:</p>
 <p class="tableblock">If the shuffle index is greater than or equal to zero and less than the max_sub_group_size, the result of this built-in function is the value of the <em>current</em> data source for the work item with sub_group_local_id equal to the shuffle index.</p>
@@ -1770,15 +1789,14 @@ There is no defined behavior for out-of-range indices.</p>
 <p class="tableblock"><em>delta</em> need not be the same value for all work items in the subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle_xor</span></span><span style="color: #990000">(</span>
-              <span style="color: #008080">gentype</span> data<span style="color: #990000">,</span>
-              <span style="color: #008080">uint</span> value <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Allows data to be transferred between work items in a subgroup as a function of the work item&#8217;s sub_group_local_id.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype intel_sub_group_shuffle_xor(
+              gentype data,
+              uint value )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Allows data to be transferred between work items in a subgroup as a function of the work item&#8217;s sub_group_local_id.
 The data that is returned for this work item is the value of <em>data</em> for the work item with sub_group_local_id equal to this work item&#8217;s sub_group_local_id XOR&#8217;d with the specified <em>value</em>.
 If the result of the XOR is greater than max_sub_group_size then it is considered out-of-range.</p>
 <p class="tableblock"><em>value</em> need not be the same for all work items in the subgroup.
@@ -1786,77 +1804,77 @@ There is no defined behavior for out-of-range indices.</p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_add_a_new_section_6_13_x_sub_group_read_and_write_functions">Add a new Section 6.13.X - "Sub Group Read and Write Functions"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-These are new functions: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">These are new functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>The OpenCL C programming language implements the following built-in functions to allow data to be read or written as a block by all work items in a subgroup.
+<div class="paragraph">
+<p>The OpenCL C programming language implements the following built-in functions to allow data to be read or written as a block by all work items in a subgroup.
 These built-in functions must be encountered by all work items in a subgroup executing the kernel.
-Furthermore, since these are block operations, the <em>pointer</em>, <em>image</em>, and <em>coordinate</em> arguments to these built-in functions must be the same for all work items in the subgroup (when applicable, only the <em>data</em> argument may be different).</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:55%;">
-<col style="width:44%;">
+Furthermore, since these are block operations, the <em>pointer</em>, <em>image</em>, and <em>coordinate</em> arguments to these built-in functions must be the same for all work items in the subgroup (when applicable, only the <em>data</em> argument may be different).</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 55.5555%;">
+<col style="width: 44.4445%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" ><strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" ><strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint2</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read2</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint4</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read4</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint8</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read8</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified pointer as a block operation.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint  intel_sub_group_block_read(
+        const __global uint* p )
+uint2 intel_sub_group_block_read2(
+        const __global uint* p )
+uint4 intel_sub_group_block_read4(
+        const __global uint* p )
+uint8 intel_sub_group_block_read8(
+        const __global uint* p )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified pointer as a block operation.
 The data is read strided, so the first value read is:</p>
-<p class="tableblock"><span class="monospaced">p[ sub_group_local_id ]</span></p>
+<p class="tableblock"><code>p[ sub_group_local_id ]</code></p>
 <p class="tableblock">and the second value read is:</p>
-<p class="tableblock"><span class="monospaced">p[ sub_group_local_id + max_sub_group_size ]</span></p>
+<p class="tableblock"><code>p[ sub_group_local_id + max_sub_group_size ]</code></p>
 <p class="tableblock">etc.</p>
 <p class="tableblock"><em>p</em> must be aligned to a 32-bit (4-byte) boundary.</p>
 <p class="tableblock">There is no defined out-of-range behavior for these functions.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint2</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint4</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint8</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified <em>image</em> at the specified coordinate as a block operation.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint  intel_sub_group_block_read(
+        image2d_t image,
+        int2 byte_coord )
+uint2 intel_sub_group_block_read2(
+        image2d_t image,
+        int2 byte_coord )
+uint4 intel_sub_group_block_read4(
+        image2d_t image,
+        int2 byte_coord )
+uint8 intel_sub_group_block_read8(
+        image2d_t image,
+        int2 byte_coord )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified <em>image</em> at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Also note that the image data is read without format conversion, so each work item may read multiple image elements
 (for images with element size smaller than 16-bits).</p>
@@ -1864,47 +1882,45 @@ Also note that the image data is read without format conversion, so each work it
 <p class="tableblock">Please see the note below describing out-of-bounds behavior for these functions.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified pointer as a block operation.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write(
+        __global uint* p, uint data )
+void  intel_sub_group_block_write2(
+        __global uint* p, uint2 data )
+void  intel_sub_group_block_write4(
+        __global uint* p, uint4 data )
+void  intel_sub_group_block_write8(
+        __global uint* p, uint8 data )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified pointer as a block operation.
 The data is written strided, so the first value is written to:</p>
-<p class="tableblock"><span class="monospaced">p[ sub_group_local_id ]</span></p>
+<p class="tableblock"><code>p[ sub_group_local_id ]</code></p>
 <p class="tableblock">and the second value is written to:</p>
-<p class="tableblock"><span class="monospaced">p[ sub_group_local_id + max_sub_group_size ]</span></p>
+<p class="tableblock"><code>p[ sub_group_local_id + max_sub_group_size ]</code></p>
 <p class="tableblock">etc.</p>
 <p class="tableblock"><em>p</em> must be aligned to a 128-bit (16-byte) boundary.</p>
 <p class="tableblock">There is no defined out-of-range behavior for these functions.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified <em>image</em> at the specified coordinate as a block operation.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write(
+        image2d_t image,
+        int2 byte_coord, uint data )
+void  intel_sub_group_block_write2(
+        image2d_t image,
+        int2 byte_coord, uint2 data )
+void  intel_sub_group_block_write4(
+        image2d_t image,
+        int2 byte_coord, uint4 data )
+void  intel_sub_group_block_write8(
+        image2d_t image,
+        int2 byte_coord, uint8 data )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified <em>image</em> at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Unlike the image block read function, which may read from any arbitrary byte offset, the x-component of the byte coordinate for the image block write functions must be a multiple of four;
 in other words, the write must begin at 32-bit boundary.
@@ -1915,163 +1931,170 @@ Also, note that the image <em>data</em> is written without format conversion, so
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>Note: The subgroup image block read and write built-ins do support bounds checking, however these built-ins bounds-check to the image width in units of uints, not in units of image elements.
-This means:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>Note: The subgroup image block read and write built-ins do support bounds checking, however these built-ins bounds-check to the image width in units of uints, not in units of image elements.
+This means:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-If the image has an element size equal to the size of a uint (four bytes, for example <span class="monospaced">CL_RGBA</span> + <span class="monospaced">CL_UNORM_INT8</span>), the image will be correctly bounds-checked.
-In this case, out-of-bounds reads will return the edge image element (the equivalent of <span class="monospaced">CLK_ADDRESS_CLAMP_TO_EDGE</span>), and out-of-bounds writes will be ignored.
-</p>
+<p>If the image has an element size equal to the size of a uint (four bytes, for example <code>CL_RGBA</code> + <code>CL_UNORM_INT8</code>), the image will be correctly bounds-checked.
+In this case, out-of-bounds reads will return the edge image element (the equivalent of <code>CLK_ADDRESS_CLAMP_TO_EDGE</code>), and out-of-bounds writes will be ignored.</p>
 </li>
 <li>
-<p>
-If the image has element size less than the size of a uint (such as <span class="monospaced">CL_R</span> + <span class="monospaced">CL_UNSIGNED_INT8</span>), the entire image is addressable, however bounds checking will occur too late.
-For this reason, extra care should be taken to avoid out-of-bounds reads and writes, since out-of-bounds reads may return invalid data and out-of-bounds writes may corrupt other images or buffers unpredictably.
-</p>
+<p>If the image has element size less than the size of a uint (such as <code>CL_R</code> + <code>CL_UNSIGNED_INT8</code>), the entire image is addressable, however bounds checking will occur too late.
+For this reason, extra care should be taken to avoid out-of-bounds reads and writes, since out-of-bounds reads may return invalid data and out-of-bounds writes may corrupt other images or buffers unpredictably.</p>
 </li>
-</ul></div>
-</div></div>
+</ul>
+</div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-Add a new sub-section 6.13.X.1 - Restrictions: 
-</dt>
+<dt class="hdlist1">Add a new sub-section 6.13.X.1 - Restrictions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>The following restrictions apply to the subgroup buffer block read and write functions:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>The following restrictions apply to the subgroup buffer block read and write functions:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-The pointer <em>p</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
-</p>
+<p>The pointer <em>p</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.</p>
 </li>
 <li>
-<p>
-If the pointer <em>p</em> is computed from a kernel argument that is a cl_mem that was created with <span class="monospaced">CL_MEM_USE_HOST_PTR</span>, then the <em>host_ptr</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
-</p>
+<p>If the pointer <em>p</em> is computed from a kernel argument that is a cl_mem that was created with <code>CL_MEM_USE_HOST_PTR</code>, then the <em>host_ptr</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.</p>
 </li>
 <li>
-<p>
-If the pointer <em>p</em> is computed from a kernel argument that is a cl_mem that is a sub-buffer, then the <em>origin</em> defining the sub-buffer offset into the <em>buffer</em> must be a multiple of 4 bytes for reads, and must be a multiple of 16 bytes for write, in addition to the <span class="monospaced">CL_DEVICE_MEM_BASE_ADDR_ALIGN</span> requirements.
-Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with <span class="monospaced">CL_MEM_USE_HOST_PTR</span>, then the <em>host_ptr</em> for the <em>buffer</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit(16-byte) aligned for writes.
-</p>
+<p>If the pointer <em>p</em> is computed from a kernel argument that is a cl_mem that is a sub-buffer, then the <em>origin</em> defining the sub-buffer offset into the <em>buffer</em> must be a multiple of 4 bytes for reads, and must be a multiple of 16 bytes for write, in addition to the <code>CL_DEVICE_MEM_BASE_ADDR_ALIGN</code> requirements.
+Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with <code>CL_MEM_USE_HOST_PTR</code>, then the <em>host_ptr</em> for the <em>buffer</em> must be 32-bit (4-byte) aligned for reads, and must be 128-bit(16-byte) aligned for writes.</p>
 </li>
 <li>
-<p>
-If the pointer <em>p</em> is computed from an SVM pointer kernel argument, then the SVM pointer kernel argument must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.
-</p>
-</li>
-</ul></div>
-<div class="paragraph"><p>The following restrictions apply to the subgroup image block read and write functions:</p></div>
-<div class="ulist"><ul>
-<li>
-<p>
-The behavior of the subgroup image block read and write built-ins is undefined for images with an element size greater than four bytes (such as <span class="monospaced">CL_RGBA</span> + <span class="monospaced">CL_FLOAT</span>).
-</p>
+<p>If the pointer <em>p</em> is computed from an SVM pointer kernel argument, then the SVM pointer kernel argument must be 32-bit (4-byte) aligned for reads, and must be 128-bit (16-byte) aligned for writes.</p>
 </li>
 <li>
-<p>
-When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, the image row pitch is required to be a multiple of 64-bytes, in addition to the <span class="monospaced">CL_DEVICE_IMAGE_PITCH_ALIGNMENT</span> requirements.
-</p>
+<p>Behavior is undefined if the subgroup size is smaller than the maximum subgroup size; in other words, if this is a partial subgroup.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>The following restrictions apply to the subgroup image block read and write functions:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>The behavior of the subgroup image block read and write built-ins is undefined for images with an element size greater than four bytes (such as <code>CL_RGBA</code> + <code>CL_FLOAT</code>).</p>
 </li>
 <li>
-<p>
-When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, if the buffer is a cl_mem that was created with <span class="monospaced">CL_MEM_USE_HOST_PTR</span>, then the <em>host_ptr</em> must be 256-bit (32-byte) aligned.
-</p>
+<p>When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, the image row pitch is required to be a multiple of 64-bytes, in addition to the <code>CL_DEVICE_IMAGE_PITCH_ALIGNMENT</code> requirements.</p>
 </li>
 <li>
-<p>
-When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, if the buffer is a cl_mem that is a sub-buffer, then the <em>origin</em> must be a multiple of 32-bytes.
-Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with CL_MEM_USE_HOST_PTR, then the <em>host_ptr</em> for the <em>buffer</em> must be 256-bit (32-byte) aligned.
-</p>
+<p>When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, if the buffer is a cl_mem that was created with <code>CL_MEM_USE_HOST_PTR</code>, then the <em>host_ptr</em> must be 256-bit (32-byte) aligned.</p>
 </li>
-</ul></div>
-</div></div>
+<li>
+<p>When reading or writing a 2D image created from a buffer with the subgroup block read and write built-ins, if the buffer is a cl_mem that is a sub-buffer, then the <em>origin</em> must be a multiple of 32-bytes.
+Additionally, if the <em>buffer</em> that the sub-buffer is created from was created with CL_MEM_USE_HOST_PTR, then the <em>host_ptr</em> for the <em>buffer</em> must be 256-bit (32-byte) aligned.</p>
+</li>
+<li>
+<p>Behavior is undefined if the subgroup size is smaller than the maximum subgroup size; in other words, if this is a partial subgroup.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2014-12-01</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>First public revision.</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2014-12-01</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>First public revision.</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2015-03-12</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fixed minor formatting errors, added restriction for subgroup image block read and write built-ins with large image formats.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2015-03-12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fixed minor formatting errors, added restriction for subgroup image block read and write built-ins with large image formats.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2016-02-12</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fixed a small bug in the shuffle up and shuffle down descriptions.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2016-02-12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fixed a small bug in the shuffle up and shuffle down descriptions.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2016-08-28</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Added additional restrictions and programming notes for the subgroup shuffle and block read built-ins.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2016-08-28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Added additional restrictions and programming notes for the subgroup shuffle and block read built-ins.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-11-15</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Converted to asciidoc.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-11-15</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Converted to asciidoc.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-12-02</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Added back a section that was inadvertently removed during conversion to asciidoc.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-12-02</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Added back a section that was inadvertently removed during conversion to asciidoc.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2019-01-15</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fixed a typo in the summary section of new built-in functions.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-01-15</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fixed a typo in the summary section of new built-in functions.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-09-17</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Added vec3 types for shuffles, restriction for block reads and writes and partial subgroups, and asciidoctor formatting fixes.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
-<div id="footnotes"><hr></div>
 <div id="footer">
 <div id="footer-text">
-Last updated
- 2019-01-15 08:30:21 PST
+Version V2.2-11-30-g5ba09e4<br>
+Last updated 2019-10-23 15:35:34 -0700
 </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 </body>
 </html>

--- a/extensions/intel/cl_intel_subgroups_short.html
+++ b/extensions/intel/cl_intel_subgroups_short.html
@@ -1,988 +1,976 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.9">
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.8">
 <title>cl_intel_subgroups_short</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+<style>
+/*! normalize.css v2.1.2 | MIT License | git.io/normalize */
+/* ========================================================================== HTML5 display definitions ========================================================================== */
+/** Correct `block` display not defined in IE 8/9. */
+article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary { display: block; }
 
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
+/** Correct `inline-block` display not defined in IE 8/9. */
+audio, canvas, video { display: inline-block; }
 
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
+/** Prevent modern browsers from displaying `audio` without controls. Remove excess height in iOS 5 devices. */
+audio:not([controls]) { display: none; height: 0; }
 
-body {
-  margin: 1em 5% 1em 5%;
-}
+/** Address `[hidden]` styling not present in IE 8/9. Hide the `template` element in IE, Safari, and Firefox < 22. */
+[hidden], template { display: none; }
 
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
+script { display: none !important; }
 
-em {
-  font-style: italic;
-  color: navy;
-}
+/* ========================================================================== Base ========================================================================== */
+/** 1. Set default font family to sans-serif. 2. Prevent iOS text size adjust after orientation change, without disabling user zoom. */
+html { font-family: sans-serif; /* 1 */ -ms-text-size-adjust: 100%; /* 2 */ -webkit-text-size-adjust: 100%; /* 2 */ }
 
-strong {
-  font-weight: bold;
-  color: #083194;
-}
+/** Remove default margin. */
+body { margin: 0; }
 
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
+/* ========================================================================== Links ========================================================================== */
+/** Remove the gray background color from active links in IE 10. */
+a { background: transparent; }
 
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
+/** Address `outline` inconsistency between Chrome and other browsers. */
+a:focus { outline: thin dotted; }
 
-div.sectionbody {
-  margin-left: 0;
-}
+/** Improve readability when focused and also mouse hovered in all browsers. */
+a:active, a:hover { outline: 0; }
 
-hr {
-  border: 1px solid silver;
-}
+/* ========================================================================== Typography ========================================================================== */
+/** Address variable `h1` font-size and margin within `section` and `article` contexts in Firefox 4+, Safari 5, and Chrome. */
+h1 { font-size: 2em; margin: 0.67em 0; }
 
-p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9, Safari 5, and Chrome. */
+abbr[title] { border-bottom: 1px dotted; }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
+/** Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome. */
+b, strong { font-weight: bold; }
 
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
+/** Address styling not present in Safari 5 and Chrome. */
+dfn { font-style: italic; }
 
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
+/** Address differences between Firefox and other browsers. */
+hr { -moz-box-sizing: content-box; box-sizing: content-box; height: 0; }
 
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
+/** Address styling not present in IE 8/9. */
+mark { background: #ff0; color: #000; }
 
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
+/** Correct font family set oddly in Safari 5 and Chrome. */
+code, kbd, pre, samp { font-family: monospace, serif; font-size: 1em; }
 
-div.content { /* Block element content. */
-  padding: 0;
-}
+/** Improve readability of pre-formatted text in all browsers. */
+pre { white-space: pre-wrap; }
 
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
+/** Set consistent quote types. */
+q { quotes: "\201C" "\201D" "\2018" "\2019"; }
 
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
+/** Address inconsistent and variable font size in all browsers. */
+small { font-size: 80%; }
 
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
+/** Prevent `sub` and `sup` affecting `line-height` in all browsers. */
+sub, sup { font-size: 75%; line-height: 0; position: relative; vertical-align: baseline; }
 
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
+sup { top: -0.5em; }
 
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
+sub { bottom: -0.25em; }
 
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
+/* ========================================================================== Embedded content ========================================================================== */
+/** Remove border when inside `a` element in IE 8/9. */
+img { border: 0; }
 
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
+/** Correct overflow displayed oddly in IE 9. */
+svg:not(:root) { overflow: hidden; }
 
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
+/* ========================================================================== Figures ========================================================================== */
+/** Address margin not present in IE 8/9 and Safari 5. */
+figure { margin: 0; }
 
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
+/* ========================================================================== Forms ========================================================================== */
+/** Define consistent border, margin, and padding. */
+fieldset { border: 1px solid #c0c0c0; margin: 0 2px; padding: 0.35em 0.625em 0.75em; }
 
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
+/** 1. Correct `color` not being inherited in IE 8/9. 2. Remove padding so people aren't caught out if they zero out fieldsets. */
+legend { border: 0; /* 1 */ padding: 0; /* 2 */ }
 
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
+/** 1. Correct font family not being inherited in all browsers. 2. Correct font size not being inherited in all browsers. 3. Address margins set differently in Firefox 4+, Safari 5, and Chrome. */
+button, input, select, textarea { font-family: inherit; /* 1 */ font-size: 100%; /* 2 */ margin: 0; /* 3 */ }
 
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
+/** Address Firefox 4+ setting `line-height` on `input` using `!important` in the UA stylesheet. */
+button, input { line-height: normal; }
 
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
+/** Address inconsistent `text-transform` inheritance for `button` and `select`. All other form control elements do not inherit `text-transform` values. Correct `button` style inheritance in Chrome, Safari 5+, and IE 8+. Correct `select` style inheritance in Firefox 4+ and Opera. */
+button, select { text-transform: none; }
 
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
+/** 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio` and `video` controls. 2. Correct inability to style clickable `input` types in iOS. 3. Improve usability and consistency of cursor style between image-type `input` and others. */
+button, html input[type="button"], input[type="reset"], input[type="submit"] { -webkit-appearance: button; /* 2 */ cursor: pointer; /* 3 */ }
 
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
+/** Re-set default cursor for disabled elements. */
+button[disabled], html input[disabled] { cursor: default; }
 
-.comment {
-  background: yellow;
-}
+/** 1. Address box sizing set to `content-box` in IE 8/9. 2. Remove excess padding in IE 8/9. */
+input[type="checkbox"], input[type="radio"] { box-sizing: border-box; /* 1 */ padding: 0; /* 2 */ }
 
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
+/** 1. Address `appearance` set to `searchfield` in Safari 5 and Chrome. 2. Address `box-sizing` set to `border-box` in Safari 5 and Chrome (include `-moz` to future-proof). */
+input[type="search"] { -webkit-appearance: textfield; /* 1 */ -moz-box-sizing: content-box; -webkit-box-sizing: content-box; /* 2 */ box-sizing: content-box; }
 
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
+/** Remove inner padding and search cancel button in Safari 5 and Chrome on OS X. */
+input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration { -webkit-appearance: none; }
 
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
+/** Remove inner padding and border in Firefox 4+. */
+button::-moz-focus-inner, input::-moz-focus-inner { border: 0; padding: 0; }
 
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
+/** 1. Remove default vertical scrollbar in IE 8/9. 2. Improve readability and alignment in all browsers. */
+textarea { overflow: auto; /* 1 */ vertical-align: top; /* 2 */ }
 
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
+/* ========================================================================== Tables ========================================================================== */
+/** Remove most spacing between table cells. */
+table { border-collapse: collapse; border-spacing: 0; }
 
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
+meta.foundation-mq-small { font-family: "only screen and (min-width: 768px)"; width: 768px; }
 
-@media print {
-  #footer-badges { display: none; }
-}
+meta.foundation-mq-medium { font-family: "only screen and (min-width:1280px)"; width: 1280px; }
 
-#toc {
-  margin-bottom: 2.5em;
-}
+meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; width: 1440px; }
 
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
+*, *:before, *:after { -moz-box-sizing: border-box; -webkit-box-sizing: border-box; box-sizing: border-box; }
 
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
+html, body { font-size: 100%; }
 
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
+body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
+a:hover { cursor: pointer; }
 
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
+img, object, embed { max-width: 100%; height: auto; }
 
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
+object, embed { height: 100%; }
+
+img { -ms-interpolation-mode: bicubic; }
+
+#map_canvas img, #map_canvas embed, #map_canvas object, .map_canvas img, .map_canvas embed, .map_canvas object { max-width: none !important; }
+
+.left { float: left !important; }
+
+.right { float: right !important; }
+
+.text-left { text-align: left !important; }
+
+.text-right { text-align: right !important; }
+
+.text-center { text-align: center !important; }
+
+.text-justify { text-align: justify !important; }
+
+.hide { display: none; }
+
+.antialiased { -webkit-font-smoothing: antialiased; }
+
+img { display: inline-block; vertical-align: middle; }
+
+textarea { height: auto; min-height: 50px; }
+
+select { width: 100%; }
+
+object, svg { display: inline-block; vertical-align: middle; }
+
+.center { margin-left: auto; margin-right: auto; }
+
+.spread { width: 100%; }
+
+p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { font-size: 1.21875em; line-height: 1.6; }
+
+.subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { line-height: 1.4; color: black; font-weight: 300; margin-top: 0.2em; margin-bottom: 0.5em; }
+
+/* Typography resets */
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
+
+/* Default Link Styles */
+a { color: #0068b0; text-decoration: none; line-height: inherit; }
+a:hover, a:focus { color: #333333; }
+a img { border: none; }
+
+/* Default paragraph styles */
+p { font-family: Noto, sans-serif; font-weight: normal; font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; text-rendering: optimizeLegibility; }
+p aside { font-size: 0.875em; line-height: 1.35; font-style: italic; }
+
+/* Default header styles */
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { font-family: Noto, sans-serif; font-weight: normal; font-style: normal; color: black; text-rendering: optimizeLegibility; margin-top: 0.5em; margin-bottom: 0.5em; line-height: 1.2125em; }
+h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small { font-size: 60%; color: #4d4d4d; line-height: 0; }
+
+h1 { font-size: 2.125em; }
+
+h2 { font-size: 1.6875em; }
+
+h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.375em; }
+
+h4 { font-size: 1.125em; }
+
+h5 { font-size: 1.125em; }
+
+h6 { font-size: 1em; }
+
+hr { border: solid #dddddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
+
+/* Helpful Typography Defaults */
+em, i { font-style: italic; line-height: inherit; }
+
+strong, b { font-weight: bold; line-height: inherit; }
+
+small { font-size: 60%; line-height: inherit; }
+
+code { font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; color: #264357; }
+
+/* Lists */
+ul, ol, dl { font-size: 1em; line-height: 1.6; margin-bottom: 0.75em; list-style-position: outside; font-family: Noto, sans-serif; }
+
+ul, ol { margin-left: 1.5em; }
+ul.no-bullet, ol.no-bullet { margin-left: 1.5em; }
+
+/* Unordered Lists */
+ul li ul, ul li ol { margin-left: 1.25em; margin-bottom: 0; font-size: 1em; /* Override nested font-size change */ }
+ul.square li ul, ul.circle li ul, ul.disc li ul { list-style: inherit; }
+ul.square { list-style-type: square; }
+ul.circle { list-style-type: circle; }
+ul.disc { list-style-type: disc; }
+ul.no-bullet { list-style: none; }
+
+/* Ordered Lists */
+ol li ul, ol li ol { margin-left: 1.25em; margin-bottom: 0; }
+
+/* Definition Lists */
+dl dt { margin-bottom: 0.3em; font-weight: bold; }
+dl dd { margin-bottom: 0.75em; }
+
+/* Abbreviations */
+abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #dddddd; cursor: help; }
+
+abbr { text-transform: none; }
+
+/* Blockquotes */
+blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #dddddd; }
+blockquote cite { display: block; font-size: 0.8125em; color: #5e93b8; }
+blockquote cite:before { content: "\2014 \0020"; }
+blockquote cite a, blockquote cite a:visited { color: #5e93b8; }
+
+blockquote, blockquote p { line-height: 1.6; color: #333333; }
+
+/* Microformats */
+.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #dddddd; padding: 0.625em 0.75em; }
+.vcard li { margin: 0; display: block; }
+.vcard .fn { font-weight: bold; font-size: 0.9375em; }
+
+.vevent .summary { font-weight: bold; }
+.vevent abbr { cursor: auto; text-decoration: none; font-weight: bold; border: none; padding: 0 0.0625em; }
+
+@media only screen and (min-width: 768px) { h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+  h1 { font-size: 2.75em; }
+  h2 { font-size: 2.3125em; }
+  h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
+  h4 { font-size: 1.4375em; } }
+/* Tables */
+table { background: white; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
+table thead, table tfoot { background: -webkit-linear-gradient(top, #add386, #90b66a); font-weight: bold; }
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: white; text-align: left; }
+table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #6d6e71; }
+table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #edf2f2; }
+table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.4; }
+
+body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.4; }
+
+a:hover, a:focus { text-decoration: underline; }
+
+.clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
+.clearfix:after, .float-group:after { clear: both; }
+
+*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: white; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
+*:not(pre) > code.nobreak { word-wrap: normal; }
+*:not(pre) > code.nowrap { white-space: nowrap; }
+
+pre, pre > code { line-height: 1.6; color: #264357; font-family: Consolas, "Liberation Mono", Courier, monospace; font-weight: normal; }
+
+em em { font-style: normal; }
+
+strong strong { font-weight: normal; }
+
+.keyseq { color: #333333; }
+
+kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
+
+.keyseq kbd:first-child { margin-left: 0; }
+
+.keyseq kbd:last-child { margin-right: 0; }
+
+.menuseq, .menuref { color: #000; }
+
+.menuseq b:not(.caret), .menuref { font-weight: inherit; }
+
+.menuseq { word-spacing: -0.02em; }
+.menuseq b.caret { font-size: 1.25em; line-height: 0.8; }
+.menuseq i.caret { font-weight: bold; text-align: center; width: 0.45em; }
+
+b.button:before, b.button:after { position: relative; top: -1px; font-weight: normal; }
+
+b.button:before { content: "["; padding: 0 3px 0 2px; }
+
+b.button:after { content: "]"; padding: 0 2px 0 3px; }
+
+#header, #content, #footnotes, #footer { width: 100%; margin-left: auto; margin-right: auto; margin-top: 0; margin-bottom: 0; max-width: 62.5em; *zoom: 1; position: relative; padding-left: 1.5em; padding-right: 1.5em; }
+#header:before, #header:after, #content:before, #content:after, #footnotes:before, #footnotes:after, #footer:before, #footer:after { content: " "; display: table; }
+#header:after, #content:after, #footnotes:after, #footer:after { clear: both; }
+
+#content { margin-top: 1.25em; }
+
+#content:before { content: none; }
+
+#header > h1:first-child { color: black; margin-top: 2.25rem; margin-bottom: 0; }
+#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #dddddd; }
+#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #dddddd; padding-bottom: 8px; }
+#header .details { border-bottom: 1px solid #dddddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #5e93b8; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
+#header .details span:first-child { margin-left: -0.125em; }
+#header .details span.email a { color: #333333; }
+#header .details br { display: none; }
+#header .details br + span:before { content: "\00a0\2013\00a0"; }
+#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333333; }
+#header .details br + span#revremark:before { content: "\00a0|\00a0"; }
+#header #revnumber { text-transform: capitalize; }
+#header #revnumber:after { content: "\00a0"; }
+
+#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #dddddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
+
+#toc { border-bottom: 0 solid #dddddd; padding-bottom: 0.5em; }
+#toc > ul { margin-left: 0.125em; }
+#toc ul.sectlevel0 > li > a { font-style: italic; }
+#toc ul.sectlevel0 ul.sectlevel1 { margin: 0.5em 0; }
+#toc ul { font-family: Noto, sans-serif; list-style-type: none; }
+#toc li { line-height: 1.3334; margin-top: 0.3334em; }
+#toc a { text-decoration: none; }
+#toc a:active { text-decoration: underline; }
+
+#toctitle { color: black; font-size: 1.2em; }
+
+@media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
+  body.toc2 { padding-left: 15em; padding-right: 0; }
+  #toc.toc2 { margin-top: 0 !important; background-color: white; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #dddddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
+  #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
+  #toc.toc2 > ul { font-size: 0.9em; margin-bottom: 0; }
+  #toc.toc2 ul ul { margin-left: 0; padding-left: 1em; }
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 15em; }
+  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #dddddd; left: auto; right: 0; } }
+@media only screen and (min-width: 1280px) { body.toc2 { padding-left: 20em; padding-right: 0; }
+  #toc.toc2 { width: 20em; }
+  #toc.toc2 #toctitle { font-size: 1.375em; }
+  #toc.toc2 > ul { font-size: 0.95em; }
+  #toc.toc2 ul ul { padding-left: 1.25em; }
+  body.toc2.toc-right { padding-left: 0; padding-right: 20em; } }
+#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+#content #toc > :first-child { margin-top: 0; }
+#content #toc > :last-child { margin-bottom: 0; }
+
+#footer { max-width: 100%; background-color: none; padding: 1.25em; }
+
+#footer-text { color: black; line-height: 1.44; }
+
+#content { margin-bottom: 0.625em; }
+
+.sect1 { padding-bottom: 0.625em; }
+
+@media only screen and (min-width: 768px) { #content { margin-bottom: 1.25em; }
+  .sect1 { padding-bottom: 1.25em; } }
+.sect1:last-child { padding-bottom: 0; }
+
+.sect1 + .sect1 { border-top: 0 solid #dddddd; }
+
+#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
+#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
+#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover { visibility: visible; }
+#content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link { color: black; text-decoration: none; }
+#content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover { color: black; }
+
+.audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock { margin-bottom: 1.25em; }
+
+.admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { text-rendering: optimizeLegibility; text-align: left; }
+
+table.tableblock > caption.title { white-space: nowrap; overflow: visible; max-width: 0; }
+
+.paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { color: black; }
+
+table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-size: inherit; }
+
+.admonitionblock > table { border-collapse: separate; border: 0; background: none; width: 100%; }
+.admonitionblock > table td.icon { text-align: center; width: 80px; }
+.admonitionblock > table td.icon img { max-width: initial; }
+.admonitionblock > table td.icon .title { font-weight: bold; font-family: Noto, sans-serif; text-transform: uppercase; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #dddddd; color: #5e93b8; }
+.admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
+
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.exampleblock > .content > :first-child { margin-top: 0; }
+.exampleblock > .content > :last-child { margin-bottom: 0; }
+
+.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.sidebarblock > :first-child { margin-top: 0; }
+.sidebarblock > :last-child { margin-bottom: 0; }
+.sidebarblock > .content > .title { color: black; margin-top: 0; }
+
+.exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
+
+.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eeeeee; }
+.sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
+
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
+.literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
+@media only screen and (min-width: 768px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 0.90625em; } }
+@media only screen and (min-width: 1280px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 1em; } }
+
+.literalblock.output pre { color: #eeeeee; background-color: #264357; }
+
+.listingblock pre.highlightjs { padding: 0; }
+.listingblock pre.highlightjs > code { padding: 1.25em 1.5625em 1.125em 1.5625em; -webkit-border-radius: 0; border-radius: 0; }
+
+.listingblock > .content { position: relative; }
+
+.listingblock code[data-lang]:before { display: none; content: attr(data-lang); position: absolute; font-size: 0.75em; top: 0.425rem; right: 0.5rem; line-height: 1; text-transform: uppercase; color: #999; }
+
+.listingblock:hover code[data-lang]:before { display: block; }
+
+.listingblock.terminal pre .command:before { content: attr(data-prompt); padding-right: 0.5em; color: #999; }
+
+.listingblock.terminal pre .command:not([data-prompt]):before { content: "$"; }
+
+table.pyhltable { border-collapse: separate; border: 0; margin-bottom: 0; background: none; }
+
+table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; line-height: 1.6; }
+
+table.pyhltable td.code { padding-left: .75em; padding-right: 0; }
+
+pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #dddddd; }
+
+pre.pygments .lineno { display: inline-block; margin-right: .25em; }
+
+table.pyhltable .linenodiv { background: none !important; padding-right: 0 !important; }
+
+.quoteblock { margin: 0 1em 0.75em 1.5em; display: table; }
+.quoteblock > .title { margin-left: -1.5em; margin-bottom: 0.75em; }
+.quoteblock blockquote, .quoteblock blockquote p { color: #333333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
+.quoteblock blockquote { margin: 0; padding: 0; border: 0; }
+.quoteblock blockquote:before { content: "\201c"; float: left; font-size: 2.75em; font-weight: bold; line-height: 0.6em; margin-left: -0.6em; color: black; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
+.quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
+.quoteblock .attribution { margin-top: 0.5em; margin-right: 0.5ex; text-align: right; }
+.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #5e93b8; }
+.quoteblock .quoteblock blockquote { padding: 0 0 0 0.75em; }
+.quoteblock .quoteblock blockquote:before { display: none; }
+
+.verseblock { margin: 0 1em 0.75em 1em; }
+.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333333; font-weight: 300; text-rendering: optimizeLegibility; }
+.verseblock pre strong { font-weight: 400; }
+.verseblock .attribution { margin-top: 1.25rem; margin-left: 0.5ex; }
+
+.quoteblock .attribution, .verseblock .attribution { font-size: 0.8125em; line-height: 1.45; font-style: italic; }
+.quoteblock .attribution br, .verseblock .attribution br { display: none; }
+.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #5e93b8; }
+
+.quoteblock.abstract { margin: 0 0 0.75em 0; display: block; }
+.quoteblock.abstract blockquote, .quoteblock.abstract blockquote p { text-align: left; word-spacing: 0; }
+.quoteblock.abstract blockquote:before, .quoteblock.abstract blockquote p:first-of-type:before { display: none; }
+
+table.tableblock { max-width: 100%; border-collapse: separate; }
+table.tableblock td > .paragraph:last-child p > p:last-child, table.tableblock th > p:last-child, table.tableblock td > p:last-child { margin-bottom: 0; }
+
+table.tableblock, th.tableblock, td.tableblock { border: 0 solid #d8d8ce; }
+
+table.grid-all > thead > tr > .tableblock, table.grid-all > tbody > tr > .tableblock { border-width: 0 1px 1px 0; }
+
+table.grid-all > tfoot > tr > .tableblock { border-width: 1px 1px 0 0; }
+
+table.grid-cols > * > tr > .tableblock { border-width: 0 1px 0 0; }
+
+table.grid-rows > thead > tr > .tableblock, table.grid-rows > tbody > tr > .tableblock { border-width: 0 0 1px 0; }
+
+table.grid-rows > tfoot > tr > .tableblock { border-width: 1px 0 0 0; }
+
+table.grid-all > * > tr > .tableblock:last-child, table.grid-cols > * > tr > .tableblock:last-child { border-right-width: 0; }
+
+table.grid-all > tbody > tr:last-child > .tableblock, table.grid-all > thead:last-child > tr > .tableblock, table.grid-rows > tbody > tr:last-child > .tableblock, table.grid-rows > thead:last-child > tr > .tableblock { border-bottom-width: 0; }
+
+table.frame-all { border-width: 1px; }
+
+table.frame-sides { border-width: 0 1px; }
+
+table.frame-topbot { border-width: 1px 0; }
+
+th.halign-left, td.halign-left { text-align: left; }
+
+th.halign-right, td.halign-right { text-align: right; }
+
+th.halign-center, td.halign-center { text-align: center; }
+
+th.valign-top, td.valign-top { vertical-align: top; }
+
+th.valign-bottom, td.valign-bottom { vertical-align: bottom; }
+
+th.valign-middle, td.valign-middle { vertical-align: middle; }
+
+table thead th, table tfoot th { font-weight: bold; }
+
+tbody tr th { display: table-cell; line-height: 1.4; background: -webkit-linear-gradient(top, #add386, #90b66a); }
+
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: white; font-weight: bold; }
+
+p.tableblock > code:only-child { background: none; padding: 0; }
+
+p.tableblock { font-size: 1em; }
+
+td > div.verse { white-space: pre; }
+
+ol { margin-left: 1.75em; }
+
+ul li ol { margin-left: 1.5em; }
+
+dl dd { margin-left: 1.125em; }
+
+dl dd:last-child, dl dd:last-child > :last-child { margin-bottom: 0; }
+
+ol > li p, ul > li p, ul dd, ol dd, .olist .olist, .ulist .ulist, .ulist .olist, .olist .ulist { margin-bottom: 0.375em; }
+
+ul.checklist, ul.none, ol.none, ul.no-bullet, ol.no-bullet, ol.unnumbered, ul.unstyled, ol.unstyled { list-style-type: none; }
+
+ul.no-bullet, ol.no-bullet, ol.unnumbered { margin-left: 0.625em; }
+
+ul.unstyled, ol.unstyled { margin-left: 0; }
+
+ul.checklist { margin-left: 0.625em; }
+
+ul.checklist li > p:first-child > .fa-square-o:first-child, ul.checklist li > p:first-child > .fa-check-square-o:first-child { width: 1.25em; font-size: 0.8em; position: relative; bottom: 0.125em; }
+
+ul.checklist li > p:first-child > input[type="checkbox"]:first-child { margin-right: 0.25em; }
+
+ul.inline { display: -ms-flexbox; display: -webkit-box; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; list-style: none; margin: 0 0 0.375em -0.75em; }
+
+ul.inline > li { margin-left: 0.75em; }
+
+.unstyled dl dt { font-weight: normal; font-style: normal; }
+
+ol.arabic { list-style-type: decimal; }
+
+ol.decimal { list-style-type: decimal-leading-zero; }
+
+ol.loweralpha { list-style-type: lower-alpha; }
+
+ol.upperalpha { list-style-type: upper-alpha; }
+
+ol.lowerroman { list-style-type: lower-roman; }
+
+ol.upperroman { list-style-type: upper-roman; }
+
+ol.lowergreek { list-style-type: lower-greek; }
+
+.hdlist > table, .colist > table { border: 0; background: none; }
+.hdlist > table > tbody > tr, .colist > table > tbody > tr { background: none; }
+
+td.hdlist1, td.hdlist2 { vertical-align: top; padding: 0 0.625em; }
+
+td.hdlist1 { font-weight: bold; padding-bottom: 0.75em; }
+
+.literalblock + .colist, .listingblock + .colist { margin-top: -0.5em; }
+
+.colist > table tr > td:first-of-type { padding: 0.4em 0.75em 0 0.75em; line-height: 1; vertical-align: top; }
+.colist > table tr > td:first-of-type img { max-width: initial; }
+.colist > table tr > td:last-of-type { padding: 0.25em 0; }
+
+.thumb, .th { line-height: 0; display: inline-block; border: solid 4px white; -webkit-box-shadow: 0 0 0 1px #dddddd; box-shadow: 0 0 0 1px #dddddd; }
+
+.imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
+.imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
+.imageblock > .title { margin-bottom: 0; }
+.imageblock.thumb, .imageblock.th { border-width: 6px; }
+.imageblock.thumb > .title, .imageblock.th > .title { padding: 0 0.125em; }
+
+.image.left, .image.right { margin-top: 0.25em; margin-bottom: 0.25em; display: inline-block; line-height: 0; }
+.image.left { margin-right: 0.625em; }
+.image.right { margin-left: 0.625em; }
+
+a.image { text-decoration: none; display: inline-block; }
+a.image object { pointer-events: none; }
+
+sup.footnote, sup.footnoteref { font-size: 0.875em; position: static; vertical-align: super; }
+sup.footnote a, sup.footnoteref a { text-decoration: none; }
+sup.footnote a:active, sup.footnoteref a:active { text-decoration: underline; }
+
+#footnotes { padding-top: 0.75em; padding-bottom: 0.75em; margin-bottom: 0.625em; }
+#footnotes hr { width: 20%; min-width: 6.25em; margin: -0.25em 0 0.75em 0; border-width: 1px 0 0 0; }
+#footnotes .footnote { padding: 0 0.375em 0 0.225em; line-height: 1.3334; font-size: 0.875em; margin-left: 1.2em; margin-bottom: 0.2em; }
+#footnotes .footnote a:first-of-type { font-weight: bold; text-decoration: none; margin-left: -1.05em; }
+#footnotes .footnote:last-of-type { margin-bottom: 0; }
+#content #footnotes { margin-top: -0.625em; margin-bottom: 0; padding: 0.75em 0; }
+
+.gist .file-data > table { border: 0; background: #fff; width: 100%; margin-bottom: 0; }
+.gist .file-data > table td.line-data { width: 99%; }
 
 div.unbreakable { page-break-inside: avoid; }
 
+.big { font-size: larger; }
 
-/*
- * xhtml11 specific
- *
- * */
+.small { font-size: smaller; }
 
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
+.underline { text-decoration: underline; }
 
+.overline { text-decoration: overline; }
 
-/*
- * html5 specific
- *
- * */
+.line-through { text-decoration: line-through; }
 
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
+.aqua { color: #00bfbf; }
 
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
+.aqua-background { background-color: #00fafa; }
 
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
+.black { color: black; }
 
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
+.black-background { background-color: black; }
 
+.blue { color: #0000bf; }
 
-/*
- * manpage specific
- *
- * */
+.blue-background { background-color: #0000fa; }
 
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
+.fuchsia { color: #bf00bf; }
 
-@media print {
-  body.manpage div#toc { display: none; }
-}
+.fuchsia-background { background-color: #fa00fa; }
 
+.gray { color: #606060; }
 
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
+.gray-background { background-color: #7d7d7d; }
 
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
+.green { color: #006000; }
 
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
+.green-background { background-color: #007d00; }
 
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
+.lime { color: #00bf00; }
 
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
+.lime-background { background-color: #00fa00; }
+
+.maroon { color: #600000; }
+
+.maroon-background { background-color: #7d0000; }
+
+.navy { color: #000060; }
+
+.navy-background { background-color: #00007d; }
+
+.olive { color: #606000; }
+
+.olive-background { background-color: #7d7d00; }
+
+.purple { color: #600060; }
+
+.purple-background { background-color: #7d007d; }
+
+.red { color: #bf0000; }
+
+.red-background { background-color: #fa0000; }
+
+.silver { color: #909090; }
+
+.silver-background { background-color: #bcbcbc; }
+
+.teal { color: #006060; }
+
+.teal-background { background-color: #007d7d; }
+
+.white { color: #bfbfbf; }
+
+.white-background { background-color: #fafafa; }
+
+.yellow { color: #bfbf00; }
+
+.yellow-background { background-color: #fafa00; }
+
+span.icon > .fa { cursor: default; }
+a span.icon > .fa { cursor: inherit; }
+
+.admonitionblock td.icon [class^="fa icon-"] { font-size: 2.5em; text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5); cursor: default; }
+.admonitionblock td.icon .icon-note:before { content: "\f05a"; color: #29475c; }
+.admonitionblock td.icon .icon-tip:before { content: "\f0eb"; text-shadow: 1px 1px 2px rgba(155, 155, 0, 0.8); color: #111; }
+.admonitionblock td.icon .icon-warning:before { content: "\f071"; color: #bf6900; }
+.admonitionblock td.icon .icon-caution:before { content: "\f06d"; color: #bf3400; }
+.admonitionblock td.icon .icon-important:before { content: "\f06a"; color: #bf0000; }
+
+.conum[data-value] { display: inline-block; color: #fff !important; background-color: black; -webkit-border-radius: 100px; border-radius: 100px; text-align: center; font-size: 0.75em; width: 1.67em; height: 1.67em; line-height: 1.67em; font-family: "Open Sans", "DejaVu Sans", sans-serif; font-style: normal; font-weight: bold; }
+.conum[data-value] * { color: #fff !important; }
+.conum[data-value] + b { display: none; }
+.conum[data-value]:after { content: attr(data-value); }
+pre .conum[data-value] { position: relative; top: -0.125em; }
+
+b.conum * { color: inherit !important; }
+
+.conum:not([data-value]):empty { display: none; }
+
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #dddddd; }
+
+.sect1 { padding-bottom: 0; }
+
+#toctitle { color: #00406F; font-weight: normal; margin-top: 1.5em; }
+
+.sidebarblock { border-color: #aaa; }
+
+code { -webkit-border-radius: 4px; border-radius: 4px; }
+
+p.tableblock.header { color: #6d6e71; }
+
+.literalblock pre, .listingblock pre { background: #eeeeee; }
+
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
-</head>
-<body class="article">
+<link rel="stylesheet" href="../katex/katex.min.css">
+<script src="../katex/katex.min.js"></script>
+<script src="../katex/contrib/auto-render.min.js"></script>
+    <!-- Use KaTeX to render math once document is loaded, see
+         https://github.com/Khan/KaTeX/tree/master/contrib/auto-render -->
+<script>
+    document.addEventListener("DOMContentLoaded", function () {
+        renderMathInElement(
+            document.body,
+            {
+                delimiters: [
+                    { left: "$$", right: "$$", display: true},
+                    { left: "\\[", right: "\\]", display: true},
+                    { left: "$", right: "$", display: false},
+                    { left: "\\(", right: "\\)", display: false}
+                ]
+            }
+        );
+    });
+</script></head>
+<body class="book">
 <div id="header">
 <h1>cl_intel_subgroups_short</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div class="details">
+<span id="revnumber">version V2.2-11-30-g5ba09e4,</span>
+<span id="revdate">Thu, 24 Oct 2019 22:38:28 +0000</span>
+<br><span id="revremark">from git branch: public_master commit: 5ba09e43bb29a2292d6af0b70148a9f846e1806f</span>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p><span class="monospaced">cl_intel_subgroups_short</span></p></div>
+<div class="paragraph">
+<p><code>cl_intel_subgroups_short</code></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel (ben <em>dot</em> ashbaugh <em>at</em> intel <em>dot</em> com)</p></div>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel (ben 'dot' ashbaugh 'at' intel 'dot' com)</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Ben Ashbaugh, Intel<br>
+<div class="paragraph">
+<p>Ben Ashbaugh, Intel<br>
 Felix J Degrood, Intel<br>
 Biju George, Intel<br>
 Raun M Krisch, Intel<br>
 Konstantin A Pyjov, Intel<br>
-Insoo Woo, Intel</p></div>
+Insoo Woo, Intel</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Final Draft</p></div>
+<div class="paragraph">
+<p>Final Draft</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Built On: 2018-11-16<br>
-Revision: 2</p></div>
+<div class="paragraph">
+<p>Built On: 2019-10-23<br>
+Revision: 3</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>OpenCL 1.2 and support for <span class="monospaced">cl_intel_subgroups</span> is required.
-This extension is written against the OpenCL API Specification Version 2.2 (revision v2.2-7), against the OpenCL C Language Specification Version 2.0 (revision v2.2-7), and against version 4 of the <span class="monospaced">cl_intel_subgroups</span> specification.</p></div>
+<div class="paragraph">
+<p>OpenCL 1.2 and support for <code>cl_intel_subgroups</code> is required.
+This extension is written against the OpenCL API Specification Version 2.2 (revision v2.2-7), against the OpenCL C Language Specification Version 2.0 (revision v2.2-7), and against version 4 of the <code>cl_intel_subgroups</code> specification.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>The goal of this extension is to allow programmers to improve the performance of applications operating on 16-bit data types by extending the subgroup functions described in the <span class="monospaced">cl_intel_subgroups</span> extension to support 16-bit integer data types (<span class="monospaced">shorts</span> and <span class="monospaced">ushorts</span>).
-Specifically, the extension:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>The goal of this extension is to allow programmers to improve the performance of applications operating on 16-bit data types by extending the subgroup functions described in the <code>cl_intel_subgroups</code> extension to support 16-bit integer data types (<code>shorts</code> and <code>ushorts</code>).
+Specifically, the extension:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Extends the subgroup broadcast function to allow 16-bit integer values to be broadcast from one work item to all other work items in the subgroup.
-</p>
+<p>Extends the subgroup broadcast function to allow 16-bit integer values to be broadcast from one work item to all other work items in the subgroup.</p>
 </li>
 <li>
-<p>
-Extends the subgroup scan and reduction functions to operate on 16-bit integer data types.
-</p>
+<p>Extends the subgroup scan and reduction functions to operate on 16-bit integer data types.</p>
 </li>
 <li>
-<p>
-Extends the Intel subgroup shuffle functions to allow arbitrarily exchanging 16-bit integer values among work items in the subgroup.
-</p>
+<p>Extends the Intel subgroup shuffle functions to allow arbitrarily exchanging 16-bit integer values among work items in the subgroup.</p>
 </li>
 <li>
-<p>
-Extends the Intel subgroup block read and write functions to allow reading and writing 16-bit integer data from images and buffers.
-</p>
+<p>Extends the Intel subgroup block read and write functions to allow reading and writing 16-bit integer data from images and buffers.</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_functions">New API Functions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_api_enums">New API Enums</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_opencl_c_functions">New OpenCL C Functions</h2>
 <div class="sectionbody">
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Add <span class="monospaced">short</span> and <span class="monospaced">ushort</span> to the list of supported data types for the subgroup broadcast, scan, and reduction functions: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Add <code>short</code> and <code>ushort</code> to the list of supported data types for the subgroup broadcast, scan, and reduction functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_broadcast</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x<span style="color: #990000">,</span> <span style="color: #008080">uint</span> sub_group_local_id <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_broadcast</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x<span style="color: #990000">,</span> <span style="color: #008080">uint</span> sub_group_local_id <span style="color: #990000">)</span>
+<div class="content">
+<pre class="highlight"><code>short   intel_sub_group_broadcast( short x, uint sub_group_local_id )
+ushort  intel_sub_group_broadcast( ushort x, uint sub_group_local_id )
 
-<span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_add</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_min</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_max</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
+short   intel_sub_group_reduce_add( short x )
+ushort  intel_sub_group_reduce_add( ushort x )
+short   intel_sub_group_reduce_min( short x )
+ushort  intel_sub_group_reduce_min( ushort x )
+short   intel_sub_group_reduce_max( short x )
+ushort  intel_sub_group_reduce_max( ushort x )
 
-<span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
+short   intel_sub_group_scan_exclusive_add( short x )
+ushort  intel_sub_group_scan_exclusive_add( ushort x )
+short   intel_sub_group_scan_exclusive_min( short x )
+ushort  intel_sub_group_scan_exclusive_min( ushort x )
+short   intel_sub_group_scan_exclusive_max( short x )
+ushort  intel_sub_group_scan_exclusive_max( ushort x )
 
-<span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span></tt></pre></div></div>
-</div></div>
+short   intel_sub_group_scan_inclusive_add( short x )
+ushort  intel_sub_group_scan_inclusive_add( ushort x )
+short   intel_sub_group_scan_inclusive_min( short x )
+ushort  intel_sub_group_scan_inclusive_min( ushort x )
+short   intel_sub_group_scan_inclusive_max( short x )
+ushort  intel_sub_group_scan_inclusive_max( ushort x )</code></pre>
+</div>
+</div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-Add <span class="monospaced">short</span>, <span class="monospaced">short2</span>, <span class="monospaced">short4</span>, <span class="monospaced">short8</span>, <span class="monospaced">short16</span>, <span class="monospaced">ushort</span>, <span class="monospaced">ushort2</span>, <span class="monospaced">ushort4</span>, <span class="monospaced">ushort8</span>, and <span class="monospaced">ushort16</span> to the list of <span class="monospaced">gentype</span> data types supported by the <span class="monospaced">sub_group_shuffle</span>, <span class="monospaced">sub_group_shuffle_down</span>, <span class="monospaced">sub_group_shuffle_up</span>, and <span class="monospaced">sub_group_shuffle_xor</span> functions: 
-</dt>
+<dt class="hdlist1">Add <code>short</code>, <code>short2</code>, <code>short3</code>, <code>short4</code>, <code>short8</code>, <code>short16</code>, <code>ushort</code>, <code>ushort2</code>, <code>ushort3</code>, <code>ushort4</code>, <code>ushort8</code>, and <code>ushort16</code> to the list of <code>gentype</code> data types supported by the <code>sub_group_shuffle</code>, <code>sub_group_shuffle_down</code>, <code>sub_group_shuffle_up</code>, and <code>sub_group_shuffle_xor</code> functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> data<span style="color: #990000">,</span> <span style="color: #008080">uint</span> c <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle_down</span></span><span style="color: #990000">(</span>
-                <span style="color: #008080">gentype</span> current<span style="color: #990000">,</span> <span style="color: #008080">gentype</span> next<span style="color: #990000">,</span> <span style="color: #008080">uint</span> delta <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle_up</span></span><span style="color: #990000">(</span>
-                <span style="color: #008080">gentype</span> previous<span style="color: #990000">,</span> <span style="color: #008080">gentype</span> current<span style="color: #990000">,</span> <span style="color: #008080">uint</span> delta <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_shuffle_xor</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> data<span style="color: #990000">,</span> <span style="color: #008080">uint</span> value <span style="color: #990000">)</span></tt></pre></div></div>
-</div></div>
+<div class="content">
+<pre class="highlight"><code>gentype intel_sub_group_shuffle( gentype data, uint c )
+gentype intel_sub_group_shuffle_down(
+                gentype current, gentype next, uint delta )
+gentype intel_sub_group_shuffle_up(
+                gentype previous, gentype current, uint delta )
+gentype intel_sub_group_shuffle_xor( gentype data, uint value )</code></pre>
+</div>
+</div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-Add <span class="monospaced">ushort</span> variants of the subgroup block read and write functions: 
-</dt>
+<dt class="hdlist1">Add <code>ushort</code> variants of the subgroup block read and write functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">ushort2</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us2</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">ushort4</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us4</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">ushort8</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us8</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">ushort2</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us2</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">ushort4</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us4</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">ushort8</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us8</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
+<div class="content">
+<pre class="highlight"><code>ushort   intel_sub_group_block_read_us( const __global ushort* p )
+ushort2  intel_sub_group_block_read_us2( const __global ushort* p )
+ushort4  intel_sub_group_block_read_us4( const __global ushort* p )
+ushort8  intel_sub_group_block_read_us8( const __global ushort* p )
+ushort   intel_sub_group_block_read_us( image2d_t image, int2 byte_coord )
+ushort2  intel_sub_group_block_read_us2( image2d_t image, int2 byte_coord )
+ushort4  intel_sub_group_block_read_us4( image2d_t image, int2 byte_coord )
+ushort8  intel_sub_group_block_read_us8( image2d_t image, int2 byte_coord )
 
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">ushort</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us2</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">ushort2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us4</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">ushort4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us8</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">ushort8</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">ushort</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us2</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">ushort2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us4</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">ushort4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us8</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">ushort8</span> data <span style="color: #990000">)</span></tt></pre></div></div>
-</div></div>
+void  intel_sub_group_block_write_us( __global ushort* p, ushort data )
+void  intel_sub_group_block_write_us2( __global ushort* p, ushort2 data )
+void  intel_sub_group_block_write_us4( __global ushort* p, ushort4 data )
+void  intel_sub_group_block_write_us8( __global ushort* p, ushort8 data )
+void  intel_sub_group_block_write_us( image2d_t image, int2 byte_coord, ushort data )
+void  intel_sub_group_block_write_us2( image2d_t image, int2 byte_coord, ushort2 data )
+void  intel_sub_group_block_write_us4( image2d_t image, int2 byte_coord, ushort4 data )
+void  intel_sub_group_block_write_us8( image2d_t image, int2 byte_coord, ushort8 data )</code></pre>
+</div>
+</div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-For naming consistency, also add suffixed aliases of the <span class="monospaced">uint</span> subgroup block read and write functions described in the <span class="monospaced">cl_intel_subgroups</span> extension: 
-</dt>
+<dt class="hdlist1">For naming consistency, also add suffixed aliases of the <code>uint</code> subgroup block read and write functions described in the <code>cl_intel_subgroups</code> extension: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint2</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui2</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint4</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui4</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint8</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui8</span></span><span style="color: #990000">(</span> <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint2</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui2</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint4</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui4</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint8</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui8</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
+<div class="content">
+<pre class="highlight"><code>uint  intel_sub_group_block_read_ui( const __global uint* p )
+uint2 intel_sub_group_block_read_ui2( const __global uint* p )
+uint4 intel_sub_group_block_read_ui4( const __global uint* p )
+uint8 intel_sub_group_block_read_ui8( const __global uint* p )
+uint  intel_sub_group_block_read_ui( image2d_t image, int2 byte_coord )
+uint2 intel_sub_group_block_read_ui2( image2d_t image, int2 byte_coord )
+uint4 intel_sub_group_block_read_ui4( image2d_t image, int2 byte_coord )
+uint8 intel_sub_group_block_read_ui8( image2d_t image, int2 byte_coord )
 
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui2</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui4</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui8</span></span><span style="color: #990000">(</span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui2</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui4</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui8</span></span><span style="color: #990000">(</span> <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span> <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">)</span></tt></pre></div></div>
-</div></div>
+void  intel_sub_group_block_write_ui( __global uint* p, uint data )
+void  intel_sub_group_block_write_ui2( __global uint* p, uint2 data )
+void  intel_sub_group_block_write_ui4( __global uint* p, uint4 data )
+void  intel_sub_group_block_write_ui8( __global uint* p, uint8 data )
+void  intel_sub_group_block_write_ui( image2d_t image, int2 byte_coord, uint data )
+void  intel_sub_group_block_write_ui2( image2d_t image, int2 byte_coord, uint2 data )
+void  intel_sub_group_block_write_ui4( image2d_t image, int2 byte_coord, uint4 data )
+void  intel_sub_group_block_write_ui8( image2d_t image, int2 byte_coord, uint8 data )</code></pre>
+</div>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -990,333 +978,330 @@ http://www.gnu.org/software/src-highlite -->
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_additions_to_section_6_13_15_work_group_functions">Additions to Section 6.13.15 - "Work Group Functions"</h3>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Add <span class="monospaced">short</span> and <span class="monospaced">ushort</span> to the list of supported data types for the subgroup broadcast, scan, and reduction functions: 
-</dt>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Add <code>short</code> and <code>ushort</code> to the list of supported data types for the subgroup broadcast, scan, and reduction functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:66%;">
-<col style="width:33%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 66.6666%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > <strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" > <strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_broadcast</span></span><span style="color: #990000">(</span>
-          <span style="color: #008080">gentype</span> x<span style="color: #990000">,</span>
-          <span style="color: #008080">uint</span> sub_group_local_id <span style="color: #990000">)</span>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_broadcast(
+          gentype x,
+          uint sub_group_local_id )
 
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_broadcast</span></span><span style="color: #990000">(</span>
-          <span style="color: #009900">short</span> x<span style="color: #990000">,</span>
-          <span style="color: #008080">uint</span> sub_group_local_id <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_broadcast</span></span><span style="color: #990000">(</span>
-          <span style="color: #008080">ushort</span> x<span style="color: #990000">,</span>
-          <span style="color: #008080">uint</span> sub_group_local_id <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Broadcasts the value of <em>x</em> for work item identified by <em>sub_group_local_id</em> (value returned by  <strong>get_sub_group_local_id</strong>) to all work items in the subgroup.
+short    intel_sub_group_broadcast(
+          short x,
+          uint sub_group_local_id )
+ushort   intel_sub_group_broadcast(
+          ushort x,
+          uint sub_group_local_id )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Broadcasts the value of <em>x</em> for work item identified by <em>sub_group_local_id</em> (value returned by  <strong>get_sub_group_local_id</strong>) to all work items in the subgroup.
 <em>sub_group_local_id</em> must be the same value for all work items in the subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_reduce_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_reduce_add( gentype x )
+gentype sub_group_reduce_min( gentype x )
+gentype sub_group_reduce_max( gentype x )
 
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_add</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_min</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_max</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_reduce_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Returns the result of the specified reduction operation for all values of <em>x</em> specified by work items in a subgroup.</p></td>
+short    intel_sub_group_reduce_add( short x )
+ushort   intel_sub_group_reduce_add( ushort x )
+short    intel_sub_group_reduce_min( short x )
+ushort   intel_sub_group_reduce_min( ushort x )
+short    intel_sub_group_reduce_max( short x )
+ushort   intel_sub_group_reduce_max( ushort x )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the result of the specified reduction operation for all values of <em>x</em> specified by work items in a subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_exclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x <span style="color: #990000">)</span>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_scan_exclusive_add( gentype x )
+gentype sub_group_scan_exclusive_min( gentype x )
+gentype sub_group_scan_exclusive_max( gentype x )
 
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_exclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Performs the specified exclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
+short    intel_sub_group_scan_exclusive_add( short x )
+ushort   intel_sub_group_scan_exclusive_add( ushort x )
+short    intel_sub_group_scan_exclusive_min( short x )
+ushort   intel_sub_group_scan_exclusive_min( ushort x )
+short    intel_sub_group_scan_exclusive_max( short x )
+ushort   intel_sub_group_scan_exclusive_max( ushort x )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Performs the specified exclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
 The scan results are returned for each work item.</p>
 <p class="tableblock">The scan order is defined by increasing subgroup local ID within the subgroup.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span>
-<span style="color: #008080">gentype</span> <span style="font-weight: bold"><span style="color: #000000">sub_group_scan_inclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">gentype</span> x<span style="color: #990000">)</span>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_scan_inclusive_add( gentype x)
+gentype sub_group_scan_inclusive_min( gentype x)
+gentype sub_group_scan_inclusive_max( gentype x)
 
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_add</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_min</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span>
-<span style="color: #009900">short</span>    <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #009900">short</span> x <span style="color: #990000">)</span>
-<span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_scan_inclusive_max</span></span><span style="color: #990000">(</span> <span style="color: #008080">ushort</span> x <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Performs the specified inclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
+short    intel_sub_group_scan_inclusive_add( short x )
+ushort   intel_sub_group_scan_inclusive_add( ushort x )
+short    intel_sub_group_scan_inclusive_min( short x )
+ushort   intel_sub_group_scan_inclusive_min( ushort x )
+short    intel_sub_group_scan_inclusive_max( short x )
+ushort   intel_sub_group_scan_inclusive_max( ushort x )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Performs the specified inclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
 The scan results are returned for each work item.</p>
 <p class="tableblock">The scan order is defined by increasing subgroup local ID within the subgroup.</p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_additions_to_section_6_13_x_sub_group_shuffle_functions">Additions to Section 6.13.X - "Sub Group Shuffle Functions"</h3>
-<div class="paragraph"><p>This section was added by the <span class="monospaced">cl_intel_subgroups</span> extension.</p></div>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Add <span class="monospaced">short</span>, <span class="monospaced">short2</span>, <span class="monospaced">short4</span>, <span class="monospaced">short8</span>, <span class="monospaced">short16</span>, <span class="monospaced">ushort</span>, <span class="monospaced">ushort2</span>, <span class="monospaced">ushort4</span>, <span class="monospaced">ushort8</span>, and <span class="monospaced">ushort16</span> to the list of data types supported by the <span class="monospaced">sub_group_shuffle</span>, <span class="monospaced">sub_group_shuffle_down</span>, <span class="monospaced">sub_group_shuffle_up</span>, and <span class="monospaced">sub_group_shuffle_xor</span> functions: 
-</dt>
+<div class="paragraph">
+<p>This section was added by the <code>cl_intel_subgroups</code> extension.</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Add <code>short</code>, <code>short2</code>, <code>short3</code>, <code>short4</code>, <code>short8</code>, <code>short16</code>, <code>ushort</code>, <code>ushort2</code>, <code>ushort3</code>, <code>ushort4</code>, <code>ushort8</code>, and <code>ushort16</code> to the list of data types supported by the <code>sub_group_shuffle</code>, <code>sub_group_shuffle_down</code>, <code>sub_group_shuffle_up</code>, and <code>sub_group_shuffle_xor</code> functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p>The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
+<div class="paragraph">
+<p>The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
 These built-in functions need not be encountered by all work items in a subgroup executing the kernel, however, data may only be shuffled among work items encountering the subgroup shuffle function.
 Shuffling data from a work item that does not encounter the subgroup shuffle function will produce undefined results.
-For these functions, <span class="monospaced">gentype</span> is <span class="monospaced">float</span>, <span class="monospaced">float2</span>, <span class="monospaced">float4</span>, <span class="monospaced">float8</span>, <span class="monospaced">float16</span>, <span class="monospaced">short</span>, <span class="monospaced">short2</span>, <span class="monospaced">short4</span>, <span class="monospaced">short8</span>, <span class="monospaced">short16</span>, <span class="monospaced">ushort</span>, <span class="monospaced">ushort2</span>, <span class="monospaced">ushort4</span>, <span class="monospaced">ushort8</span>, <span class="monospaced">ushort16</span>, <span class="monospaced">int</span>, <span class="monospaced">int2</span>, <span class="monospaced">int4</span>, <span class="monospaced">int8</span>, <span class="monospaced">int16</span>, <span class="monospaced">uint</span>, <span class="monospaced">uint2</span>, <span class="monospaced">uint4</span>, <span class="monospaced">uint8</span>, <span class="monospaced">uint16</span>, <span class="monospaced">long</span>, or <span class="monospaced">ulong</span>.</p></div>
-<div class="paragraph"><p>If <span class="monospaced">cl_khr_fp16</span> is supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">half</span>.</p></div>
-<div class="paragraph"><p>If <span class="monospaced">cl_khr_fp64</span> or doubles are supported, <span class="monospaced">gentype</span> also includes <span class="monospaced">double</span>.</p></div>
-</div></div>
+For these functions, <code>gentype</code> is <code>float</code>, <code>float2</code>, <code>float3</code>, <code>float4</code>, <code>float8</code>, <code>float16</code>, <code>short</code>, <code>short2</code>, <code>short3</code>, <code>short4</code>, <code>short8</code>, <code>short16</code>, <code>ushort</code>, <code>ushort2</code>, <code>ushort3</code>, <code>ushort4</code>, <code>ushort8</code>, <code>ushort16</code>, <code>int</code>, <code>int2</code>, <code>int3</code>, <code>int4</code>, <code>int8</code>, <code>int16</code>, <code>uint</code>, <code>uint2</code>, <code>uint3</code>, <code>uint4</code>, <code>uint8</code>, <code>uint16</code>, <code>long</code>, or <code>ulong</code>.</p>
+</div>
+<div class="paragraph">
+<p>If <code>cl_khr_fp16</code> is supported, <code>gentype</code> also includes <code>half</code>.</p>
+</div>
+<div class="paragraph">
+<p>If <code>cl_khr_fp64</code> or doubles are supported, <code>gentype</code> also includes <code>double</code>.</p>
+</div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_modifications_to_section_6_13_x_sub_group_read_and_write_functions">Modifications to Section 6.13.X "Sub Group Read and Write Functions"</h3>
-<div class="paragraph"><p>This section was added by the <span class="monospaced">cl_intel_subgroups</span> extension.</p></div>
-<div class="dlist"><dl>
-<dt class="hdlist1">
-Add suffixed aliases of the previously un-suffixed 32-bit block read and write functions. There is no change to the description or behavior of these functions: 
-</dt>
+<div class="paragraph">
+<p>This section was added by the <code>cl_intel_subgroups</code> extension.</p>
+</div>
+<div class="dlist">
+<dl>
+<dt class="hdlist1">Add suffixed aliases of the previously un-suffixed 32-bit block read and write functions. There is no change to the description or behavior of these functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:55%;">
-<col style="width:44%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 55.5555%;">
+<col style="width: 44.4445%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" ><strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" ><strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint2</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read2</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint4</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read4</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint8</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read8</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint  intel_sub_group_block_read(
+        const __global uint* p )
+uint2 intel_sub_group_block_read2(
+        const __global uint* p )
+uint4 intel_sub_group_block_read4(
+        const __global uint* p )
+uint8 intel_sub_group_block_read8(
+        const __global uint* p )
 
-<span style="color: #008080">uint</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint2</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui2</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint4</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui4</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">uint8</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui8</span></span><span style="color: #990000">(</span>
-        <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified pointer as a block operation&#8230;</p></td>
+uint  intel_sub_group_block_read_ui(
+        const __global uint* p )
+uint2 intel_sub_group_block_read_ui2(
+        const __global uint* p )
+uint4 intel_sub_group_block_read_ui4(
+        const __global uint* p )
+uint8 intel_sub_group_block_read_ui8(
+        const __global uint* p )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified pointer as a block operation&#8230;&#8203;</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">uint</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint2</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint4</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint8</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">uint  intel_sub_group_block_read(
+        image2d_t image,
+        int2 byte_coord )
+uint2 intel_sub_group_block_read2(
+        image2d_t image,
+        int2 byte_coord )
+uint4 intel_sub_group_block_read4(
+        image2d_t image,
+        int2 byte_coord )
+uint8 intel_sub_group_block_read8(
+        image2d_t image,
+        int2 byte_coord )
 
-<span style="color: #008080">uint</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint2</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint4</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">uint8</span> <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_ui8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified image at the specified coordinate as a block operation&#8230;</p></td>
+uint  intel_sub_group_block_read_ui(
+        image2d_t image,
+        int2 byte_coord )
+uint2 intel_sub_group_block_read_ui2(
+        image2d_t image,
+        int2 byte_coord )
+uint4 intel_sub_group_block_read_ui4(
+        image2d_t image,
+        int2 byte_coord )
+uint8 intel_sub_group_block_read_ui8(
+        image2d_t image,
+        int2 byte_coord )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified image at the specified coordinate as a block operation&#8230;&#8203;</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">)</span>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write(
+        __global uint* p, uint data )
+void  intel_sub_group_block_write2(
+        __global uint* p, uint2 data )
+void  intel_sub_group_block_write4(
+        __global uint* p, uint4 data )
+void  intel_sub_group_block_write8(
+        __global uint* p, uint8 data )
 
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> uint<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified pointer as a block operation&#8230;</p></td>
+void  intel_sub_group_block_write_ui(
+        __global uint* p, uint data )
+void  intel_sub_group_block_write_ui2(
+        __global uint* p, uint2 data )
+void  intel_sub_group_block_write_ui4(
+        __global uint* p, uint4 data )
+void  intel_sub_group_block_write_ui8(
+        __global uint* p, uint8 data )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified pointer as a block operation&#8230;&#8203;</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">)</span>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write(
+        image2d_t image,
+        int2 byte_coord, uint data )
+void  intel_sub_group_block_write2(
+        image2d_t image,
+        int2 byte_coord, uint2 data )
+void  intel_sub_group_block_write4(
+        image2d_t image,
+        int2 byte_coord, uint4 data )
+void  intel_sub_group_block_write8(
+        image2d_t image,
+        int2 byte_coord, uint8 data )
 
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_ui8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">uint8</span> data <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified image at the specified coordinate as a block operation&#8230;</p></td>
+void  intel_sub_group_block_write_ui(
+        image2d_t image,
+        int2 byte_coord, uint data )
+void  intel_sub_group_block_write_ui2(
+        image2d_t image,
+        int2 byte_coord, uint2 data )
+void  intel_sub_group_block_write_ui4(
+        image2d_t image,
+        int2 byte_coord, uint4 data )
+void  intel_sub_group_block_write_ui8(
+        image2d_t image,
+        int2 byte_coord, uint8 data )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified image at the specified coordinate as a block operation&#8230;&#8203;</p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </dd>
-<dt class="hdlist1">
-Also, add <span class="monospaced">ushort</span> variants of the block read and write functions.  In the descriptions of these functions, the "note below describing out-of-bounds behavior" is in the <span class="monospaced">cl_intel_subgroups</span> extension specification: 
-</dt>
+<dt class="hdlist1">Also, add <code>ushort</code> variants of the block read and write functions.  In the descriptions of these functions, the "note below describing out-of-bounds behavior" is in the <code>cl_intel_subgroups</code> extension specification: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:55%;">
-<col style="width:44%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 55.5555%;">
+<col style="width: 44.4445%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" ><strong>Function</strong></th>
-<th class="tableblock halign-left valign-top" ><strong>Description</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Function</strong></th>
+<th class="tableblock halign-left valign-top"><strong>Description</strong></th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us</span></span><span style="color: #990000">(</span>
-          <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">ushort2</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us2</span></span><span style="color: #990000">(</span>
-          <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">ushort4</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us4</span></span><span style="color: #990000">(</span>
-          <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p <span style="color: #990000">)</span>
-<span style="color: #008080">ushort8</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us8</span></span><span style="color: #990000">(</span>
-          <span style="font-weight: bold"><span style="color: #0000FF">const</span></span> <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Reads 1, 2, 4, or 8 ushorts of data for each work item in the subgroup from the specified pointer as a block operation.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">ushort   intel_sub_group_block_read_us(
+          const __global ushort* p )
+ushort2  intel_sub_group_block_read_us2(
+          const __global ushort* p )
+ushort4  intel_sub_group_block_read_us4(
+          const __global ushort* p )
+ushort8  intel_sub_group_block_read_us8(
+          const __global ushort* p )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 ushorts of data for each work item in the subgroup from the specified pointer as a block operation.
 The data is read strided, so the first value read is:</p>
-<p class="tableblock"><span class="monospaced">p[ sub_group_local_id ]</span></p>
+<p class="tableblock"><code>p[ sub_group_local_id ]</code></p>
 <p class="tableblock">and the second value read is:</p>
-<p class="tableblock"><span class="monospaced">p[ sub_group_local_id + max_sub_group_size ]</span></p>
+<p class="tableblock"><code>p[ sub_group_local_id + max_sub_group_size ]</code></p>
 <p class="tableblock">etc.</p>
 <p class="tableblock"><em>p</em> must be aligned to a 32-bit (4-byte) boundary.</p>
 <p class="tableblock">There is no defined out-of-range behavior for these functions.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #008080">ushort</span>   <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us</span></span><span style="color: #990000">(</span>
-          <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-          <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">ushort2</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us2</span></span><span style="color: #990000">(</span>
-          <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-          <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">ushort4</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us4</span></span><span style="color: #990000">(</span>
-          <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-          <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span>
-<span style="color: #008080">ushort8</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_read_us8</span></span><span style="color: #990000">(</span>
-          <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-          <span style="color: #008080">int2</span> byte_coord <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Reads 1, 2, 4, or 8 ushorts of data for each work item in the subgroup from the specified <em>image</em> at the specified coordinate as a block operation.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">ushort   intel_sub_group_block_read_us(
+          image2d_t image,
+          int2 byte_coord )
+ushort2  intel_sub_group_block_read_us2(
+          image2d_t image,
+          int2 byte_coord )
+ushort4  intel_sub_group_block_read_us4(
+          image2d_t image,
+          int2 byte_coord )
+ushort8  intel_sub_group_block_read_us8(
+          image2d_t image,
+          int2 byte_coord )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 ushorts of data for each work item in the subgroup from the specified <em>image</em> at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Also note that the image data is read without format conversion, so each work item may read multiple image elements
 (for images with element size smaller than 16-bits).</p>
@@ -1324,47 +1309,45 @@ Also note that the image data is read without format conversion, so each work it
 <p class="tableblock">Please see the note below describing out-of-bounds behavior for these functions.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">ushort</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">ushort2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">ushort4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">__global</span> ushort<span style="color: #990000">*</span> p<span style="color: #990000">,</span> <span style="color: #008080">ushort8</span> data <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Writes 1, 2, 4, or 8 ushorts of data for each work item in the subgroup to the specified pointer as a block operation.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write_us(
+        __global ushort* p, ushort data )
+void  intel_sub_group_block_write_us2(
+        __global ushort* p, ushort2 data )
+void  intel_sub_group_block_write_us4(
+        __global ushort* p, ushort4 data )
+void  intel_sub_group_block_write_us8(
+        __global ushort* p, ushort8 data )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 ushorts of data for each work item in the subgroup to the specified pointer as a block operation.
 The data is written strided, so the first value is written to:</p>
-<p class="tableblock"><span class="monospaced">p[ sub_group_local_id ]</span></p>
+<p class="tableblock"><code>p[ sub_group_local_id ]</code></p>
 <p class="tableblock">and the second value is written to:</p>
-<p class="tableblock"><span class="monospaced">p[ sub_group_local_id + max_sub_group_size ]</span></p>
+<p class="tableblock"><code>p[ sub_group_local_id + max_sub_group_size ]</code></p>
 <p class="tableblock">etc.</p>
 <p class="tableblock"><em>p</em> must be aligned to a 128-bit (16-byte) boundary.</p>
 <p class="tableblock">There is no defined out-of-range behavior for these functions.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="listingblock">
-<div class="content"><!-- Generator: GNU source-highlight 3.1.8
-by Lorenzo Bettini
-http://www.lorenzobettini.it
-http://www.gnu.org/software/src-highlite -->
-<pre><tt><span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">ushort</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us2</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">ushort2</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us4</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">ushort4</span> data <span style="color: #990000">)</span>
-<span style="color: #009900">void</span>  <span style="font-weight: bold"><span style="color: #000000">intel_sub_group_block_write_us8</span></span><span style="color: #990000">(</span>
-        <span style="color: #008080">image2d_t</span> image<span style="color: #990000">,</span>
-        <span style="color: #008080">int2</span> byte_coord<span style="color: #990000">,</span> <span style="color: #008080">ushort8</span> data <span style="color: #990000">)</span></tt></pre></div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Writes 1, 2, 4, or 8 ushorts of data for each work item in the subgroup to the specified <em>image</em> at the specified coordinate as a block operation.
+<td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write_us(
+        image2d_t image,
+        int2 byte_coord, ushort data )
+void  intel_sub_group_block_write_us2(
+        image2d_t image,
+        int2 byte_coord, ushort2 data )
+void  intel_sub_group_block_write_us4(
+        image2d_t image,
+        int2 byte_coord, ushort4 data )
+void  intel_sub_group_block_write_us8(
+        image2d_t image,
+        int2 byte_coord, ushort8 data )</code></pre>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 ushorts of data for each work item in the subgroup to the specified <em>image</em> at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Unlike the image block read function, which may read from any arbitrary byte offset, the x-component of the byte coordinate for the image block write functions must be a multiple of four;
 in other words, the write must begin at 32-bit boundary.
@@ -1375,61 +1358,71 @@ Also, note that the image <em>data</em> is written without format conversion, so
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </dd>
-</dl></div>
+</dl>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2016-10-20</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>First public revision.</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2016-10-20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>First public revision.</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-11-15</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Conversion to asciidoc.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-11-15</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Conversion to asciidoc.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-09-17</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Added vec3 types for shuffles and asciidoctor formatting fixes.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
-<div id="footnotes"><hr></div>
 <div id="footer">
 <div id="footer-text">
-Last updated
- 2018-11-16 09:32:34 PST
+Version V2.2-11-30-g5ba09e4<br>
+Last updated 2019-10-23 15:35:34 -0700
 </div>
 </div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR updates the Intel HTML extension specifications.  These specifications include the fixes added in https://github.com/KhronosGroup/OpenCL-Docs/pull/135 and switches to the new Asciidoctor toolchain.