### PR TITLE
Update C++ for OpenCL extension spec.

### DIFF
--- a/extensions/ext/cl_ext_cxx_for_opencl.html
+++ b/extensions/ext/cl_ext_cxx_for_opencl.html
@@ -750,9 +750,9 @@ p.tableblock.header { color: #6d6e71; }
 <h1>cl_ext_cxx_for_opencl</h1>
 <div class="details">
 <span id="author" class="author">Khronos<sup>&#174;</sup> OpenCL Working Group</span><br>
-<span id="revnumber">version v3.0.9-3-ged2ee44,</span>
-<span id="revdate">Wed, 20 Oct 2021 10:42:40 +0000</span>
-<br><span id="revremark">from git branch: master commit: ed2ee44e40c7dc381f1fef06b2c49afb4685bfc8</span>
+<span id="revnumber">version v3.0.9-8-gcc22b57,</span>
+<span id="revdate">Mon, 08 Nov 2021 15:16:46 +0000</span>
+<br><span id="revremark">from git branch:  commit: cc22b57164f3eb2c272f602b807c40b0850a67c9</span>
 </div>
 </div>
 <div id="content">
@@ -837,7 +837,7 @@ respective owners.</p>
 <h2 id="_version"><a class="anchor" href="#_version"></a>Version</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Built On: 2021-10-13<br>
+<p>Built On: 2021-10-29<br>
 Version: 1.0.0</p>
 </div>
 </div>
@@ -860,8 +860,13 @@ Version 3.0.3.</p>
 <div class="sectionbody">
 <div class="paragraph">
 <p>This extension adds support for building programs written using the C++ for
-OpenCL kernel language. It also enables applications to query the version of
-the language supported by the device compiler.</p>
+OpenCL kernel language documented in the <strong>OpenCL-Docs</strong> repository
+(<a href="https://github.com/KhronosGroup/OpenCL-Docs" class="bare">https://github.com/KhronosGroup/OpenCL-Docs</a>)
+with stable versions published in releases of the repository.</p>
+</div>
+<div class="paragraph">
+<p>This extension also enables applications to query the version of the language
+supported by the device compiler.</p>
 </div>
 </div>
 </div>
@@ -1045,8 +1050,8 @@ __OPENCL_CPP_VERSION__ macro agrees with the version returned by
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.3-rc-26-g17d39ef<br>
-Last updated 2020-09-02 20:50:43 +0100
+Version v3.0.9-8-gcc22b57<br>
+Last updated 2021-10-29 21:30:09 +0100
 </div>
 </div>
 <style>


### PR DESCRIPTION
This html contains the latest version of cl_ext_cxx_for_opencl.