### PR TITLE
add KHR extensions to OpenCL registry

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,10 +1,10 @@
 = OpenCL-Registry
 
 The OpenCL-Registry repository contains the OpenCL API and Extension
-Registry, including specifications, reference pages and reference cards, and
-the enumerant registry. It is also used as a backing store for the web view
-of the registry at https://www.khronos.org/registry/cl/ ; commits to the
-main branch of this repository will be reflected there.
+Registry, including specifications, reference pages, and reference cards.
+It is also used as a backing store for the web view of the registry at
+https://www.khronos.org/registry/cl/ ; commits to the main branch of this
+repository will be reflected there.
 
 Please file issues with the OpenCL API (specification bugs, feature
 requests, etc.) on the companion https://github.com/KhronosGroup/OpenCL-Docs
@@ -31,8 +31,8 @@ your assigned range for API extensions.
 == Adding Extension Specifications
 
 Extension specification documents can be added by proposing a pull request
-to main, adding the specification '.txt' file under
-'extensions/<vendor>/filename.txt'. You must also:
+to main, adding the specification '.txt' or '.html' file under
+'extensions/<vendor>/<filename>'. You must also:
 
 * Modify 'extensions/registry.py' to include the extension, using the next
   free extension number. Execute the python script 'nextfree.py' in the
@@ -47,22 +47,23 @@ to main, adding the specification '.txt' file under
 
 Sometimes extension text files contain inappropriate UTF-8 characters. They
 should be restricted to the ASCII subset of UTF-8 at present. They can be
-removed using the iconv Linux command-line tool via
+identified using the iconv Linux command-line tool via
 
     iconv -c -f utf-8 -t ascii filename.txt
 
 (see internal Bugzilla issue 16141 for more).
 
-We will be transitioning to an asciidoc-based extension specification format
-at some point.
+It is recommended to use the asciidoc-based extension template to generate HTML
+extension specifications instead, see
+https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_extension_template.asciidoc
 
 == Repository Contents
 
 Interesting files in this repository include:
 
-* 'index.php' - toplevel index page for the web view. This relies on PHP
-  include files found elsewhere on https://www.khronos.org and so is not very useful
-  in isolation.
+* 'index.php' - top-level index page for the web view. This relies on PHP
+  include files found elsewhere on https://www.khronos.org and so is not very
+  useful in isolation.
 * 'extensions/' - OpenCL extension specifications, grouped into
   vendor-specific subdirectories.
 ** 'extensions/registry.py' - extension registry.

--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 The Khronos Group Inc.
+# Copyright (c) 2021 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,10 @@
 PYTHON = python3
 SCRIPTS = registry.py makeindex.py
 
-all: clext.php
+all: clext.php khrext.php
+
+khrext.php: $(SCRIPTS)
+	$(PYTHON) makeindex.py -key khrnumber >$@
 
 clext.php: $(SCRIPTS)
-	$(PYTHON) makeindex.py number >$@
+	$(PYTHON) makeindex.py -key number >$@

--- a/extensions/clext.php
+++ b/extensions/clext.php
@@ -1,144 +1,138 @@
-<ol>
-<li value=1><a href="extensions/khr/cl_khr_gl_sharing.txt">cl_khr_gl_sharing</a>
+<ul>
+<li><a href="extensions/altera/cl_altera_compiler_mode.txt">cl_altera_compiler_mode</a>
 </li>
-<li value=2><a href="extensions/nv/cl_nv_d3d9_sharing.txt">cl_nv_d3d9_sharing</a>
+<li><a href="extensions/altera/cl_altera_device_temperature.txt">cl_altera_device_temperature</a>
 </li>
-<li value=3><a href="extensions/nv/cl_nv_d3d10_sharing.txt">cl_nv_d3d10_sharing</a>
+<li><a href="extensions/altera/cl_altera_live_object_tracking.txt">cl_altera_live_object_tracking</a>
 </li>
-<li value=4><a href="extensions/nv/cl_nv_d3d11_sharing.txt">cl_nv_d3d11_sharing</a>
+<li><a href="extensions/amd/cl_amd_bus_addressable_memory.txt">cl_amd_bus_addressable_memory</a>
 </li>
-<li value=5><a href="extensions/khr/cl_khr_icd.txt">cl_khr_icd</a>
+<li><a href="extensions/amd/cl_amd_device_attribute_query.txt">cl_amd_device_attribute_query</a>
 </li>
-<li value=6><a href="extensions/khr/cl_khr_d3d10_sharing.txt">cl_khr_d3d10_sharing</a>
+<li><a href="extensions/amd/cl_amd_fp64.txt">cl_amd_fp64</a>
 </li>
-<li value=7><a href="extensions/amd/cl_amd_device_attribute_query.txt">cl_amd_device_attribute_query</a>
+<li><a href="extensions/amd/cl_amd_media_ops.txt">cl_amd_media_ops</a>
 </li>
-<li value=8><a href="extensions/amd/cl_amd_fp64.txt">cl_amd_fp64</a>
+<li><a href="extensions/amd/cl_amd_media_ops2.txt">cl_amd_media_ops2</a>
 </li>
-<li value=9><a href="extensions/amd/cl_amd_media_ops.txt">cl_amd_media_ops</a>
+<li><a href="extensions/amd/cl_amd_planar_yuv.txt">cl_amd_planar_yuv</a>
 </li>
-<li value=10><a href="extensions/ext/cl_ext_migrate_memobject.txt">cl_ext_migrate_memobject</a>
+<li><a href="extensions/arm/cl_arm_controlled_kernel_termination.html">cl_arm_controlled_kernel_termination</a>
 </li>
-<li value=11><a href="extensions/ext/cl_ext_device_fission.txt">cl_ext_device_fission</a>
+<li><a href="extensions/arm/cl_arm_get_core_id.txt">cl_arm_core_id</a>
 </li>
-<li value=12><a href="extensions/ext/cl_ext_atomic_counters_32.txt">cl_ext_atomic_counters_32</a>
+<li><a href="extensions/arm/cl_arm_import_memory.txt">cl_arm_import_memory</a>
 </li>
-<li value=13><a href="extensions/ext/cl_ext_atomic_counters_64.txt">cl_ext_atomic_counters_64</a>
+<li><a href="extensions/arm/cl_arm_integer_dot_product.txt">cl_arm_integer_dot_product</a>
 </li>
-<li value=14><a href="extensions/intel/cl_intel_dx9_media_sharing.txt">cl_intel_dx9_media_sharing</a>
+<li><a href="extensions/arm/cl_arm_job_slot_selection.txt">cl_arm_job_slot_selection</a>
 </li>
-<li value=15><a href="extensions/amd/cl_amd_media_ops2.txt">cl_amd_media_ops2</a>
+<li><a href="extensions/arm/cl_arm_non_uniform_work_group_size.txt">cl_arm_non_uniform_work_group_size</a>
 </li>
-<li value=16><a href="extensions/intel/cl_intel_thread_local_exec.txt">cl_intel_thread_local_exec</a>
+<li><a href="extensions/arm/cl_arm_printf.txt">cl_arm_printf</a>
 </li>
-<li value=17><a href="extensions/nv/cl_nv_compiler_options.txt">cl_nv_compiler_options</a>
+<li><a href="extensions/arm/cl_arm_scheduling_controls.html">cl_arm_scheduling_controls</a>
 </li>
-<li value=18><a href="extensions/nv/cl_nv_device_attribute_query.txt">cl_nv_device_attribute_query</a>
+<li><a href="extensions/arm/cl_arm_shared_virtual_memory.txt">cl_arm_shared_virtual_memory</a>
 </li>
-<li value=19><a href="extensions/nv/cl_nv_pragma_unroll.txt">cl_nv_pragma_unroll</a>
+<li><a href="extensions/arm/cl_arm_thread_limit_hint.txt">cl_arm_thread_limit_hint</a>
 </li>
-<li value=20><a href="extensions/intel/cl_intel_device_partition_by_names.txt">cl_intel_device_partition_by_names</a>
+<li><a href="extensions/ext/cl_ext_atomic_counters_32.txt">cl_ext_atomic_counters_32</a>
 </li>
-<li value=21><a href="extensions/qcom/cl_qcom_ext_host_ptr.txt">cl_qcom_ext_host_ptr</a>
+<li><a href="extensions/ext/cl_ext_atomic_counters_64.txt">cl_ext_atomic_counters_64</a>
 </li>
-<li value=22><a href="extensions/qcom/cl_qcom_ion_host_ptr.txt">cl_qcom_ion_host_ptr</a>
+<li><a href="extensions/ext/cl_ext_cxx_for_opencl.html">cl_ext_cxx_for_opencl</a>
 </li>
-<li value=23><a href="extensions/intel/cl_intel_motion_estimation.txt">cl_intel_motion_estimation</a>
+<li><a href="extensions/ext/cl_ext_device_fission.txt">cl_ext_device_fission</a>
 </li>
-<li value=24><a href="extensions/intel/cl_intel_accelerator.txt">cl_intel_accelerator</a>
+<li><a href="extensions/ext/cl_ext_migrate_memobject.txt">cl_ext_migrate_memobject</a>
 </li>
-<li value=25><a href="extensions/amd/cl_amd_bus_addressable_memory.txt">cl_amd_bus_addressable_memory</a>
+<li><a href="extensions/img/cl_img_cached_allocations.html">cl_img_cached_allocations</a>
 </li>
-<li value=26><a href="extensions/arm/cl_arm_get_core_id.txt">cl_arm_core_id</a>
+<li><a href="extensions/img/cl_img_generate_mipmap.html">cl_img_generate_mipmap</a>
 </li>
-<li value=27><a href="extensions/arm/cl_arm_printf.txt">cl_arm_printf</a>
+<li><a href="extensions/img/cl_img_mem_properties.html">cl_img_mem_properties</a>
 </li>
-<li value=28><a href="extensions/altera/cl_altera_live_object_tracking.txt">cl_altera_live_object_tracking</a>
+<li><a href="extensions/img/cl_img_use_gralloc_ptr.html">cl_img_use_gralloc_ptr</a>
 </li>
-<li value=29><a href="extensions/altera/cl_altera_device_temperature.txt">cl_altera_device_temperature</a>
+<li><a href="extensions/img/cl_img_yuv_image.html">cl_img_yuv_image</a>
 </li>
-<li value=30><a href="extensions/altera/cl_altera_compiler_mode.txt">cl_altera_compiler_mode</a>
+<li><a href="extensions/intel/cl_intel_accelerator.txt">cl_intel_accelerator</a>
 </li>
-<li value=31><a href="extensions/intel/cl_intel_d3d11_nv12_media_sharing.txt">cl_intel_d3d11_nv12_media_sharing</a>
+<li><a href="extensions/intel/cl_intel_advanced_motion_estimation.txt">cl_intel_advanced_motion_estimation</a>
 </li>
-<li value=32><a href="extensions/qcom/cl_qcom_android_native_buffer_host_ptr.txt">cl_qcom_android_native_buffer_host_ptr</a>
+<li><a href="extensions/intel/cl_intel_command_queue_families.html">cl_intel_command_queue_families</a>
 </li>
-<li value=33><a href="extensions/intel/cl_intel_advanced_motion_estimation.txt">cl_intel_advanced_motion_estimation</a>
+<li><a href="extensions/intel/cl_intel_create_buffer_with_properties.html">cl_intel_create_buffer_with_properties</a>
 </li>
-<li value=34><a href="extensions/intel/cl_intel_simultaneous_sharing.txt">cl_intel_simultaneous_sharing</a>
+<li><a href="extensions/intel/cl_intel_d3d11_nv12_media_sharing.txt">cl_intel_d3d11_nv12_media_sharing</a>
 </li>
-<li value=35><a href="extensions/intel/cl_intel_subgroups.html">cl_intel_subgroups</a>
+<li><a href="extensions/intel/cl_intel_device_partition_by_names.txt">cl_intel_device_partition_by_names</a>
 </li>
-<li value=36><a href="extensions/intel/cl_intel_va_api_media_sharing.txt">cl_intel_va_api_media_sharing</a>
+<li><a href="extensions/intel/cl_intel_device_side_avc_motion_estimation.txt">cl_intel_device_side_avc_motion_estimation</a>
 </li>
-<li value=37><a href="extensions/intel/cl_intel_egl_image_yuv.txt">cl_intel_egl_image_yuv</a>
+<li><a href="extensions/intel/cl_intel_driver_diagnostics.txt">cl_intel_driver_diagnostics</a>
 </li>
-<li value=38><a href="extensions/arm/cl_arm_import_memory.txt">cl_arm_import_memory</a>
+<li><a href="extensions/intel/cl_intel_dx9_media_sharing.txt">cl_intel_dx9_media_sharing</a>
 </li>
-<li value=39><a href="extensions/arm/cl_arm_non_uniform_work_group_size.txt">cl_arm_non_uniform_work_group_size</a>
+<li><a href="extensions/intel/cl_intel_egl_image_yuv.txt">cl_intel_egl_image_yuv</a>
 </li>
-<li value=40><a href="extensions/arm/cl_arm_shared_virtual_memory.txt">cl_arm_shared_virtual_memory</a>
+<li><a href="extensions/intel/cl_intel_media_block_io.txt">cl_intel_media_block_io</a>
 </li>
-<li value=41><a href="extensions/arm/cl_arm_thread_limit_hint.txt">cl_arm_thread_limit_hint</a>
+<li><a href="extensions/intel/cl_intel_mem_channel_property.html">cl_intel_mem_channel_property</a>
 </li>
-<li value=42><a href="extensions/intel/cl_intel_packed_yuv.html">cl_intel_packed_yuv</a>
+<li><a href="extensions/intel/cl_intel_mem_force_host_memory.html">cl_intel_mem_force_host_memory</a>
 </li>
-<li value=43><a href="extensions/intel/cl_intel_required_subgroup_size.html">cl_intel_required_subgroup_size</a>
+<li><a href="extensions/intel/cl_intel_motion_estimation.txt">cl_intel_motion_estimation</a>
 </li>
-<li value=44><a href="extensions/img/cl_img_cached_allocations.html">cl_img_cached_allocations</a>
+<li><a href="extensions/intel/cl_intel_packed_yuv.html">cl_intel_packed_yuv</a>
 </li>
-<li value=45><a href="extensions/img/cl_img_use_gralloc_ptr.html">cl_img_use_gralloc_ptr</a>
+<li><a href="extensions/intel/cl_intel_planar_yuv.html">cl_intel_planar_yuv</a>
 </li>
-<li value=46><a href="extensions/img/cl_img_yuv_image.html">cl_img_yuv_image</a>
+<li><a href="extensions/intel/cl_intel_required_subgroup_size.html">cl_intel_required_subgroup_size</a>
 </li>
-<li value=47><a href="extensions/intel/cl_intel_driver_diagnostics.txt">cl_intel_driver_diagnostics</a>
+<li><a href="extensions/intel/cl_intel_sharing_format_query.html">cl_intel_sharing_format_query</a>
 </li>
-<li value=48><a href="extensions/intel/cl_intel_subgroups_short.html">cl_intel_subgroups_short</a>
+<li><a href="extensions/intel/cl_intel_simultaneous_sharing.txt">cl_intel_simultaneous_sharing</a>
 </li>
-<li value=49><a href="extensions/intel/cl_intel_planar_yuv.html">cl_intel_planar_yuv</a>
+<li><a href="extensions/intel/cl_intel_spirv_device_side_avc_motion_estimation.html">cl_intel_spirv_device_side_avc_motion_estimation</a>
 </li>
-<li value=50><a href="extensions/intel/cl_intel_device_side_avc_motion_estimation.txt">cl_intel_device_side_avc_motion_estimation</a>
+<li><a href="extensions/intel/cl_intel_spirv_media_block_io.html">cl_intel_spirv_media_block_io</a>
 </li>
-<li value=51><a href="extensions/intel/cl_intel_media_block_io.txt">cl_intel_media_block_io</a>
+<li><a href="extensions/intel/cl_intel_spirv_subgroups.html">cl_intel_spirv_subgroups</a>
 </li>
-<li value=52><a href="extensions/arm/cl_arm_integer_dot_product.txt">cl_arm_integer_dot_product</a>
+<li><a href="extensions/intel/cl_intel_subgroups.html">cl_intel_subgroups</a>
 </li>
-<li value=53><a href="extensions/qcom/cl_qcom_ext_host_ptr_iocoherent.txt">cl_qcom_ext_host_ptr_iocoherent</a>
+<li><a href="extensions/intel/cl_intel_subgroups_char.html">cl_intel_subgroups_char</a>
 </li>
-<li value=54><a href="extensions/amd/cl_amd_planar_yuv.txt">cl_amd_planar_yuv</a>
+<li><a href="extensions/intel/cl_intel_subgroups_long.html">cl_intel_subgroups_long</a>
 </li>
-<li value=55><a href="extensions/intel/cl_intel_spirv_subgroups.html">cl_intel_spirv_subgroups</a>
+<li><a href="extensions/intel/cl_intel_subgroups_short.html">cl_intel_subgroups_short</a>
 </li>
-<li value=56><a href="extensions/intel/cl_intel_spirv_media_block_io.html">cl_intel_spirv_media_block_io</a>
+<li><a href="extensions/intel/cl_intel_thread_local_exec.txt">cl_intel_thread_local_exec</a>
 </li>
-<li value=57><a href="extensions/intel/cl_intel_spirv_device_side_avc_motion_estimation.html">cl_intel_spirv_device_side_avc_motion_estimation</a>
+<li><a href="extensions/intel/cl_intel_va_api_media_sharing.txt">cl_intel_va_api_media_sharing</a>
 </li>
-<li value=58><a href="extensions/arm/cl_arm_job_slot_selection.txt">cl_arm_job_slot_selection</a>
+<li><a href="extensions/nv/cl_nv_compiler_options.txt">cl_nv_compiler_options</a>
 </li>
-<li value=59><a href="extensions/intel/cl_intel_subgroups_char.html">cl_intel_subgroups_char</a>
+<li><a href="extensions/nv/cl_nv_d3d10_sharing.txt">cl_nv_d3d10_sharing</a>
 </li>
-<li value=60><a href="extensions/intel/cl_intel_subgroups_long.html">cl_intel_subgroups_long</a>
+<li><a href="extensions/nv/cl_nv_d3d11_sharing.txt">cl_nv_d3d11_sharing</a>
 </li>
-<li value=61><a href="extensions/intel/cl_intel_create_buffer_with_properties.html">cl_intel_create_buffer_with_properties</a>
+<li><a href="extensions/nv/cl_nv_d3d9_sharing.txt">cl_nv_d3d9_sharing</a>
 </li>
-<li value=62><a href="extensions/intel/cl_intel_mem_channel_property.html">cl_intel_mem_channel_property</a>
+<li><a href="extensions/nv/cl_nv_device_attribute_query.txt">cl_nv_device_attribute_query</a>
 </li>
-<li value=63><a href="extensions/arm/cl_arm_scheduling_controls.html">cl_arm_scheduling_controls</a>
+<li><a href="extensions/nv/cl_nv_pragma_unroll.txt">cl_nv_pragma_unroll</a>
 </li>
-<li value=64><a href="extensions/ext/cl_ext_cxx_for_opencl.html">cl_ext_cxx_for_opencl</a>
+<li><a href="extensions/pocl/cl_pocl_content_size.html">cl_pocl_content_size</a>
 </li>
-<li value=65><a href="extensions/intel/cl_intel_mem_force_host_memory.html">cl_intel_mem_force_host_memory</a>
+<li><a href="extensions/qcom/cl_qcom_android_native_buffer_host_ptr.txt">cl_qcom_android_native_buffer_host_ptr</a>
 </li>
-<li value=66><a href="extensions/img/cl_img_generate_mipmap.html">cl_img_generate_mipmap</a>
+<li><a href="extensions/qcom/cl_qcom_ext_host_ptr.txt">cl_qcom_ext_host_ptr</a>
 </li>
-<li value=67><a href="extensions/img/cl_img_mem_properties.html">cl_img_mem_properties</a>
+<li><a href="extensions/qcom/cl_qcom_ext_host_ptr_iocoherent.txt">cl_qcom_ext_host_ptr_iocoherent</a>
 </li>
-<li value=68><a href="extensions/intel/cl_intel_command_queue_families.html">cl_intel_command_queue_families</a>
+<li><a href="extensions/qcom/cl_qcom_ion_host_ptr.txt">cl_qcom_ion_host_ptr</a>
 </li>
-<li value=69><a href="extensions/arm/cl_arm_controlled_kernel_termination.html">cl_arm_controlled_kernel_termination</a>
-</li>
-<li value=70><a href="extensions/intel/cl_intel_sharing_format_query.html">cl_intel_sharing_format_query</a>
-</li>
-<li value=71><a href="extensions/pocl/cl_pocl_content_size.html">cl_pocl_content_size</a>
-</li>
-</ol>
+</ul>

--- a/extensions/khrext.php
+++ b/extensions/khrext.php
@@ -1,0 +1,104 @@
+<ul>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_3d_image_writes">cl_khr_3d_image_writes</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_async_work_group_copy_fence">cl_khr_async_work_group_copy_fence</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_byte_addressable_store">cl_khr_byte_addressable_store</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_create_command_queue">cl_khr_create_command_queue</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_d3d10_sharing">cl_khr_d3d10_sharing</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_d3d11_sharing">cl_khr_d3d11_sharing</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_depth_images">cl_khr_depth_images</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_device_enqueue_local_arg_types">cl_khr_device_enqueue_local_arg_types</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_device_uuid">cl_khr_device_uuid</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_dx9_media_sharing">cl_khr_dx9_media_sharing</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_egl_event">cl_khr_egl_event</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_egl_image">cl_khr_egl_image</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_async_copies">cl_khr_extended_async_copies</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_bit_ops">cl_khr_extended_bit_ops</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_versioning">cl_khr_extended_versioning</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_fp16">cl_khr_fp16</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_fp64">cl_khr_fp64</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_depth_images">cl_khr_gl_depth_images</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_event">cl_khr_gl_event</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_msaa_sharing">cl_khr_gl_msaa_sharing</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_sharing">cl_khr_gl_sharing</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_global_int32_base_atomics</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_global_int32_extended_atomics</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_icd-opencl">cl_khr_icd</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_il_program">cl_khr_il_program</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_image2d_from_buffer">cl_khr_image2d_from_buffer</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_initialize_memory">cl_khr_initialize_memory</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int64_atomics">cl_khr_int64_base_atomics</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int64_atomics">cl_khr_int64_extended_atomics</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_integer_dot_product">cl_khr_integer_dot_product</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_local_int32_base_atomics</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_local_int32_extended_atomics</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image">cl_khr_mipmap_image</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image">cl_khr_mipmap_image_writes</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_pci_bus_info">cl_khr_pci_bus_info</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_priority_hints">cl_khr_priority_hints</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_select_fprounding_mode">cl_khr_select_fprounding_mode</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_spir">cl_khr_spir</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_srgb_image_writes">cl_khr_srgb_image_writes</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_ballot">cl_khr_subgroup_ballot</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_clustered_reduce">cl_khr_subgroup_clustered_reduce</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_extended_types">cl_khr_subgroup_extended_types</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_named_barrier">cl_khr_subgroup_named_barrier</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_non_uniform_arithmetic">cl_khr_subgroup_non_uniform_arithmetic</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_non_uniform_vote">cl_khr_subgroup_non_uniform_vote</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_shuffle">cl_khr_subgroup_shuffle</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_shuffle_relative">cl_khr_subgroup_shuffle_relative</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroups">cl_khr_subgroups</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_suggested_local_work_size">cl_khr_suggested_local_work_size</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_terminate_context">cl_khr_terminate_context</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_throttle_hints">cl_khr_throttle_hints</a>
+</li>
+</ul>

--- a/extensions/nextfree.py
+++ b/extensions/nextfree.py
@@ -32,7 +32,7 @@ file = 'registry.py'
 exec(open(file).read())
 
 # Track the next free extension number
-keys = { 'number' }
+keys = { 'khrnumber', 'number' }
 max = {}
 for k in keys:
     max[k] = 0

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -281,20 +281,260 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/intel/cl_intel_va_api_media_sharing.txt',
     },
-    'cl_khr_d3d10_sharing' : {
-        'number' : 6,
+    'cl_khr_3d_image_writes' : {
+        'khrnumber' : 1,
         'flags' : { 'public' },
-        'url' : 'extensions/khr/cl_khr_d3d10_sharing.txt',
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_3d_image_writes',
+    },
+    'cl_khr_async_work_group_copy_fence' : {
+        'khrnumber' : 2,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_async_work_group_copy_fence',
+    },
+    'cl_khr_byte_addressable_store' : {
+        'khrnumber' : 3,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_byte_addressable_store',
+    },
+    'cl_khr_create_command_queue' : {
+        'khrnumber' : 4,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_create_command_queue',
+    },
+    'cl_khr_d3d10_sharing' : {
+        'khrnumber' : 5,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_d3d10_sharing',
+    },
+    'cl_khr_d3d11_sharing' : {
+        'khrnumber' : 6,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_d3d11_sharing',
+    },
+    'cl_khr_depth_images' : {
+        'khrnumber' : 7,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_depth_images',
+    },
+    'cl_khr_device_enqueue_local_arg_types' : {
+        'khrnumber' : 8,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_device_enqueue_local_arg_types',
+    },
+    'cl_khr_device_uuid' : {
+        'khrnumber' : 9,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_device_uuid',
+    },
+    'cl_khr_dx9_media_sharing' : {
+        'khrnumber' : 10,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_dx9_media_sharing',
+    },
+    'cl_khr_egl_event' : {
+        'khrnumber' : 11,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_egl_event',
+    },
+    'cl_khr_egl_image' : {
+        'khrnumber' : 12,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_egl_image',
+    },
+    'cl_khr_extended_async_copies' : {
+        'khrnumber' : 13,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_async_copies',
+    },
+    'cl_khr_extended_bit_ops' : {
+        'khrnumber' : 14,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_bit_ops',
+    },
+    'cl_khr_extended_versioning' : {
+        'khrnumber' : 15,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_versioning',
+    },
+    'cl_khr_fp16' : {
+        'khrnumber' : 16,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_fp16',
+    },
+    'cl_khr_fp64' : {
+        'khrnumber' : 17,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_fp64',
+    },
+    'cl_khr_gl_depth_images' : {
+        'khrnumber' : 18,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_depth_images',
+    },
+    'cl_khr_gl_event' : {
+        'khrnumber' : 19,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_event',
+    },
+    'cl_khr_gl_msaa_sharing' : {
+        'khrnumber' : 20,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_msaa_sharing',
     },
     'cl_khr_gl_sharing' : {
-        'number' : 1,
+        'khrnumber' : 21,
         'flags' : { 'public' },
-        'url' : 'extensions/khr/cl_khr_gl_sharing.txt',
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_sharing',
+    },
+    'cl_khr_global_int32_base_atomics' : {
+        'khrnumber' : 22,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics',
+    },
+    'cl_khr_global_int32_extended_atomics' : {
+        'khrnumber' : 23,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics',
     },
     'cl_khr_icd' : {
-        'number' : 5,
+        'khrnumber' : 24,
         'flags' : { 'public' },
-        'url' : 'extensions/khr/cl_khr_icd.txt',
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_icd-opencl',
+    },
+    'cl_khr_il_program' : {
+        'khrnumber' : 25,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_il_program',
+    },
+    'cl_khr_image2d_from_buffer' : {
+        'khrnumber' : 26,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_image2d_from_buffer',
+    },
+    'cl_khr_initialize_memory' : {
+        'khrnumber' : 27,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_initialize_memory',
+    },
+    'cl_khr_int64_base_atomics' : {
+        'khrnumber' : 28,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int64_atomics',
+    },
+    'cl_khr_int64_extended_atomics' : {
+        'khrnumber' : 29,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int64_atomics',
+    },
+    'cl_khr_local_int32_base_atomics' : {
+        'khrnumber' : 30,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics',
+    },
+    'cl_khr_local_int32_extended_atomics' : {
+        'khrnumber' : 31,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics',
+    },
+    'cl_khr_integer_dot_product' : {
+        'khrnumber' : 32,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_integer_dot_product',
+    },
+    'cl_khr_mipmap_image' : {
+        'khrnumber' : 33,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image',
+    },
+    'cl_khr_mipmap_image_writes' : {
+        'khrnumber' : 34,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image',
+    },
+    'cl_khr_pci_bus_info' : {
+        'khrnumber' : 35,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_pci_bus_info',
+    },
+    'cl_khr_priority_hints' : {
+        'khrnumber' : 36,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_priority_hints',
+    },
+    'cl_khr_select_fprounding_mode' : {
+        'khrnumber' : 37,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_select_fprounding_mode',
+    },
+    'cl_khr_spir' : {
+        'khrnumber' : 38,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_spir',
+    },
+    'cl_khr_srgb_image_writes' : {
+        'khrnumber' : 39,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_srgb_image_writes',
+    },
+    'cl_khr_subgroups' : {
+        'khrnumber' : 40,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroups',
+    },
+    'cl_khr_subgroup_ballot' : {
+        'khrnumber' : 41,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_ballot',
+    },
+    'cl_khr_subgroup_clustered_reduce' : {
+        'khrnumber' : 42,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_clustered_reduce',
+    },
+    'cl_khr_subgroup_extended_types' : {
+        'khrnumber' : 43,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_extended_types',
+    },
+    'cl_khr_subgroup_named_barrier' : {
+        'khrnumber' : 44,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_named_barrier',
+    },
+    'cl_khr_subgroup_non_uniform_arithmetic' : {
+        'khrnumber' : 45,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_non_uniform_arithmetic',
+    },
+    'cl_khr_subgroup_non_uniform_vote' : {
+        'khrnumber' : 46,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_non_uniform_vote',
+    },
+    'cl_khr_subgroup_shuffle' : {
+        'khrnumber' : 47,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_shuffle',
+    },
+    'cl_khr_subgroup_shuffle_relative' : {
+        'khrnumber' : 48,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_shuffle_relative',
+    },
+    'cl_khr_suggested_local_work_size' : {
+        'khrnumber' : 49,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_suggested_local_work_size',
+    },
+    'cl_khr_terminate_context' : {
+        'khrnumber' : 50,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_terminate_context',
+    },
+    'cl_khr_throttle_hints' : {
+        'khrnumber' : 51,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_throttle_hints',
     },
     'cl_nv_compiler_options' : {
         'number' : 17,

--- a/index.php
+++ b/index.php
@@ -249,8 +249,69 @@ include_once("../../assets/static_pages/khr_page_top.php");
     updated placeholder.)</p>
 
 
+    <h6> <a name="khrextspecs"></a>
+     Khronos Extension Specifications</h6>
+
+<p> Khronos extensions are published in the OpenCL Extension Specification.
+    These links are to the appropriate chapter of the OpenCL Extension
+    Specification.</p>
+
+<ul>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_3d_image_writes">cl_khr_3d_image_writes</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_async_work_group_copy_fence">cl_khr_async_work_group_copy_fence</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_byte_addressable_store">cl_khr_byte_addressable_store</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_create_command_queue">cl_khr_create_command_queue</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_d3d10_sharing">cl_khr_d3d10_sharing</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_d3d11_sharing">cl_khr_d3d11_sharing</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_depth_images">cl_khr_depth_images</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_device_enqueue_local_arg_types">cl_khr_device_enqueue_local_arg_types</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_device_uuid">cl_khr_device_uuid</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_dx9_media_sharing">cl_khr_dx9_media_sharing</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_egl_event">cl_khr_egl_event</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_egl_image">cl_khr_egl_image</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_async_copies">cl_khr_extended_async_copies</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_bit_ops">cl_khr_extended_bit_ops</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_versioning">cl_khr_extended_versioning</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_fp16">cl_khr_fp16</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_fp64">cl_khr_fp64</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_depth_images">cl_khr_gl_depth_images</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_event">cl_khr_gl_event</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_msaa_sharing">cl_khr_gl_msaa_sharing</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_sharing">cl_khr_gl_sharing</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_global_int32_base_atomics</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_global_int32_extended_atomics</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_icd-opencl">cl_khr_icd</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_il_program">cl_khr_il_program</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_image2d_from_buffer">cl_khr_image2d_from_buffer</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_initialize_memory">cl_khr_initialize_memory</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int64_atomics">cl_khr_int64_base_atomics</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int64_atomics">cl_khr_int64_extended_atomics</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_local_int32_base_atomics</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_local_int32_extended_atomics</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_integer_dot_product">cl_khr_integer_dot_product</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image">cl_khr_mipmap_image</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image">cl_khr_mipmap_image_writes</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_pci_bus_info">cl_khr_pci_bus_info</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_priority_hints">cl_khr_priority_hints</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_select_fprounding_mode">cl_khr_select_fprounding_mode</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_spir">cl_khr_spir</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_srgb_image_writes">cl_khr_srgb_image_writes</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroups">cl_khr_subgroups</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_ballot">cl_khr_subgroup_ballot</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_clustered_reduce">cl_khr_subgroup_clustered_reduce</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_extended_types">cl_khr_subgroup_extended_types</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_named_barrier">cl_khr_subgroup_named_barrier</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_non_uniform_arithmetic">cl_khr_subgroup_non_uniform_arithmetic</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_non_uniform_vote">cl_khr_subgroup_non_uniform_vote</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_shuffle">cl_khr_subgroup_shuffle</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_shuffle_relative">cl_khr_subgroup_shuffle_relative</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_suggested_local_work_size">cl_khr_suggested_local_work_size</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_terminate_context">cl_khr_terminate_context</a></li>
+<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_throttle_hints">cl_khr_throttle_hints</a></li>
+</ul>
+
 <h6> <a name="otherextspecs"></a>
-     Extension Specifications</h6>
+     Vendor and Multi-Vendor Extension Specifications</h6>
 
 <?php include("extensions/clext.php"); ?>
 

--- a/index.php
+++ b/index.php
@@ -256,59 +256,7 @@ include_once("../../assets/static_pages/khr_page_top.php");
     These links are to the appropriate chapter of the OpenCL Extension
     Specification.</p>
 
-<ul>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_3d_image_writes">cl_khr_3d_image_writes</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_async_work_group_copy_fence">cl_khr_async_work_group_copy_fence</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_byte_addressable_store">cl_khr_byte_addressable_store</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_create_command_queue">cl_khr_create_command_queue</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_d3d10_sharing">cl_khr_d3d10_sharing</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_d3d11_sharing">cl_khr_d3d11_sharing</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_depth_images">cl_khr_depth_images</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_device_enqueue_local_arg_types">cl_khr_device_enqueue_local_arg_types</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_device_uuid">cl_khr_device_uuid</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_dx9_media_sharing">cl_khr_dx9_media_sharing</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_egl_event">cl_khr_egl_event</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_egl_image">cl_khr_egl_image</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_async_copies">cl_khr_extended_async_copies</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_bit_ops">cl_khr_extended_bit_ops</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_extended_versioning">cl_khr_extended_versioning</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_fp16">cl_khr_fp16</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_fp64">cl_khr_fp64</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_depth_images">cl_khr_gl_depth_images</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_event">cl_khr_gl_event</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_msaa_sharing">cl_khr_gl_msaa_sharing</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_gl_sharing">cl_khr_gl_sharing</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_global_int32_base_atomics</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_global_int32_extended_atomics</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_icd-opencl">cl_khr_icd</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_il_program">cl_khr_il_program</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_image2d_from_buffer">cl_khr_image2d_from_buffer</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_initialize_memory">cl_khr_initialize_memory</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int64_atomics">cl_khr_int64_base_atomics</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int64_atomics">cl_khr_int64_extended_atomics</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_local_int32_base_atomics</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_int32_atomics">cl_khr_local_int32_extended_atomics</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_integer_dot_product">cl_khr_integer_dot_product</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image">cl_khr_mipmap_image</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_mipmap_image">cl_khr_mipmap_image_writes</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_pci_bus_info">cl_khr_pci_bus_info</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_priority_hints">cl_khr_priority_hints</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_select_fprounding_mode">cl_khr_select_fprounding_mode</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_spir">cl_khr_spir</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_srgb_image_writes">cl_khr_srgb_image_writes</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroups">cl_khr_subgroups</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_ballot">cl_khr_subgroup_ballot</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_clustered_reduce">cl_khr_subgroup_clustered_reduce</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_extended_types">cl_khr_subgroup_extended_types</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_named_barrier">cl_khr_subgroup_named_barrier</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_non_uniform_arithmetic">cl_khr_subgroup_non_uniform_arithmetic</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_non_uniform_vote">cl_khr_subgroup_non_uniform_vote</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_shuffle">cl_khr_subgroup_shuffle</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_subgroup_shuffle_relative">cl_khr_subgroup_shuffle_relative</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_suggested_local_work_size">cl_khr_suggested_local_work_size</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_terminate_context">cl_khr_terminate_context</a></li>
-<li><a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_throttle_hints">cl_khr_throttle_hints</a></li>
-</ul>
+<?php include("extensions/khrext.php"); ?>
 
 <h6> <a name="otherextspecs"></a>
      Vendor and Multi-Vendor Extension Specifications</h6>


### PR DESCRIPTION
See internal issue 188.

Updates scripts and the extension registry to include KHR extensions (mostly new) in addition to EXT and vendor-specific extensions (existing).

Summary of the changes are:

1. I modified the script to generate separate unnumbered, alphabetized lists for KHR extensions and non-KHR extensions instead of a single ordered list based on the extension number for (primarily non-KHR) extensions. This was the biggest change (but not too bad, the script is very short).
1. I modified the registry webpage to include both extension lists instead of only the primarily-non-KHR extension list.
1. I added all KHR extensions to registry.py with links into the extension spec.
1. A few minor changes to Makefiles or other supporting scripts.

Needs working group sign-off before merging.