### PR TITLE
update the OpenCL reference pages for v3.0.13

### DIFF
--- a/sdk/3.0/docs/man/html/ATOMIC_VAR_INIT.html
+++ b/sdk/3.0/docs/man/html/ATOMIC_VAR_INIT.html
@@ -840,8 +840,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/EXTENSION.html
+++ b/sdk/3.0/docs/man/html/EXTENSION.html
@@ -1199,8 +1199,8 @@ A kernel can now use this preprocessor <code>#define</code> to do something like
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/abstractDataTypes.html
+++ b/sdk/3.0/docs/man/html/abstractDataTypes.html
@@ -926,8 +926,8 @@ API Specification</a>.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/accessQualifiers.html
+++ b/sdk/3.0/docs/man/html/accessQualifiers.html
@@ -865,8 +865,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/addressOperator.html
+++ b/sdk/3.0/docs/man/html/addressOperator.html
@@ -831,8 +831,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/addressSpaceQualifierFuncs.html
+++ b/sdk/3.0/docs/man/html/addressSpaceQualifierFuncs.html
@@ -870,8 +870,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/addressSpaceQualifiers.html
+++ b/sdk/3.0/docs/man/html/addressSpaceQualifiers.html
@@ -900,8 +900,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/alignmentOfDataTypes.html
+++ b/sdk/3.0/docs/man/html/alignmentOfDataTypes.html
@@ -845,8 +845,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/appScalarTypes.html
+++ b/sdk/3.0/docs/man/html/appScalarTypes.html
@@ -829,8 +829,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/appVectorTypes.html
+++ b/sdk/3.0/docs/man/html/appVectorTypes.html
@@ -838,8 +838,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/arithmeticOperators.html
+++ b/sdk/3.0/docs/man/html/arithmeticOperators.html
@@ -853,8 +853,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/as_typen.html
+++ b/sdk/3.0/docs/man/html/as_typen.html
@@ -886,8 +886,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/assignmentOperator.html
+++ b/sdk/3.0/docs/man/html/assignmentOperator.html
@@ -895,8 +895,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/asyncCopyFunctions.html
+++ b/sdk/3.0/docs/man/html/asyncCopyFunctions.html
@@ -957,8 +957,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomicFlagTestAndSet.html
+++ b/sdk/3.0/docs/man/html/atomicFlagTestAndSet.html
@@ -897,8 +897,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomicFunctions.html
+++ b/sdk/3.0/docs/man/html/atomicFunctions.html
@@ -857,8 +857,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomicRestrictions.html
+++ b/sdk/3.0/docs/man/html/atomicRestrictions.html
@@ -883,8 +883,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomicTypes.html
+++ b/sdk/3.0/docs/man/html/atomicTypes.html
@@ -868,8 +868,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomic_compare_exchange.html
+++ b/sdk/3.0/docs/man/html/atomic_compare_exchange.html
@@ -1162,8 +1162,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomic_exchange.html
+++ b/sdk/3.0/docs/man/html/atomic_exchange.html
@@ -896,8 +896,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomic_fetch_key.html
+++ b/sdk/3.0/docs/man/html/atomic_fetch_key.html
@@ -974,8 +974,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomic_flag.html
+++ b/sdk/3.0/docs/man/html/atomic_flag.html
@@ -836,8 +836,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomic_flag_clear.html
+++ b/sdk/3.0/docs/man/html/atomic_flag_clear.html
@@ -894,8 +894,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomic_init.html
+++ b/sdk/3.0/docs/man/html/atomic_init.html
@@ -851,8 +851,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomic_load.html
+++ b/sdk/3.0/docs/man/html/atomic_load.html
@@ -888,8 +888,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomic_store.html
+++ b/sdk/3.0/docs/man/html/atomic_store.html
@@ -895,8 +895,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/atomic_work_item_fence.html
+++ b/sdk/3.0/docs/man/html/atomic_work_item_fence.html
@@ -882,8 +882,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/attributes-blocksAndControlFlow.html
+++ b/sdk/3.0/docs/man/html/attributes-blocksAndControlFlow.html
@@ -829,8 +829,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/attributes-loopUnroll.html
+++ b/sdk/3.0/docs/man/html/attributes-loopUnroll.html
@@ -939,8 +939,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/attributes-types.html
+++ b/sdk/3.0/docs/man/html/attributes-types.html
@@ -832,8 +832,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/attributes-variables.html
+++ b/sdk/3.0/docs/man/html/attributes-variables.html
@@ -978,8 +978,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/bitwiseOperators.html
+++ b/sdk/3.0/docs/man/html/bitwiseOperators.html
@@ -822,8 +822,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/blocks.html
+++ b/sdk/3.0/docs/man/html/blocks.html
@@ -841,8 +841,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clBuildProgram.html
+++ b/sdk/3.0/docs/man/html/clBuildProgram.html
@@ -981,8 +981,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCloneKernel.html
+++ b/sdk/3.0/docs/man/html/clCloneKernel.html
@@ -908,8 +908,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCompileProgram.html
+++ b/sdk/3.0/docs/man/html/clCompileProgram.html
@@ -1048,8 +1048,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateBuffer.html
+++ b/sdk/3.0/docs/man/html/clCreateBuffer.html
@@ -1068,8 +1068,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateCommandQueue.html
+++ b/sdk/3.0/docs/man/html/clCreateCommandQueue.html
@@ -936,8 +936,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateCommandQueueWithProperties.html
+++ b/sdk/3.0/docs/man/html/clCreateCommandQueueWithProperties.html
@@ -977,8 +977,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateContext.html
+++ b/sdk/3.0/docs/man/html/clCreateContext.html
@@ -1025,8 +1025,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateContextFromType.html
+++ b/sdk/3.0/docs/man/html/clCreateContextFromType.html
@@ -916,8 +916,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateEventFromEGLSyncKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateEventFromEGLSyncKHR.html
@@ -931,8 +931,8 @@ of type <code>EGL_SYNC_FENCE_KHR</code> created with respect to <code>EGLDisplay
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateEventFromGLsyncKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateEventFromGLsyncKHR.html
@@ -902,8 +902,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromD3D10BufferKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateFromD3D10BufferKHR.html
@@ -928,8 +928,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromD3D10Texture2DKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateFromD3D10Texture2DKHR.html
@@ -938,8 +938,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromD3D10Texture3DKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateFromD3D10Texture3DKHR.html
@@ -1283,8 +1283,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromD3D11BufferKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateFromD3D11BufferKHR.html
@@ -931,8 +931,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromD3D11Texture2DKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateFromD3D11Texture2DKHR.html
@@ -941,8 +941,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromD3D11Texture3DKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateFromD3D11Texture3DKHR.html
@@ -1251,8 +1251,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromDX9MediaSurfaceKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateFromDX9MediaSurfaceKHR.html
@@ -1190,8 +1190,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromEGLImageKHR.html
+++ b/sdk/3.0/docs/man/html/clCreateFromEGLImageKHR.html
@@ -975,8 +975,8 @@ required by the OpenCL implementation on the host.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromGLBuffer.html
+++ b/sdk/3.0/docs/man/html/clCreateFromGLBuffer.html
@@ -1421,8 +1421,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromGLRenderbuffer.html
+++ b/sdk/3.0/docs/man/html/clCreateFromGLRenderbuffer.html
@@ -1421,8 +1421,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateFromGLTexture.html
+++ b/sdk/3.0/docs/man/html/clCreateFromGLTexture.html
@@ -1469,8 +1469,8 @@ Otherwise, it returns a NULL value with one of the following error values return
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateImage.html
+++ b/sdk/3.0/docs/man/html/clCreateImage.html
@@ -1101,8 +1101,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateImage2D.html
+++ b/sdk/3.0/docs/man/html/clCreateImage2D.html
@@ -953,8 +953,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateImage3D.html
+++ b/sdk/3.0/docs/man/html/clCreateImage3D.html
@@ -970,8 +970,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateKernel.html
+++ b/sdk/3.0/docs/man/html/clCreateKernel.html
@@ -883,8 +883,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateKernelsInProgram.html
+++ b/sdk/3.0/docs/man/html/clCreateKernelsInProgram.html
@@ -906,8 +906,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreatePipe.html
+++ b/sdk/3.0/docs/man/html/clCreatePipe.html
@@ -930,8 +930,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateProgramWithBinary.html
+++ b/sdk/3.0/docs/man/html/clCreateProgramWithBinary.html
@@ -965,8 +965,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateProgramWithBuiltInKernels.html
+++ b/sdk/3.0/docs/man/html/clCreateProgramWithBuiltInKernels.html
@@ -904,8 +904,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateProgramWithIL.html
+++ b/sdk/3.0/docs/man/html/clCreateProgramWithIL.html
@@ -901,8 +901,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateProgramWithSource.html
+++ b/sdk/3.0/docs/man/html/clCreateProgramWithSource.html
@@ -898,8 +898,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateSampler.html
+++ b/sdk/3.0/docs/man/html/clCreateSampler.html
@@ -901,8 +901,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateSamplerWithProperties.html
+++ b/sdk/3.0/docs/man/html/clCreateSamplerWithProperties.html
@@ -961,8 +961,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateSubBuffer.html
+++ b/sdk/3.0/docs/man/html/clCreateSubBuffer.html
@@ -986,8 +986,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateSubDevices.html
+++ b/sdk/3.0/docs/man/html/clCreateSubDevices.html
@@ -1043,8 +1043,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clCreateUserEvent.html
+++ b/sdk/3.0/docs/man/html/clCreateUserEvent.html
@@ -881,8 +881,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueAcquireD3D10ObjectsKHR.html
+++ b/sdk/3.0/docs/man/html/clEnqueueAcquireD3D10ObjectsKHR.html
@@ -964,8 +964,8 @@ Otherwise it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueAcquireD3D11ObjectsKHR.html
+++ b/sdk/3.0/docs/man/html/clEnqueueAcquireD3D11ObjectsKHR.html
@@ -970,8 +970,8 @@ Otherwise it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueAcquireDX9MediaSurfacesKHR.html
+++ b/sdk/3.0/docs/man/html/clEnqueueAcquireDX9MediaSurfacesKHR.html
@@ -1163,8 +1163,8 @@ Otherwise it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueAcquireEGLObjectsKHR.html
+++ b/sdk/3.0/docs/man/html/clEnqueueAcquireEGLObjectsKHR.html
@@ -910,8 +910,8 @@ Otherwise, it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueAcquireGLObjects.html
+++ b/sdk/3.0/docs/man/html/clEnqueueAcquireGLObjects.html
@@ -1472,8 +1472,8 @@ Otherwise, it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueBarrier.html
+++ b/sdk/3.0/docs/man/html/clEnqueueBarrier.html
@@ -877,8 +877,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueBarrierWithWaitList.html
+++ b/sdk/3.0/docs/man/html/clEnqueueBarrierWithWaitList.html
@@ -922,8 +922,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueCopyBuffer.html
+++ b/sdk/3.0/docs/man/html/clEnqueueCopyBuffer.html
@@ -952,8 +952,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueCopyBufferRect.html
+++ b/sdk/3.0/docs/man/html/clEnqueueCopyBufferRect.html
@@ -1058,8 +1058,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueCopyBufferToImage.html
+++ b/sdk/3.0/docs/man/html/clEnqueueCopyBufferToImage.html
@@ -995,8 +995,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueCopyImage.html
+++ b/sdk/3.0/docs/man/html/clEnqueueCopyImage.html
@@ -1002,8 +1002,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueCopyImageToBuffer.html
+++ b/sdk/3.0/docs/man/html/clEnqueueCopyImageToBuffer.html
@@ -992,8 +992,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueFillBuffer.html
+++ b/sdk/3.0/docs/man/html/clEnqueueFillBuffer.html
@@ -974,8 +974,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueFillImage.html
+++ b/sdk/3.0/docs/man/html/clEnqueueFillImage.html
@@ -992,8 +992,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueMapBuffer.html
+++ b/sdk/3.0/docs/man/html/clEnqueueMapBuffer.html
@@ -1061,8 +1061,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueMapImage.html
+++ b/sdk/3.0/docs/man/html/clEnqueueMapImage.html
@@ -1072,8 +1072,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueMarker.html
+++ b/sdk/3.0/docs/man/html/clEnqueueMarker.html
@@ -889,8 +889,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueMarkerWithWaitList.html
+++ b/sdk/3.0/docs/man/html/clEnqueueMarkerWithWaitList.html
@@ -920,8 +920,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueMigrateMemObjects.html
+++ b/sdk/3.0/docs/man/html/clEnqueueMigrateMemObjects.html
@@ -1002,8 +1002,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueNDRangeKernel.html
+++ b/sdk/3.0/docs/man/html/clEnqueueNDRangeKernel.html
@@ -1130,8 +1130,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueNativeKernel.html
+++ b/sdk/3.0/docs/man/html/clEnqueueNativeKernel.html
@@ -988,8 +988,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueReadBuffer.html
+++ b/sdk/3.0/docs/man/html/clEnqueueReadBuffer.html
@@ -1001,8 +1001,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueReadBufferRect.html
+++ b/sdk/3.0/docs/man/html/clEnqueueReadBufferRect.html
@@ -1196,8 +1196,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueReadImage.html
+++ b/sdk/3.0/docs/man/html/clEnqueueReadImage.html
@@ -1132,8 +1132,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueReleaseD3D10ObjectsKHR.html
+++ b/sdk/3.0/docs/man/html/clEnqueueReleaseD3D10ObjectsKHR.html
@@ -960,8 +960,8 @@ Otherwise it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueReleaseD3D11ObjectsKHR.html
+++ b/sdk/3.0/docs/man/html/clEnqueueReleaseD3D11ObjectsKHR.html
@@ -963,8 +963,8 @@ Otherwise it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueReleaseDX9MediaSurfacesKHR.html
+++ b/sdk/3.0/docs/man/html/clEnqueueReleaseDX9MediaSurfacesKHR.html
@@ -1162,8 +1162,8 @@ Otherwise it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueReleaseEGLObjectsKHR.html
+++ b/sdk/3.0/docs/man/html/clEnqueueReleaseEGLObjectsKHR.html
@@ -918,8 +918,8 @@ returns <code>CL_SUCCESS</code>. Otherwise, it returns one of the following erro
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueReleaseGLObjects.html
+++ b/sdk/3.0/docs/man/html/clEnqueueReleaseGLObjects.html
@@ -1480,8 +1480,8 @@ Otherwise, it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueSVMFree.html
+++ b/sdk/3.0/docs/man/html/clEnqueueSVMFree.html
@@ -945,8 +945,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueSVMMap.html
+++ b/sdk/3.0/docs/man/html/clEnqueueSVMMap.html
@@ -959,8 +959,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueSVMMemFill.html
+++ b/sdk/3.0/docs/man/html/clEnqueueSVMMemFill.html
@@ -958,8 +958,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueSVMMemcpy.html
+++ b/sdk/3.0/docs/man/html/clEnqueueSVMMemcpy.html
@@ -963,8 +963,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueSVMMigrateMem.html
+++ b/sdk/3.0/docs/man/html/clEnqueueSVMMigrateMem.html
@@ -960,8 +960,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueSVMUnmap.html
+++ b/sdk/3.0/docs/man/html/clEnqueueSVMUnmap.html
@@ -960,8 +960,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueTask.html
+++ b/sdk/3.0/docs/man/html/clEnqueueTask.html
@@ -977,8 +977,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueUnmapMemObject.html
+++ b/sdk/3.0/docs/man/html/clEnqueueUnmapMemObject.html
@@ -932,8 +932,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clEnqueueWaitForEvents.html
+++ b/sdk/3.0/docs/man/html/clEnqueueWaitForEvents.html
@@ -889,8 +889,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clFinish.html
+++ b/sdk/3.0/docs/man/html/clFinish.html
@@ -865,8 +865,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clFlush.html
+++ b/sdk/3.0/docs/man/html/clFlush.html
@@ -881,8 +881,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetCommandQueueInfo.html
+++ b/sdk/3.0/docs/man/html/clGetCommandQueueInfo.html
@@ -970,8 +970,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetContextInfo.html
+++ b/sdk/3.0/docs/man/html/clGetContextInfo.html
@@ -945,8 +945,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetDeviceAndHostTimer.html
+++ b/sdk/3.0/docs/man/html/clGetDeviceAndHostTimer.html
@@ -904,8 +904,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetDeviceIDs.html
+++ b/sdk/3.0/docs/man/html/clGetDeviceIDs.html
@@ -976,8 +976,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetDeviceIDsFromD3D10KHR.html
+++ b/sdk/3.0/docs/man/html/clGetDeviceIDsFromD3D10KHR.html
@@ -1027,8 +1027,8 @@ Otherwise it may return:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetDeviceIDsFromD3D11KHR.html
+++ b/sdk/3.0/docs/man/html/clGetDeviceIDsFromD3D11KHR.html
@@ -1026,8 +1026,8 @@ Otherwise it may return:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetDeviceIDsFromDX9MediaAdapterKHR.html
+++ b/sdk/3.0/docs/man/html/clGetDeviceIDsFromDX9MediaAdapterKHR.html
@@ -1252,8 +1252,8 @@ Otherwise, it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetDeviceInfo.html
+++ b/sdk/3.0/docs/man/html/clGetDeviceInfo.html
@@ -1987,8 +1987,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetEventInfo.html
+++ b/sdk/3.0/docs/man/html/clGetEventInfo.html
@@ -1115,8 +1115,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetEventProfilingInfo.html
+++ b/sdk/3.0/docs/man/html/clGetEventProfilingInfo.html
@@ -964,8 +964,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetExtensionFunctionAddressForPlatform.html
+++ b/sdk/3.0/docs/man/html/clGetExtensionFunctionAddressForPlatform.html
@@ -926,8 +926,8 @@ typedef cl_int
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetGLContextInfoKHR.html
+++ b/sdk/3.0/docs/man/html/clGetGLContextInfoKHR.html
@@ -1531,8 +1531,8 @@ required by the OpenCL implementation on the host.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetGLObjectInfo.html
+++ b/sdk/3.0/docs/man/html/clGetGLObjectInfo.html
@@ -875,8 +875,8 @@ Otherwise, it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetGLTextureInfo.html
+++ b/sdk/3.0/docs/man/html/clGetGLTextureInfo.html
@@ -940,8 +940,8 @@ Otherwise, it returns one of the following errors:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetHostTimer.html
+++ b/sdk/3.0/docs/man/html/clGetHostTimer.html
@@ -897,8 +897,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetImageInfo.html
+++ b/sdk/3.0/docs/man/html/clGetImageInfo.html
@@ -988,8 +988,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetKernelArgInfo.html
+++ b/sdk/3.0/docs/man/html/clGetKernelArgInfo.html
@@ -1005,8 +1005,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetKernelInfo.html
+++ b/sdk/3.0/docs/man/html/clGetKernelInfo.html
@@ -955,8 +955,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetKernelSubGroupInfo.html
+++ b/sdk/3.0/docs/man/html/clGetKernelSubGroupInfo.html
@@ -1035,8 +1035,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetKernelWorkGroupInfo.html
+++ b/sdk/3.0/docs/man/html/clGetKernelWorkGroupInfo.html
@@ -992,8 +992,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetMemObjectInfo.html
+++ b/sdk/3.0/docs/man/html/clGetMemObjectInfo.html
@@ -1031,8 +1031,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetPipeInfo.html
+++ b/sdk/3.0/docs/man/html/clGetPipeInfo.html
@@ -945,8 +945,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetPlatformIDs.html
+++ b/sdk/3.0/docs/man/html/clGetPlatformIDs.html
@@ -869,8 +869,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetPlatformInfo.html
+++ b/sdk/3.0/docs/man/html/clGetPlatformInfo.html
@@ -996,8 +996,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetProgramBuildInfo.html
+++ b/sdk/3.0/docs/man/html/clGetProgramBuildInfo.html
@@ -1008,8 +1008,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetProgramInfo.html
+++ b/sdk/3.0/docs/man/html/clGetProgramInfo.html
@@ -1069,8 +1069,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetSamplerInfo.html
+++ b/sdk/3.0/docs/man/html/clGetSamplerInfo.html
@@ -951,8 +951,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clGetSupportedImageFormats.html
+++ b/sdk/3.0/docs/man/html/clGetSupportedImageFormats.html
@@ -916,8 +916,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clIcdGetPlatformIDsKHR.html
+++ b/sdk/3.0/docs/man/html/clIcdGetPlatformIDsKHR.html
@@ -871,8 +871,8 @@ below:</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clLinkProgram.html
+++ b/sdk/3.0/docs/man/html/clLinkProgram.html
@@ -1041,8 +1041,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clReleaseCommandQueue.html
+++ b/sdk/3.0/docs/man/html/clReleaseCommandQueue.html
@@ -871,8 +871,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clReleaseContext.html
+++ b/sdk/3.0/docs/man/html/clReleaseContext.html
@@ -864,8 +864,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clReleaseDevice.html
+++ b/sdk/3.0/docs/man/html/clReleaseDevice.html
@@ -881,8 +881,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clReleaseEvent.html
+++ b/sdk/3.0/docs/man/html/clReleaseEvent.html
@@ -895,8 +895,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clReleaseKernel.html
+++ b/sdk/3.0/docs/man/html/clReleaseKernel.html
@@ -866,8 +866,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clReleaseMemObject.html
+++ b/sdk/3.0/docs/man/html/clReleaseMemObject.html
@@ -868,8 +868,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clReleaseProgram.html
+++ b/sdk/3.0/docs/man/html/clReleaseProgram.html
@@ -865,8 +865,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clReleaseSampler.html
+++ b/sdk/3.0/docs/man/html/clReleaseSampler.html
@@ -866,8 +866,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clRetainCommandQueue.html
+++ b/sdk/3.0/docs/man/html/clRetainCommandQueue.html
@@ -871,8 +871,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clRetainContext.html
+++ b/sdk/3.0/docs/man/html/clRetainContext.html
@@ -868,8 +868,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clRetainDevice.html
+++ b/sdk/3.0/docs/man/html/clRetainDevice.html
@@ -874,8 +874,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clRetainEvent.html
+++ b/sdk/3.0/docs/man/html/clRetainEvent.html
@@ -859,8 +859,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clRetainKernel.html
+++ b/sdk/3.0/docs/man/html/clRetainKernel.html
@@ -862,8 +862,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clRetainMemObject.html
+++ b/sdk/3.0/docs/man/html/clRetainMemObject.html
@@ -865,8 +865,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clRetainProgram.html
+++ b/sdk/3.0/docs/man/html/clRetainProgram.html
@@ -860,8 +860,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clRetainSampler.html
+++ b/sdk/3.0/docs/man/html/clRetainSampler.html
@@ -861,8 +861,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSVMAlloc.html
+++ b/sdk/3.0/docs/man/html/clSVMAlloc.html
@@ -996,8 +996,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSVMFree.html
+++ b/sdk/3.0/docs/man/html/clSVMFree.html
@@ -876,8 +876,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetCommandQueueProperty.html
+++ b/sdk/3.0/docs/man/html/clSetCommandQueueProperty.html
@@ -907,8 +907,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetContextDestructorCallback.html
+++ b/sdk/3.0/docs/man/html/clSetContextDestructorCallback.html
@@ -911,8 +911,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetDefaultDeviceCommandQueue.html
+++ b/sdk/3.0/docs/man/html/clSetDefaultDeviceCommandQueue.html
@@ -893,8 +893,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetEventCallback.html
+++ b/sdk/3.0/docs/man/html/clSetEventCallback.html
@@ -961,8 +961,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetKernelArg.html
+++ b/sdk/3.0/docs/man/html/clSetKernelArg.html
@@ -1054,8 +1054,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetKernelArgSVMPointer.html
+++ b/sdk/3.0/docs/man/html/clSetKernelArgSVMPointer.html
@@ -900,8 +900,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetKernelExecInfo.html
+++ b/sdk/3.0/docs/man/html/clSetKernelExecInfo.html
@@ -937,8 +937,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetMemObjectDestructorCallback.html
+++ b/sdk/3.0/docs/man/html/clSetMemObjectDestructorCallback.html
@@ -977,8 +977,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetProgramReleaseCallback.html
+++ b/sdk/3.0/docs/man/html/clSetProgramReleaseCallback.html
@@ -922,8 +922,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetProgramSpecializationConstant.html
+++ b/sdk/3.0/docs/man/html/clSetProgramSpecializationConstant.html
@@ -930,8 +930,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clSetUserEventStatus.html
+++ b/sdk/3.0/docs/man/html/clSetUserEventStatus.html
@@ -928,8 +928,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clTerminateContextKHR.html
+++ b/sdk/3.0/docs/man/html/clTerminateContextKHR.html
@@ -910,8 +910,8 @@ required by the OpenCL implementation on the host.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clUnloadCompiler.html
+++ b/sdk/3.0/docs/man/html/clUnloadCompiler.html
@@ -853,8 +853,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clUnloadPlatformCompiler.html
+++ b/sdk/3.0/docs/man/html/clUnloadPlatformCompiler.html
@@ -870,8 +870,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/clWaitForEvents.html
+++ b/sdk/3.0/docs/man/html/clWaitForEvents.html
@@ -880,8 +880,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_buffer_region.html
+++ b/sdk/3.0/docs/man/html/cl_buffer_region.html
@@ -845,8 +845,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_image_desc.html
+++ b/sdk/3.0/docs/man/html/cl_image_desc.html
@@ -998,8 +998,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_image_format.html
+++ b/sdk/3.0/docs/man/html/cl_image_format.html
@@ -1127,8 +1127,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_3d_image_writes.html
+++ b/sdk/3.0/docs/man/html/cl_khr_3d_image_writes.html
@@ -816,8 +816,8 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_byte_addressable_store.html
+++ b/sdk/3.0/docs/man/html/cl_khr_byte_addressable_store.html
@@ -814,8 +814,8 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_d3d10_sharing.html
+++ b/sdk/3.0/docs/man/html/cl_khr_d3d10_sharing.html
@@ -898,8 +898,8 @@ program termination.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_d3d11_sharing.html
+++ b/sdk/3.0/docs/man/html/cl_khr_d3d11_sharing.html
@@ -880,8 +880,8 @@ If the Direct3D 11 device is deleted through the Direct3D 11 API, subsequent use
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_depth_images.html
+++ b/sdk/3.0/docs/man/html/cl_khr_depth_images.html
@@ -814,8 +814,8 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_device_enqueue_local_arg_types.html
+++ b/sdk/3.0/docs/man/html/cl_khr_device_enqueue_local_arg_types.html
@@ -827,8 +827,8 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_dx9_media_sharing.html
+++ b/sdk/3.0/docs/man/html/cl_khr_dx9_media_sharing.html
@@ -1090,8 +1090,8 @@ the same as <code>CL_RGBA</code>, <code>CL_FLOAT</code>.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_egl_event.html
+++ b/sdk/3.0/docs/man/html/cl_khr_egl_event.html
@@ -857,8 +857,8 @@ The companion EGL_KHR_cl_event extension provides the complementary functionalit
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_egl_image.html
+++ b/sdk/3.0/docs/man/html/cl_khr_egl_image.html
@@ -840,8 +840,8 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_fp16.html
+++ b/sdk/3.0/docs/man/html/cl_khr_fp16.html
@@ -1189,8 +1189,8 @@ They are of type <code>half</code> and are accurate within the precision of the 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_fp64.html
+++ b/sdk/3.0/docs/man/html/cl_khr_fp64.html
@@ -824,8 +824,8 @@ is supported.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_gl_depth_images.html
+++ b/sdk/3.0/docs/man/html/cl_khr_gl_depth_images.html
@@ -896,8 +896,8 @@ If a GL texture object with an internal format from table 9.4 is successfully cr
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_gl_event.html
+++ b/sdk/3.0/docs/man/html/cl_khr_gl_event.html
@@ -864,8 +864,8 @@ While this is the only way to ensure completion that is portable to all platform
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_gl_msaa_sharing.html
+++ b/sdk/3.0/docs/man/html/cl_khr_gl_msaa_sharing.html
@@ -917,8 +917,8 @@ Accessing a coordinate outside the image and/or a sample that is outside the num
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_gl_sharing.html
+++ b/sdk/3.0/docs/man/html/cl_khr_gl_sharing.html
@@ -885,8 +885,8 @@ For a detailed description of how the level of detail is computed, please refer 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_global_int32_base_atomics.html
+++ b/sdk/3.0/docs/man/html/cl_khr_global_int32_base_atomics.html
@@ -826,8 +826,8 @@ instead of <code>atom_</code>.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_global_int32_extended_atomics.html
+++ b/sdk/3.0/docs/man/html/cl_khr_global_int32_extended_atomics.html
@@ -826,8 +826,8 @@ instead of <code>atom_</code>.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_icd.html
+++ b/sdk/3.0/docs/man/html/cl_khr_icd.html
@@ -931,8 +931,8 @@ For each of these platforms, the ICD Loader queries the platform&#8217;s extensi
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_il_program.html
+++ b/sdk/3.0/docs/man/html/cl_khr_il_program.html
@@ -821,8 +821,8 @@ This feature is now core.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_image2d_from_buffer.html
+++ b/sdk/3.0/docs/man/html/cl_khr_image2d_from_buffer.html
@@ -814,8 +814,8 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_initialize_memory.html
+++ b/sdk/3.0/docs/man/html/cl_khr_initialize_memory.html
@@ -873,8 +873,8 @@ The only requirement is there should be no values set from outside the context, 
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_int64_base_atomics.html
+++ b/sdk/3.0/docs/man/html/cl_khr_int64_base_atomics.html
@@ -824,8 +824,8 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_int64_extended_atomics.html
+++ b/sdk/3.0/docs/man/html/cl_khr_int64_extended_atomics.html
@@ -824,8 +824,8 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_local_int32_base_atomics.html
+++ b/sdk/3.0/docs/man/html/cl_khr_local_int32_base_atomics.html
@@ -826,8 +826,8 @@ instead of <code>atom_</code>.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_local_int32_extended_atomics.html
+++ b/sdk/3.0/docs/man/html/cl_khr_local_int32_extended_atomics.html
@@ -826,8 +826,8 @@ instead of <code>atom_</code>.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_mipmap_image.html
+++ b/sdk/3.0/docs/man/html/cl_khr_mipmap_image.html
@@ -882,8 +882,8 @@ If the <code>cl_khr_mipmap_image_writes</code> extension is supported by the Ope
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_priority_hints.html
+++ b/sdk/3.0/docs/man/html/cl_khr_priority_hints.html
@@ -826,8 +826,8 @@ It is expected that the the user guides associated with each implementation whic
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_spir.html
+++ b/sdk/3.0/docs/man/html/cl_khr_spir.html
@@ -851,8 +851,8 @@ Once a program object has been created from a SPIR binary,
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_srgb_image_writes.html
+++ b/sdk/3.0/docs/man/html/cl_khr_srgb_image_writes.html
@@ -842,8 +842,8 @@ written as-is.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_subgroups.html
+++ b/sdk/3.0/docs/man/html/cl_khr_subgroups.html
@@ -821,8 +821,8 @@ The feature is now core.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_terminate_context.html
+++ b/sdk/3.0/docs/man/html/cl_khr_terminate_context.html
@@ -855,8 +855,8 @@ Examples of the second case are when a kernel is running too long, or gets stuck
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/cl_khr_throttle_hints.html
+++ b/sdk/3.0/docs/man/html/cl_khr_throttle_hints.html
@@ -830,8 +830,8 @@ For example, a task may have high priority (<code>CL_QUEUE_PRIORITY_HIGH_KHR</co
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/commaOperator.html
+++ b/sdk/3.0/docs/man/html/commaOperator.html
@@ -815,8 +815,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/commonFunctions.html
+++ b/sdk/3.0/docs/man/html/commonFunctions.html
@@ -928,8 +928,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/constant.html
+++ b/sdk/3.0/docs/man/html/constant.html
@@ -863,8 +863,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/convert_T.html
+++ b/sdk/3.0/docs/man/html/convert_T.html
@@ -1107,8 +1107,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/deadLinks.html
+++ b/sdk/3.0/docs/man/html/deadLinks.html
@@ -835,8 +835,8 @@ below for each such link.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/enqueue_kernel.html
+++ b/sdk/3.0/docs/man/html/enqueue_kernel.html
@@ -841,8 +841,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/enqueue_marker.html
+++ b/sdk/3.0/docs/man/html/enqueue_marker.html
@@ -869,8 +869,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/enums.html
+++ b/sdk/3.0/docs/man/html/enums.html
@@ -1397,8 +1397,8 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/equalityOperators.html
+++ b/sdk/3.0/docs/man/html/equalityOperators.html
@@ -869,8 +869,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/eventFunctions.html
+++ b/sdk/3.0/docs/man/html/eventFunctions.html
@@ -1029,8 +1029,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/fpMacros.html
+++ b/sdk/3.0/docs/man/html/fpMacros.html
@@ -1145,8 +1145,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/genericAddressSpace.html
+++ b/sdk/3.0/docs/man/html/genericAddressSpace.html
@@ -828,8 +828,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/geometricFunctions.html
+++ b/sdk/3.0/docs/man/html/geometricFunctions.html
@@ -930,8 +930,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/global.html
+++ b/sdk/3.0/docs/man/html/global.html
@@ -852,8 +852,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/halfDataType.html
+++ b/sdk/3.0/docs/man/html/halfDataType.html
@@ -872,8 +872,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/helperFunctions.html
+++ b/sdk/3.0/docs/man/html/helperFunctions.html
@@ -853,8 +853,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/imageQueryFunctions.html
+++ b/sdk/3.0/docs/man/html/imageQueryFunctions.html
@@ -981,8 +981,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/imageReadFunctions.html
+++ b/sdk/3.0/docs/man/html/imageReadFunctions.html
@@ -1235,8 +1235,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/imageSamplerlessReadFunctions.html
+++ b/sdk/3.0/docs/man/html/imageSamplerlessReadFunctions.html
@@ -1138,8 +1138,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/imageWriteFunctions.html
+++ b/sdk/3.0/docs/man/html/imageWriteFunctions.html
@@ -1096,8 +1096,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/indirectionOperator.html
+++ b/sdk/3.0/docs/man/html/indirectionOperator.html
@@ -825,8 +825,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/integerFunctions.html
+++ b/sdk/3.0/docs/man/html/integerFunctions.html
@@ -1012,8 +1012,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/integerMacros.html
+++ b/sdk/3.0/docs/man/html/integerMacros.html
@@ -911,8 +911,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/intro.html
+++ b/sdk/3.0/docs/man/html/intro.html
@@ -766,9 +766,9 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 <div id="header">
 <h1>OpenCL Reference Pages</h1>
 <div class="details">
-<span id="revnumber">version v3.0.12,</span>
-<span id="revdate">Tue, 20 Sep 2022 00:00:00 +0000</span>
-<br><span id="revremark">from git branch: main commit: 996a022a7ad45583591df5e665af0f8f38b85e83</span>
+<span id="revnumber">version v3.0.13,</span>
+<span id="revdate">Tue Mar 14 12:00:00 AM UTC 2023</span>
+<br><span id="revremark">from git branch:  commit: 8c7870a2ffed533c61c31dbc057f2cf35b21d5e6</span>
 </div>
 </div>
 <div id="content">
@@ -847,8 +847,8 @@ OpenCL-Docs.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:59 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/kernel.html
+++ b/sdk/3.0/docs/man/html/kernel.html
@@ -850,8 +850,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/kernelQueryFunctions.html
+++ b/sdk/3.0/docs/man/html/kernelQueryFunctions.html
@@ -842,8 +842,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/legacyFenceFunctions.html
+++ b/sdk/3.0/docs/man/html/legacyFenceFunctions.html
@@ -873,8 +873,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/local.html
+++ b/sdk/3.0/docs/man/html/local.html
@@ -845,8 +845,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/logicalOperators.html
+++ b/sdk/3.0/docs/man/html/logicalOperators.html
@@ -846,8 +846,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/mathConstants.html
+++ b/sdk/3.0/docs/man/html/mathConstants.html
@@ -869,8 +869,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/mathFunctions.html
+++ b/sdk/3.0/docs/man/html/mathFunctions.html
@@ -1265,7 +1265,7 @@ all arguments and the return type, unless otherwise specified.</p>
 <p>A subset of functions from <a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#table-builtin-math" class="bare" target="_blank" rel="noopener">https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#table-builtin-math</a> that are defined with
 the half_ prefix .
 These functions are implemented with a minimum of 10-bits of accuracy,
-i.e. an ULP value &lt;= 8192 ulp.</p>
+i.e. the maximum error value &lt;= 8192 ulp.</p>
 </li>
 <li>
 <p>A subset of functions from <a href="https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#table-builtin-math" class="bare" target="_blank" rel="noopener">https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#table-builtin-math</a> that are defined with
@@ -1503,8 +1503,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/memory_order.html
+++ b/sdk/3.0/docs/man/html/memory_order.html
@@ -860,8 +860,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/memory_scope.html
+++ b/sdk/3.0/docs/man/html/memory_scope.html
@@ -860,8 +860,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/miscVectorFunctions.html
+++ b/sdk/3.0/docs/man/html/miscVectorFunctions.html
@@ -937,8 +937,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/operators.html
+++ b/sdk/3.0/docs/man/html/operators.html
@@ -863,8 +863,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/optionalAttributeQualifiers.html
+++ b/sdk/3.0/docs/man/html/optionalAttributeQualifiers.html
@@ -916,8 +916,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/otherDataTypes.html
+++ b/sdk/3.0/docs/man/html/otherDataTypes.html
@@ -1025,8 +1025,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/pipeFunctions.html
+++ b/sdk/3.0/docs/man/html/pipeFunctions.html
@@ -898,8 +898,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/pipeQueryFunctions.html
+++ b/sdk/3.0/docs/man/html/pipeQueryFunctions.html
@@ -853,8 +853,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/pipeWorkgroupFunctions.html
+++ b/sdk/3.0/docs/man/html/pipeWorkgroupFunctions.html
@@ -903,8 +903,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/prePostOperators.html
+++ b/sdk/3.0/docs/man/html/prePostOperators.html
@@ -832,8 +832,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/preprocessorDirectives.html
+++ b/sdk/3.0/docs/man/html/preprocessorDirectives.html
@@ -977,8 +977,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/printfFunction.html
+++ b/sdk/3.0/docs/man/html/printfFunction.html
@@ -852,8 +852,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/private.html
+++ b/sdk/3.0/docs/man/html/private.html
@@ -827,8 +827,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/relationalFunctions.html
+++ b/sdk/3.0/docs/man/html/relationalFunctions.html
@@ -1028,8 +1028,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/relationalOperators.html
+++ b/sdk/3.0/docs/man/html/relationalOperators.html
@@ -865,8 +865,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/reservedDataTypes.html
+++ b/sdk/3.0/docs/man/html/reservedDataTypes.html
@@ -899,8 +899,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/restrictions.html
+++ b/sdk/3.0/docs/man/html/restrictions.html
@@ -1020,8 +1020,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/samplers.html
+++ b/sdk/3.0/docs/man/html/samplers.html
@@ -959,8 +959,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/scalarDataTypes.html
+++ b/sdk/3.0/docs/man/html/scalarDataTypes.html
@@ -1024,8 +1024,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/selectionOperator.html
+++ b/sdk/3.0/docs/man/html/selectionOperator.html
@@ -828,8 +828,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/shiftOperators.html
+++ b/sdk/3.0/docs/man/html/shiftOperators.html
@@ -844,8 +844,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/sizeofOperator.html
+++ b/sdk/3.0/docs/man/html/sizeofOperator.html
@@ -862,8 +862,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/storageSpecifiers.html
+++ b/sdk/3.0/docs/man/html/storageSpecifiers.html
@@ -855,8 +855,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/subgroupFunctions.html
+++ b/sdk/3.0/docs/man/html/subgroupFunctions.html
@@ -1058,8 +1058,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/supportedImageFormats.html
+++ b/sdk/3.0/docs/man/html/supportedImageFormats.html
@@ -1000,8 +1000,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/syncFunctions.html
+++ b/sdk/3.0/docs/man/html/syncFunctions.html
@@ -879,8 +879,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/unaryLogicalOperator.html
+++ b/sdk/3.0/docs/man/html/unaryLogicalOperator.html
@@ -834,8 +834,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/unaryOperators.html
+++ b/sdk/3.0/docs/man/html/unaryOperators.html
@@ -814,8 +814,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/vectorDataLoadandStoreFunctions.html
+++ b/sdk/3.0/docs/man/html/vectorDataLoadandStoreFunctions.html
@@ -1145,8 +1145,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/vectorDataTypes.html
+++ b/sdk/3.0/docs/man/html/vectorDataTypes.html
@@ -962,8 +962,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/workGroupFunctions.html
+++ b/sdk/3.0/docs/man/html/workGroupFunctions.html
@@ -969,8 +969,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 

--- a/sdk/3.0/docs/man/html/workItemFunctions.html
+++ b/sdk/3.0/docs/man/html/workItemFunctions.html
@@ -1039,8 +1039,8 @@ Fixes and changes should be made to the Specification, not directly.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Version v3.0.12<br>
-Last updated 2022-09-19 17:14:58 -0700
+Version v3.0.13<br>
+Last updated 2023-03-13 17:50:03 -0700
 </div>
 </div>
 


### PR DESCRIPTION
There were very few refpages changes in v3.0.13 - really only just to mathFunctions.html - but it still seems like good practice to update them.