### PR TITLE
Match OpenCL-Docs default branch rename

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,13 +18,13 @@ extension specifications, and problems with the content of the registry
 
 OpenCL enumerants are now documented in the specification repository
 https://github.com/KhronosGroup/OpenCL-Docs in the file
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/xml/cl.xml
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/xml/cl.xml
 
-New enumerant ranges can be allocated by proposing a pull request to master
+New enumerant ranges can be allocated by proposing a pull request to `main`
 branch of OpenCL-Docs modifying `cl.xml`, following the
 existing examples. Allocate ranges starting at the lowest free values
 available (search for "`Reserved for vendor extensions`"). Ranges are not
-officially allocated until your pull request is *accepted* into master
+officially allocated until your pull request is *accepted* into `main`
 branch of the OpenCL-Docs repository. At that point you can use values from
 your assigned range for API extensions.
 

--- a/extensions/img/cl_img_cached_allocations.txt
+++ b/extensions/img/cl_img_cached_allocations.txt
@@ -8,4 +8,4 @@ https://www.khronos.org/registry/OpenCL/extensions/img/cl_img_cached_allocations
 The asciidoc source for this extension specification may
 be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_img_cached_allocations.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/extensions/cl_img_cached_allocations.asciidoc

--- a/extensions/img/cl_img_use_gralloc_ptr.txt
+++ b/extensions/img/cl_img_use_gralloc_ptr.txt
@@ -8,4 +8,4 @@ https://www.khronos.org/registry/OpenCL/extensions/img/cl_img_use_gralloc_ptr.ht
 The asciidoc source for this extension specification may
 be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_img_use_gralloc_ptr.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/extensions/cl_img_use_gralloc_ptr.asciidoc

--- a/extensions/img/cl_img_yuv_image.txt
+++ b/extensions/img/cl_img_yuv_image.txt
@@ -8,4 +8,4 @@ https://www.khronos.org/registry/OpenCL/extensions/img/cl_img_yuv_image.html
 The asciidoc source for this extension specification may
 be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_img_yuv_image.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/extensions/cl_img_yuv_image.asciidoc

--- a/extensions/intel/cl_intel_packed_yuv.txt
+++ b/extensions/intel/cl_intel_packed_yuv.txt
@@ -8,4 +8,4 @@ https://www.khronos.org/registry/OpenCL/extensions/intel/cl_intel_packed_yuv.htm
 The asciidoc source for this extension specification may
 be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_intel_packed_yuv.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/extensions/cl_intel_packed_yuv.asciidoc

--- a/extensions/intel/cl_intel_planar_yuv.txt
+++ b/extensions/intel/cl_intel_planar_yuv.txt
@@ -8,4 +8,4 @@ https://www.khronos.org/registry/OpenCL/extensions/intel/cl_intel_planar_yuv.htm
 The asciidoc source for this extension specification may
 be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_intel_planar_yuv.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/extensions/cl_intel_planar_yuv.asciidoc

--- a/extensions/intel/cl_intel_required_subgroup_size.txt
+++ b/extensions/intel/cl_intel_required_subgroup_size.txt
@@ -8,4 +8,4 @@ https://www.khronos.org/registry/OpenCL/extensions/intel/cl_intel_required_subgr
 The asciidoc source for this extension specification may
 be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_intel_required_subgroup_size.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/extensions/cl_intel_required_subgroup_size.asciidoc

--- a/extensions/intel/cl_intel_subgroups.txt
+++ b/extensions/intel/cl_intel_subgroups.txt
@@ -8,4 +8,4 @@ https://www.khronos.org/registry/OpenCL/extensions/intel/cl_intel_subgroups.html
 The asciidoc source for this extension specification may
 be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_intel_subgroups.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/extensions/cl_intel_subgroups.asciidoc

--- a/extensions/intel/cl_intel_subgroups_short.txt
+++ b/extensions/intel/cl_intel_subgroups_short.txt
@@ -8,4 +8,4 @@ https://www.khronos.org/registry/OpenCL/extensions/intel/cl_intel_subgroups_shor
 The asciidoc source for this extension specification may
 be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/extensions/cl_intel_subgroups_short.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/extensions/cl_intel_subgroups_short.asciidoc

--- a/extensions/khr/cl_khr_d3d10_sharing.txt
+++ b/extensions/khr/cl_khr_d3d10_sharing.txt
@@ -9,4 +9,4 @@ https://www.khronos.org/registry/OpenCL/
 
 The Asciidoc source for this extension may be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/ext/cl_khr_d3d10_sharing.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/ext/cl_khr_d3d10_sharing.asciidoc

--- a/extensions/khr/cl_khr_gl_sharing.txt
+++ b/extensions/khr/cl_khr_gl_sharing.txt
@@ -9,6 +9,6 @@ https://www.khronos.org/registry/OpenCL/
 
 The Asciidoc source for this extension may be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/ext/cl_khr_gl_sharing__context.asciidoc
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/ext/cl_khr_gl_sharing__memobjs.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/ext/cl_khr_gl_sharing__context.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/ext/cl_khr_gl_sharing__memobjs.asciidoc
 

--- a/extensions/khr/cl_khr_icd.txt
+++ b/extensions/khr/cl_khr_icd.txt
@@ -9,4 +9,4 @@ https://www.khronos.org/registry/OpenCL/
 
 The Asciidoc source for this extension may be found here:
 
-https://github.com/KhronosGroup/OpenCL-Docs/blob/master/ext/cl_khr_icd.asciidoc
+https://github.com/KhronosGroup/OpenCL-Docs/blob/main/ext/cl_khr_icd.asciidoc

--- a/index.php
+++ b/index.php
@@ -242,7 +242,7 @@ include_once("../../assets/static_pages/khr_page_top.php");
 
 <h6> Enumerant and Extension Number Registry </h6>
 
-<p> <a href="https://github.com/KhronosGroup/OpenCL-Docs/blob/master/xml/cl.xml">
+<p> <a href="https://github.com/KhronosGroup/OpenCL-Docs/blob/main/xml/cl.xml">
     cl.xml </a> is the registry of reserved OpenCL API enumerant ranges.
     (Note that following this link will probably not render sensibly in
     browsers, since the file is not entirely valid XML, simply a manually


### PR DESCRIPTION
OpenCL-Docs is renaming it's default branch to `main`, match that.  This PR
does not include rebuilds of specifications etc, so those still contain the old
links.  That will be automatically fixed on the next release.

This should only merge *after* the OpenCL-Docs branch rename (see https://github.com/KhronosGroup/OpenCL-Docs/pull/766).