### PR TITLE
Rename cl_intel_thread_local_exec to cl_intel_exec_by_local_thread

### DIFF
--- a/extensions/clext.php
+++ b/extensions/clext.php
@@ -77,6 +77,8 @@
 </li>
 <li><a href="extensions/intel/cl_intel_egl_image_yuv.txt">cl_intel_egl_image_yuv</a>
 </li>
+<li><a href="extensions/intel/cl_intel_exec_by_local_thread.txt">cl_intel_exec_by_local_thread</a>
+</li>
 <li><a href="extensions/intel/cl_intel_media_block_io.txt">cl_intel_media_block_io</a>
 </li>
 <li><a href="extensions/intel/cl_intel_mem_channel_property.html">cl_intel_mem_channel_property</a>
@@ -108,8 +110,6 @@
 <li><a href="extensions/intel/cl_intel_subgroups_long.html">cl_intel_subgroups_long</a>
 </li>
 <li><a href="extensions/intel/cl_intel_subgroups_short.html">cl_intel_subgroups_short</a>
-</li>
-<li><a href="extensions/intel/cl_intel_thread_local_exec.txt">cl_intel_thread_local_exec</a>
 </li>
 <li><a href="extensions/intel/cl_intel_va_api_media_sharing.txt">cl_intel_va_api_media_sharing</a>
 </li>

--- a/extensions/intel/cl_intel_exec_by_local_thread.txt
+++ b/extensions/intel/cl_intel_exec_by_local_thread.txt
@@ -1,6 +1,6 @@
 Name Strings
 
-    cl_intel_thread_local_exec
+    cl_intel_exec_by_local_thread
 
 Contributors
 

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -191,6 +191,11 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/intel/cl_intel_egl_image_yuv.txt',
     },
+    'cl_intel_exec_by_local_thread' : {
+        'number' : 16,
+        'flags' : { 'public' },
+        'url' : 'extensions/intel/cl_intel_exec_by_local_thread.txt',
+    },
     'cl_intel_media_block_io' : {
         'number' : 51,
         'flags' : { 'public' },
@@ -270,11 +275,6 @@ registry = {
         'number' : 48,
         'flags' : { 'public' },
         'url' : 'extensions/intel/cl_intel_subgroups_short.html',
-    },
-    'cl_intel_thread_local_exec' : {
-        'number' : 16,
-        'flags' : { 'public' },
-        'url' : 'extensions/intel/cl_intel_thread_local_exec.txt',
     },
     'cl_intel_va_api_media_sharing' : {
         'number' : 36,


### PR DESCRIPTION
cl_intel_exec_by_local_thread is the correct extension name.