### PR TITLE
publish cl_intel_subgroups_short version 1.1

### DIFF
--- a/extensions/intel/cl_intel_subgroups_short.html
+++ b/extensions/intel/cl_intel_subgroups_short.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.8">
+<meta name="generator" content="Asciidoctor 2.0.16">
 <title>cl_intel_subgroups_short</title>
 <style>
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
@@ -140,7 +140,7 @@ meta.foundation-mq-large { font-family: "only screen and (min-width:1440px)"; wi
 
 html, body { font-size: 100%; }
 
-body { background: white; color: #222222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
+body { background: #fff; color: #222; padding: 0; margin: 0; font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif; font-weight: normal; font-style: normal; line-height: 1; position: relative; cursor: auto; }
 
 a:hover { cursor: pointer; }
 
@@ -189,7 +189,7 @@ div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .
 
 /* Default Link Styles */
 a { color: #0068b0; text-decoration: none; line-height: inherit; }
-a:hover, a:focus { color: #333333; }
+a:hover, a:focus { color: #333; }
 a img { border: none; }
 
 /* Default paragraph styles */
@@ -212,7 +212,7 @@ h5 { font-size: 1.125em; }
 
 h6 { font-size: 1em; }
 
-hr { border: solid #dddddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
+hr { border: solid #ddd; border-width: 1px 0 0; clear: both; margin: 1.25em 0 1.1875em; height: 0; }
 
 /* Helpful Typography Defaults */
 em, i { font-style: italic; line-height: inherit; }
@@ -245,20 +245,20 @@ dl dt { margin-bottom: 0.3em; font-weight: bold; }
 dl dd { margin-bottom: 0.75em; }
 
 /* Abbreviations */
-abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #dddddd; cursor: help; }
+abbr, acronym { text-transform: uppercase; font-size: 90%; color: black; border-bottom: 1px dotted #ddd; cursor: help; }
 
 abbr { text-transform: none; }
 
 /* Blockquotes */
-blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #dddddd; }
-blockquote cite { display: block; font-size: 0.8125em; color: #5e93b8; }
+blockquote { margin: 0 0 0.75em; padding: 0.5625em 1.25em 0 1.1875em; border-left: 1px solid #ddd; }
+blockquote cite { display: block; font-size: 0.8125em; color: #365E7A; }
 blockquote cite:before { content: "\2014 \0020"; }
-blockquote cite a, blockquote cite a:visited { color: #5e93b8; }
+blockquote cite a, blockquote cite a:visited { color: #365E7A; }
 
-blockquote, blockquote p { line-height: 1.6; color: #333333; }
+blockquote, blockquote p { line-height: 1.6; color: #333; }
 
 /* Microformats */
-.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #dddddd; padding: 0.625em 0.75em; }
+.vcard { display: inline-block; margin: 0 0 1.25em 0; border: 1px solid #ddd; padding: 0.625em 0.75em; }
 .vcard li { margin: 0; display: block; }
 .vcard .fn { font-weight: bold; font-size: 0.9375em; }
 
@@ -271,11 +271,11 @@ blockquote, blockquote p { line-height: 1.6; color: #333333; }
   h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
   h4 { font-size: 1.4375em; } }
 /* Tables */
-table { background: white; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
-table thead, table tfoot { background: -webkit-linear-gradient(top, #add386, #90b66a); font-weight: bold; }
-table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: white; text-align: left; }
+table { background: #fff; margin-bottom: 1.25em; border: solid 1px #d8d8ce; }
+table thead, table tfoot { background: #eee; font-weight: bold; }
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td { padding: 0.5em 0.625em 0.625em; font-size: inherit; color: #222; text-align: left; }
 table tr th, table tr td { padding: 0.5625em 0.625em; font-size: inherit; color: #6d6e71; }
-table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #edf2f2; }
+table tr.even, table tr.alt, table tr:nth-of-type(even) { background: #f8f8f8; }
 table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td { display: table-cell; line-height: 1.4; }
 
 body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
@@ -287,7 +287,7 @@ a:hover, a:focus { text-decoration: underline; }
 .clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
 .clearfix:after, .float-group:after { clear: both; }
 
-*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: white; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
+*:not(pre) > code { font-size: inherit; font-style: normal !important; letter-spacing: 0; padding: 0; background-color: transparent; -webkit-border-radius: 0; border-radius: 0; line-height: inherit; word-wrap: break-word; }
 *:not(pre) > code.nobreak { word-wrap: normal; }
 *:not(pre) > code.nowrap { white-space: nowrap; }
 
@@ -299,7 +299,7 @@ strong strong { font-weight: normal; }
 
 .keyseq { color: #333333; }
 
-kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
+kbd { font-family: Consolas, "Liberation Mono", Courier, monospace; display: inline-block; color: black; font-size: 0.65em; line-height: 1.45; background-color: #f7f7f7; border: 1px solid #ccc; -webkit-border-radius: 3px; border-radius: 3px; -moz-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 0.1em white inset; margin: 0 0.15em; padding: 0.2em 0.5em; vertical-align: middle; position: relative; top: -0.1em; white-space: nowrap; }
 
 .keyseq kbd:first-child { margin-left: 0; }
 
@@ -328,21 +328,21 @@ b.button:after { content: "]"; padding: 0 2px 0 3px; }
 #content:before { content: none; }
 
 #header > h1:first-child { color: black; margin-top: 2.25rem; margin-bottom: 0; }
-#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #dddddd; }
-#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #dddddd; padding-bottom: 8px; }
-#header .details { border-bottom: 1px solid #dddddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #5e93b8; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
+#header > h1:first-child + #toc { margin-top: 8px; border-top: 1px solid #ddd; }
+#header > h1:only-child, body.toc2 #header > h1:nth-last-child(2) { border-bottom: 1px solid #ddd; padding-bottom: 8px; }
+#header .details { border-bottom: 1px solid #ddd; line-height: 1.45; padding-top: 0.25em; padding-bottom: 0.25em; padding-left: 0.25em; color: #365E7A; display: -ms-flexbox; display: -webkit-flex; display: flex; -ms-flex-flow: row wrap; -webkit-flex-flow: row wrap; flex-flow: row wrap; }
 #header .details span:first-child { margin-left: -0.125em; }
-#header .details span.email a { color: #333333; }
+#header .details span.email a { color: #333; }
 #header .details br { display: none; }
 #header .details br + span:before { content: "\00a0\2013\00a0"; }
-#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333333; }
+#header .details br + span.author:before { content: "\00a0\22c5\00a0"; color: #333; }
 #header .details br + span#revremark:before { content: "\00a0|\00a0"; }
 #header #revnumber { text-transform: capitalize; }
 #header #revnumber:after { content: "\00a0"; }
 
-#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #dddddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
+#content > h1:first-child:not([class]) { color: black; border-bottom: 1px solid #ddd; padding-bottom: 8px; margin-top: 0; padding-top: 1rem; margin-bottom: 1.25rem; }
 
-#toc { border-bottom: 0 solid #dddddd; padding-bottom: 0.5em; }
+#toc { border-bottom: 0 solid #ddd; padding-bottom: 0.5em; }
 #toc > ul { margin-left: 0.125em; }
 #toc ul.sectlevel0 > li > a { font-style: italic; }
 #toc ul.sectlevel0 ul.sectlevel1 { margin: 0.5em 0; }
@@ -355,20 +355,20 @@ b.button:after { content: "]"; padding: 0 2px 0 3px; }
 
 @media only screen and (min-width: 768px) { #toctitle { font-size: 1.375em; }
   body.toc2 { padding-left: 15em; padding-right: 0; }
-  #toc.toc2 { margin-top: 0 !important; background-color: white; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #dddddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
+  #toc.toc2 { margin-top: 0 !important; background-color: #fff; position: fixed; width: 15em; left: 0; top: 0; border-right: 1px solid #ddd; border-top-width: 0 !important; border-bottom-width: 0 !important; z-index: 1000; padding: 1.25em 1em; height: 100%; overflow: auto; }
   #toc.toc2 #toctitle { margin-top: 0; margin-bottom: 0.8rem; font-size: 1.2em; }
   #toc.toc2 > ul { font-size: 0.9em; margin-bottom: 0; }
   #toc.toc2 ul ul { margin-left: 0; padding-left: 1em; }
   #toc.toc2 ul.sectlevel0 ul.sectlevel1 { padding-left: 0; margin-top: 0.5em; margin-bottom: 0.5em; }
   body.toc2.toc-right { padding-left: 0; padding-right: 15em; }
-  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #dddddd; left: auto; right: 0; } }
+  body.toc2.toc-right #toc.toc2 { border-right-width: 0; border-left: 1px solid #ddd; left: auto; right: 0; } }
 @media only screen and (min-width: 1280px) { body.toc2 { padding-left: 20em; padding-right: 0; }
   #toc.toc2 { width: 20em; }
   #toc.toc2 #toctitle { font-size: 1.375em; }
   #toc.toc2 > ul { font-size: 0.95em; }
   #toc.toc2 ul ul { padding-left: 1.25em; }
   body.toc2.toc-right { padding-left: 0; padding-right: 20em; } }
-#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+#content #toc { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: #fff; -webkit-border-radius: 0; border-radius: 0; }
 #content #toc > :first-child { margin-top: 0; }
 #content #toc > :last-child { margin-bottom: 0; }
 
@@ -384,7 +384,7 @@ b.button:after { content: "]"; padding: 0 2px 0 3px; }
   .sect1 { padding-bottom: 1.25em; } }
 .sect1:last-child { padding-bottom: 0; }
 
-.sect1 + .sect1 { border-top: 0 solid #dddddd; }
+.sect1 + .sect1 { border-top: 0 solid #ddd; }
 
 #content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
 #content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
@@ -406,29 +406,29 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-si
 .admonitionblock > table td.icon { text-align: center; width: 80px; }
 .admonitionblock > table td.icon img { max-width: initial; }
 .admonitionblock > table td.icon .title { font-weight: bold; font-family: Noto, sans-serif; text-transform: uppercase; }
-.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #dddddd; color: #5e93b8; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #ddd; color: #365E7A; }
 .admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
 
-.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: #fff; -webkit-border-radius: 0; border-radius: 0; }
 .exampleblock > .content > :first-child { margin-top: 0; }
 .exampleblock > .content > :last-child { margin-bottom: 0; }
 
-.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 0; border-radius: 0; }
+.sidebarblock { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: #fff; -webkit-border-radius: 0; border-radius: 0; }
 .sidebarblock > :first-child { margin-top: 0; }
 .sidebarblock > :last-child { margin-bottom: 0; }
 .sidebarblock > .content > .title { color: black; margin-top: 0; }
 
 .exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
 
-.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eeeeee; }
+.literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #eee; }
 .sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
 
-.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { border: 1px hidden #666; -webkit-border-radius: 0; border-radius: 0; word-wrap: break-word; padding: 1.25em 1.5625em 1.125em 1.5625em; font-size: 0.8125em; }
 .literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap { overflow-x: auto; white-space: pre; word-wrap: normal; }
 @media only screen and (min-width: 768px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 0.90625em; } }
 @media only screen and (min-width: 1280px) { .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] { font-size: 1em; } }
 
-.literalblock.output pre { color: #eeeeee; background-color: #264357; }
+.literalblock.output pre { color: #eee; background-color: #264357; }
 
 .listingblock pre.highlightjs { padding: 0; }
 .listingblock pre.highlightjs > code { padding: 1.25em 1.5625em 1.125em 1.5625em; -webkit-border-radius: 0; border-radius: 0; }
@@ -449,7 +449,7 @@ table.pyhltable td { vertical-align: top; padding-top: 0; padding-bottom: 0; lin
 
 table.pyhltable td.code { padding-left: .75em; padding-right: 0; }
 
-pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #dddddd; }
+pre.pygments .lineno, table.pyhltable td:not(.code) { color: #999; padding-left: 0; padding-right: .5em; border-right: 1px solid #ddd; }
 
 pre.pygments .lineno { display: inline-block; margin-right: .25em; }
 
@@ -457,23 +457,23 @@ table.pyhltable .linenodiv { background: none !important; padding-right: 0 !impo
 
 .quoteblock { margin: 0 1em 0.75em 1.5em; display: table; }
 .quoteblock > .title { margin-left: -1.5em; margin-bottom: 0.75em; }
-.quoteblock blockquote, .quoteblock blockquote p { color: #333333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
+.quoteblock blockquote, .quoteblock blockquote p { color: #333; font-size: 1.15rem; line-height: 1.75; word-spacing: 0.1em; letter-spacing: 0; font-style: italic; text-align: justify; }
 .quoteblock blockquote { margin: 0; padding: 0; border: 0; }
 .quoteblock blockquote:before { content: "\201c"; float: left; font-size: 2.75em; font-weight: bold; line-height: 0.6em; margin-left: -0.6em; color: black; text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1); }
 .quoteblock blockquote > .paragraph:last-child p { margin-bottom: 0; }
 .quoteblock .attribution { margin-top: 0.5em; margin-right: 0.5ex; text-align: right; }
-.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #5e93b8; }
+.quoteblock .quoteblock { margin-left: 0; margin-right: 0; padding: 0.5em 0; border-left: 3px solid #365E7A; }
 .quoteblock .quoteblock blockquote { padding: 0 0 0 0.75em; }
 .quoteblock .quoteblock blockquote:before { display: none; }
 
 .verseblock { margin: 0 1em 0.75em 1em; }
-.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333333; font-weight: 300; text-rendering: optimizeLegibility; }
+.verseblock pre { font-family: "Open Sans", "DejaVu Sans", sans; font-size: 1.15rem; color: #333; font-weight: 300; text-rendering: optimizeLegibility; }
 .verseblock pre strong { font-weight: 400; }
 .verseblock .attribution { margin-top: 1.25rem; margin-left: 0.5ex; }
 
 .quoteblock .attribution, .verseblock .attribution { font-size: 0.8125em; line-height: 1.45; font-style: italic; }
 .quoteblock .attribution br, .verseblock .attribution br { display: none; }
-.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #5e93b8; }
+.quoteblock .attribution cite, .verseblock .attribution cite { display: block; letter-spacing: -0.025em; color: #365E7A; }
 
 .quoteblock.abstract { margin: 0 0 0.75em 0; display: block; }
 .quoteblock.abstract blockquote, .quoteblock.abstract blockquote p { text-align: left; word-spacing: 0; }
@@ -518,9 +518,9 @@ th.valign-middle, td.valign-middle { vertical-align: middle; }
 
 table thead th, table tfoot th { font-weight: bold; }
 
-tbody tr th { display: table-cell; line-height: 1.4; background: -webkit-linear-gradient(top, #add386, #90b66a); }
+tbody tr th { display: table-cell; line-height: 1.4; background: #eee; }
 
-tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: white; font-weight: bold; }
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p { color: #222; font-weight: bold; }
 
 p.tableblock > code:only-child { background: none; padding: 0; }
 
@@ -583,7 +583,7 @@ td.hdlist1 { font-weight: bold; padding-bottom: 0.75em; }
 .colist > table tr > td:first-of-type img { max-width: initial; }
 .colist > table tr > td:last-of-type { padding: 0.25em 0; }
 
-.thumb, .th { line-height: 0; display: inline-block; border: solid 4px white; -webkit-box-shadow: 0 0 0 1px #dddddd; box-shadow: 0 0 0 1px #dddddd; }
+.thumb, .th { line-height: 0; display: inline-block; border: solid 4px #fff; -webkit-box-shadow: 0 0 0 1px #ddd; box-shadow: 0 0 0 1px #ddd; }
 
 .imageblock.left, .imageblock[style*="float: left"] { margin: 0.25em 0.625em 1.25em 0; }
 .imageblock.right, .imageblock[style*="float: right"] { margin: 0.25em 0 1.25em 0.625em; }
@@ -708,7 +708,7 @@ b.conum * { color: inherit !important; }
 
 .conum:not([data-value]):empty { display: none; }
 
-h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #dddddd; }
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { border-bottom: 1px solid #ddd; }
 
 .sect1 { padding-bottom: 0; }
 
@@ -720,8 +720,251 @@ code { -webkit-border-radius: 4px; border-radius: 4px; }
 
 p.tableblock.header { color: #6d6e71; }
 
-.literalblock pre, .listingblock pre { background: #eeeeee; }
+.literalblock pre, .listingblock pre { background: #eee; }
 
+/* From https://github.com/KhronosGroup/Vulkan-Docs/pull/901 */
+a code { color: inherit; }
+
+/* From https://github.com/KhronosGroup/Vulkan-Docs/pull/1157 */
+/* Make VUID anchor handles*/
+li > p > a[id^="VUID-"] { visibility: hidden; position: absolute; z-index: 1001; width: 2.2ex; margin-left: -2.2ex; display: block; text-decoration: none !important; text-align: center; font-weight: normal; }
+
+li > p > a[id^="VUID-"]:before { content: "\00A7"; font-size: 1em; display: block; padding-top: 0em; background: #fff; }
+
+li > p:hover > a[id^="VUID-"], li > p > a[id^="VUID-"]:hover { visibility: visible; }
+
+li > p > a[id^="VUID-"].link { color: black; text-decoration: none; }
+
+/* TODO: not quite sure what these two do */
+li > p > a[id^="VUID-"].link:hover { color: black; }
+
+.vuid { color: #4d4d4d; font-family: monospace; }
+
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<style>
+pre.rouge table td { padding: 5px; }
+pre.rouge table pre { margin: 0; }
+pre.rouge .kp {
+  color: #445588;
+  font-weight: bold;
+  font-style: italic;
+}
+pre.rouge .fm {
+  color: #00c5cd;
+  font-weight: bold;
+}
+pre.rouge .nx {
+  color: #ff4500;
+  font-weight: bold;
+}
+pre.rouge .vm {
+  color: #ffa500;
+  font-weight: bold;
+}
+pre.rouge .cm {
+  color: #555544;
+  font-style: italic;
+}
+pre.rouge .cp {
+  color: #555555;
+  font-weight: bold;
+}
+pre.rouge .c1 {
+  color: #555544;
+  font-style: italic;
+}
+pre.rouge .cs {
+  color: #555555;
+  font-weight: bold;
+  font-style: italic;
+}
+pre.rouge .c, pre.rouge .ch, pre.rouge .cd, pre.rouge .cpf {
+  color: #555544;
+  font-style: italic;
+}
+pre.rouge .err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+pre.rouge .gd {
+  color: #000000;
+  background-color: #ffdddd;
+}
+pre.rouge .ge {
+  color: #000000;
+  font-style: italic;
+}
+pre.rouge .gr {
+  color: #aa0000;
+}
+pre.rouge .gh {
+  color: #999999;
+}
+pre.rouge .gi {
+  color: #000000;
+  background-color: #ddffdd;
+}
+pre.rouge .go {
+  color: #888888;
+}
+pre.rouge .gp {
+  color: #555555;
+}
+pre.rouge .gs {
+  font-weight: bold;
+}
+pre.rouge .gu {
+  color: #aaaaaa;
+}
+pre.rouge .gt {
+  color: #aa0000;
+}
+pre.rouge .kc {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kd {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kn {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kr {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .kt {
+  color: #445588;
+  font-weight: bold;
+}
+pre.rouge .k, pre.rouge .kv {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .mf {
+  color: #009999;
+}
+pre.rouge .mh {
+  color: #009999;
+}
+pre.rouge .il {
+  color: #009999;
+}
+pre.rouge .mi {
+  color: #009999;
+}
+pre.rouge .mo {
+  color: #009999;
+}
+pre.rouge .m, pre.rouge .mb, pre.rouge .mx {
+  color: #009999;
+}
+pre.rouge .sb {
+  color: #d14;
+}
+pre.rouge .sc {
+  color: #d14;
+}
+pre.rouge .sd {
+  color: #d14;
+}
+pre.rouge .s2 {
+  color: #d14;
+}
+pre.rouge .se {
+  color: #d14;
+}
+pre.rouge .sh {
+  color: #d14;
+}
+pre.rouge .si {
+  color: #d14;
+}
+pre.rouge .sx {
+  color: #d14;
+}
+pre.rouge .sr {
+  color: #009926;
+}
+pre.rouge .s1 {
+  color: #d14;
+}
+pre.rouge .ss {
+  color: #990073;
+}
+pre.rouge .s, pre.rouge .sa, pre.rouge .dl {
+  color: #d14;
+}
+pre.rouge .na {
+  color: #008080;
+}
+pre.rouge .bp {
+  color: #999999;
+}
+pre.rouge .nb {
+  color: #0086B3;
+}
+pre.rouge .nc {
+  color: #445588;
+  font-weight: bold;
+}
+pre.rouge .no {
+  color: #008080;
+}
+pre.rouge .nd {
+  color: #3c5d5d;
+  font-weight: bold;
+}
+pre.rouge .ni {
+  color: #800080;
+}
+pre.rouge .ne {
+  color: #990000;
+  font-weight: bold;
+}
+pre.rouge .nf {
+  color: #990000;
+  font-weight: bold;
+}
+pre.rouge .nl {
+  color: #990000;
+  font-weight: bold;
+}
+pre.rouge .nn {
+  color: #555555;
+}
+pre.rouge .nt {
+  color: #000080;
+}
+pre.rouge .vc {
+  color: #008080;
+}
+pre.rouge .vg {
+  color: #008080;
+}
+pre.rouge .vi {
+  color: #008080;
+}
+pre.rouge .nv {
+  color: #008080;
+}
+pre.rouge .ow {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .o {
+  color: #000000;
+  font-weight: bold;
+}
+pre.rouge .w {
+  color: #bbbbbb;
+}
+pre.rouge {
+  background-color: #f8f8f8;
+}
 </style>
 <link rel="stylesheet" href="../katex/katex.min.css">
 <script src="../katex/katex.min.js"></script>
@@ -747,14 +990,14 @@ p.tableblock.header { color: #6d6e71; }
 <div id="header">
 <h1>cl_intel_subgroups_short</h1>
 <div class="details">
-<span id="revnumber">version V2.2-11-30-g5ba09e4,</span>
-<span id="revdate">Thu, 24 Oct 2019 22:38:28 +0000</span>
-<br><span id="revremark">from git branch: public_master commit: 5ba09e43bb29a2292d6af0b70148a9f846e1806f</span>
+<span id="revnumber">version v3.0.14-10-gff88d06,</span>
+<span id="revdate">Mon, 12 Jun 2023 22:42:42 +0000</span>
+<br><span id="revremark">from git branch: main commit: ff88d0674a775a7b458bf1500d052f2f67a2c2fe</span>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
-<h2 id="_name_strings">Name Strings</h2>
+<h2 id="_name_strings"><a class="anchor" href="#_name_strings"></a>Name Strings</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p><code>cl_intel_subgroups_short</code></p>
@@ -762,7 +1005,7 @@ p.tableblock.header { color: #6d6e71; }
 </div>
 </div>
 <div class="sect1">
-<h2 id="_contact">Contact</h2>
+<h2 id="_contact"><a class="anchor" href="#_contact"></a>Contact</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Ben Ashbaugh, Intel (ben 'dot' ashbaugh 'at' intel 'dot' com)</p>
@@ -770,10 +1013,11 @@ p.tableblock.header { color: #6d6e71; }
 </div>
 </div>
 <div class="sect1">
-<h2 id="_contributors">Contributors</h2>
+<h2 id="_contributors"><a class="anchor" href="#_contributors"></a>Contributors</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Ben Ashbaugh, Intel<br>
+Eugene Chereshnev, Intel<br>
 Felix J Degrood, Intel<br>
 Biju George, Intel<br>
 Raun M Krisch, Intel<br>
@@ -783,32 +1027,32 @@ Insoo Woo, Intel</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_notice">Notice</h2>
+<h2 id="_notice"><a class="anchor" href="#_notice"></a>Notice</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Copyright (c) 2018-2019 Intel Corporation.  All rights reserved.</p>
+<p>Copyright (c) 2018-2023 Intel Corporation.  All rights reserved.</p>
 </div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_status">Status</h2>
+<h2 id="_status"><a class="anchor" href="#_status"></a>Status</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Final Draft</p>
+<p>Complete</p>
 </div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_version">Version</h2>
+<h2 id="_version"><a class="anchor" href="#_version"></a>Version</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Built On: 2019-10-23<br>
-Revision: 3</p>
+<p>Built On: 2023-05-22<br>
+Revision: 1.1.0</p>
 </div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_dependencies">Dependencies</h2>
+<h2 id="_dependencies"><a class="anchor" href="#_dependencies"></a>Dependencies</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>OpenCL 1.2 and support for <code>cl_intel_subgroups</code> is required.
@@ -817,32 +1061,32 @@ This extension is written against the OpenCL API Specification Version 2.2 (revi
 </div>
 </div>
 <div class="sect1">
-<h2 id="_overview">Overview</h2>
+<h2 id="_overview"><a class="anchor" href="#_overview"></a>Overview</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>The goal of this extension is to allow programmers to improve the performance of applications operating on 16-bit data types by extending the subgroup functions described in the <code>cl_intel_subgroups</code> extension to support 16-bit integer data types (<code>shorts</code> and <code>ushorts</code>).
+<p>The goal of this extension is to allow programmers to improve the performance of applications operating on 16-bit data types by extending the sub-group functions described in the <code>cl_intel_subgroups</code> extension to support 16-bit integer data types (<code>shorts</code> and <code>ushorts</code>).
 Specifically, the extension:</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p>Extends the subgroup broadcast function to allow 16-bit integer values to be broadcast from one work item to all other work items in the subgroup.</p>
+<p>Extends the sub-group broadcast function to allow 16-bit integer values to be broadcast from one work item to all other work items in the sub-group.</p>
 </li>
 <li>
-<p>Extends the subgroup scan and reduction functions to operate on 16-bit integer data types.</p>
+<p>Extends the sub-group scan and reduction functions to operate on 16-bit integer data types.</p>
 </li>
 <li>
-<p>Extends the Intel subgroup shuffle functions to allow arbitrarily exchanging 16-bit integer values among work items in the subgroup.</p>
+<p>Extends the Intel sub-group shuffle functions to allow arbitrarily exchanging 16-bit integer values among work items in the sub-group.</p>
 </li>
 <li>
-<p>Extends the Intel subgroup block read and write functions to allow reading and writing 16-bit integer data from images and buffers.</p>
+<p>Extends the Intel sub-group block read and write functions to allow reading and writing 16-bit integer data from images and buffers.</p>
 </li>
 </ul>
 </div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_new_api_functions">New API Functions</h2>
+<h2 id="_new_api_functions"><a class="anchor" href="#_new_api_functions"></a>New API Functions</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>None.</p>
@@ -850,7 +1094,7 @@ Specifically, the extension:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_new_api_enums">New API Enums</h2>
+<h2 id="_new_api_enums"><a class="anchor" href="#_new_api_enums"></a>New API Enums</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>None.</p>
@@ -858,39 +1102,39 @@ Specifically, the extension:</p>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_new_opencl_c_functions">New OpenCL C Functions</h2>
+<h2 id="_new_opencl_c_functions"><a class="anchor" href="#_new_opencl_c_functions"></a>New OpenCL C Functions</h2>
 <div class="sectionbody">
 <div class="dlist">
 <dl>
-<dt class="hdlist1">Add <code>short</code> and <code>ushort</code> to the list of supported data types for the subgroup broadcast, scan, and reduction functions: </dt>
+<dt class="hdlist1">Add <code>short</code> and <code>ushort</code> to the list of supported data types for the sub-group broadcast, scan, and reduction functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code>short   intel_sub_group_broadcast( short x, uint sub_group_local_id )
-ushort  intel_sub_group_broadcast( ushort x, uint sub_group_local_id )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">short</span>   <span class="nf">intel_sub_group_broadcast</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">sub_group_local_id</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_broadcast</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">sub_group_local_id</span> <span class="p">);</span>
 
-short   intel_sub_group_reduce_add( short x )
-ushort  intel_sub_group_reduce_add( ushort x )
-short   intel_sub_group_reduce_min( short x )
-ushort  intel_sub_group_reduce_min( ushort x )
-short   intel_sub_group_reduce_max( short x )
-ushort  intel_sub_group_reduce_max( ushort x )
+<span class="kt">short</span>   <span class="nf">intel_sub_group_reduce_add</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_reduce_add</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_reduce_min</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_reduce_min</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_reduce_max</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_reduce_max</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
 
-short   intel_sub_group_scan_exclusive_add( short x )
-ushort  intel_sub_group_scan_exclusive_add( ushort x )
-short   intel_sub_group_scan_exclusive_min( short x )
-ushort  intel_sub_group_scan_exclusive_min( ushort x )
-short   intel_sub_group_scan_exclusive_max( short x )
-ushort  intel_sub_group_scan_exclusive_max( ushort x )
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_exclusive_add</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_exclusive_add</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_exclusive_min</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_exclusive_min</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_exclusive_max</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_exclusive_max</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
 
-short   intel_sub_group_scan_inclusive_add( short x )
-ushort  intel_sub_group_scan_inclusive_add( ushort x )
-short   intel_sub_group_scan_inclusive_min( short x )
-ushort  intel_sub_group_scan_inclusive_min( ushort x )
-short   intel_sub_group_scan_inclusive_max( short x )
-ushort  intel_sub_group_scan_inclusive_max( ushort x )</code></pre>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_inclusive_add</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_inclusive_add</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_inclusive_min</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_inclusive_min</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_inclusive_max</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_inclusive_max</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span></code></pre>
 </div>
 </div>
 </div>
@@ -902,68 +1146,76 @@ ushort  intel_sub_group_scan_inclusive_max( ushort x )</code></pre>
 <div class="content">
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code>gentype intel_sub_group_shuffle( gentype data, uint c )
-gentype intel_sub_group_shuffle_down(
-                gentype current, gentype next, uint delta )
-gentype intel_sub_group_shuffle_up(
-                gentype previous, gentype current, uint delta )
-gentype intel_sub_group_shuffle_xor( gentype data, uint value )</code></pre>
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kp">gentype</span> <span class="nf">intel_sub_group_shuffle</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">data</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">c</span> <span class="p">);</span>
+<span class="kp">gentype</span> <span class="nf">intel_sub_group_shuffle_down</span><span class="p">(</span>
+                <span class="kp">gentype</span> <span class="n">current</span><span class="p">,</span> <span class="kp">gentype</span> <span class="n">next</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">delta</span> <span class="p">);</span>
+<span class="kp">gentype</span> <span class="nf">intel_sub_group_shuffle_up</span><span class="p">(</span>
+                <span class="kp">gentype</span> <span class="n">previous</span><span class="p">,</span> <span class="kp">gentype</span> <span class="n">current</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">delta</span> <span class="p">);</span>
+<span class="kp">gentype</span> <span class="nf">intel_sub_group_shuffle_xor</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">data</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">value</span> <span class="p">);</span></code></pre>
 </div>
 </div>
 </div>
 </div>
 </dd>
-<dt class="hdlist1">Add <code>ushort</code> variants of the subgroup block read and write functions: </dt>
+<dt class="hdlist1">Add <code>ushort</code> variants of the sub-group block read and write functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code>ushort   intel_sub_group_block_read_us( const __global ushort* p )
-ushort2  intel_sub_group_block_read_us2( const __global ushort* p )
-ushort4  intel_sub_group_block_read_us4( const __global ushort* p )
-ushort8  intel_sub_group_block_read_us8( const __global ushort* p )
-ushort   intel_sub_group_block_read_us( image2d_t image, int2 byte_coord )
-ushort2  intel_sub_group_block_read_us2( image2d_t image, int2 byte_coord )
-ushort4  intel_sub_group_block_read_us4( image2d_t image, int2 byte_coord )
-ushort8  intel_sub_group_block_read_us8( image2d_t image, int2 byte_coord )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">ushort</span>   <span class="nf">intel_sub_group_block_read_us</span><span class="p">(</span> <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">ushort2</span>  <span class="nf">intel_sub_group_block_read_us2</span><span class="p">(</span> <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">ushort4</span>  <span class="nf">intel_sub_group_block_read_us4</span><span class="p">(</span> <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">ushort8</span>  <span class="nf">intel_sub_group_block_read_us8</span><span class="p">(</span> <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">ushort</span>   <span class="nf">intel_sub_group_block_read_us</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">ushort2</span>  <span class="nf">intel_sub_group_block_read_us2</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">ushort4</span>  <span class="nf">intel_sub_group_block_read_us4</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">ushort8</span>  <span class="nf">intel_sub_group_block_read_us8</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
 
-void  intel_sub_group_block_write_us( __global ushort* p, ushort data )
-void  intel_sub_group_block_write_us2( __global ushort* p, ushort2 data )
-void  intel_sub_group_block_write_us4( __global ushort* p, ushort4 data )
-void  intel_sub_group_block_write_us8( __global ushort* p, ushort8 data )
-void  intel_sub_group_block_write_us( image2d_t image, int2 byte_coord, ushort data )
-void  intel_sub_group_block_write_us2( image2d_t image, int2 byte_coord, ushort2 data )
-void  intel_sub_group_block_write_us4( image2d_t image, int2 byte_coord, ushort4 data )
-void  intel_sub_group_block_write_us8( image2d_t image, int2 byte_coord, ushort8 data )</code></pre>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us</span><span class="p">(</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us2</span><span class="p">(</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us4</span><span class="p">(</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us8</span><span class="p">(</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort8</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us2</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us4</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us8</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort8</span> <span class="n">data</span> <span class="p">);</span>
+
+<span class="cm">/* Extension version 1.1 adds the functions: */</span>
+
+<span class="kt">ushort16</span> <span class="nf">intel_sub_group_block_read_us16</span><span class="p">(</span> <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">ushort16</span> <span class="nf">intel_sub_group_block_read_us16</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us16</span><span class="p">(</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort16</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us16</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort16</span> <span class="n">data</span> <span class="p">);</span></code></pre>
 </div>
 </div>
 </div>
 </div>
 </dd>
-<dt class="hdlist1">For naming consistency, also add suffixed aliases of the <code>uint</code> subgroup block read and write functions described in the <code>cl_intel_subgroups</code> extension: </dt>
+<dt class="hdlist1">For naming consistency, also add suffixed aliases of the <code>uint</code> sub-group block read and write functions described in the <code>cl_intel_subgroups</code> extension: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
 <div class="listingblock">
 <div class="content">
-<pre class="highlight"><code>uint  intel_sub_group_block_read_ui( const __global uint* p )
-uint2 intel_sub_group_block_read_ui2( const __global uint* p )
-uint4 intel_sub_group_block_read_ui4( const __global uint* p )
-uint8 intel_sub_group_block_read_ui8( const __global uint* p )
-uint  intel_sub_group_block_read_ui( image2d_t image, int2 byte_coord )
-uint2 intel_sub_group_block_read_ui2( image2d_t image, int2 byte_coord )
-uint4 intel_sub_group_block_read_ui4( image2d_t image, int2 byte_coord )
-uint8 intel_sub_group_block_read_ui8( image2d_t image, int2 byte_coord )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">uint</span>  <span class="nf">intel_sub_group_block_read_ui</span><span class="p">(</span> <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint2</span> <span class="nf">intel_sub_group_block_read_ui2</span><span class="p">(</span> <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint4</span> <span class="nf">intel_sub_group_block_read_ui4</span><span class="p">(</span> <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint8</span> <span class="nf">intel_sub_group_block_read_ui8</span><span class="p">(</span> <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint</span>  <span class="nf">intel_sub_group_block_read_ui</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">uint2</span> <span class="nf">intel_sub_group_block_read_ui2</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">uint4</span> <span class="nf">intel_sub_group_block_read_ui4</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">uint8</span> <span class="nf">intel_sub_group_block_read_ui8</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
 
-void  intel_sub_group_block_write_ui( __global uint* p, uint data )
-void  intel_sub_group_block_write_ui2( __global uint* p, uint2 data )
-void  intel_sub_group_block_write_ui4( __global uint* p, uint4 data )
-void  intel_sub_group_block_write_ui8( __global uint* p, uint8 data )
-void  intel_sub_group_block_write_ui( image2d_t image, int2 byte_coord, uint data )
-void  intel_sub_group_block_write_ui2( image2d_t image, int2 byte_coord, uint2 data )
-void  intel_sub_group_block_write_ui4( image2d_t image, int2 byte_coord, uint4 data )
-void  intel_sub_group_block_write_ui8( image2d_t image, int2 byte_coord, uint8 data )</code></pre>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui</span><span class="p">(</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui2</span><span class="p">(</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui4</span><span class="p">(</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui8</span><span class="p">(</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint8</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui2</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui4</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui8</span><span class="p">(</span> <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span> <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint8</span> <span class="n">data</span> <span class="p">);</span></code></pre>
 </div>
 </div>
 </div>
@@ -974,13 +1226,13 @@ void  intel_sub_group_block_write_ui8( image2d_t image, int2 byte_coord, uint8 d
 </div>
 </div>
 <div class="sect1">
-<h2 id="_modifications_to_the_opencl_c_specification">Modifications to the OpenCL C Specification</h2>
+<h2 id="_modifications_to_the_opencl_c_specification"><a class="anchor" href="#_modifications_to_the_opencl_c_specification"></a>Modifications to the OpenCL C Specification</h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_additions_to_section_6_13_15_work_group_functions">Additions to Section 6.13.15 - "Work Group Functions"</h3>
+<h3 id="_additions_to_section_6_13_15_work_group_functions"><a class="anchor" href="#_additions_to_section_6_13_15_work_group_functions"></a>Additions to Section 6.13.15 - "Work-group Functions"</h3>
 <div class="dlist">
 <dl>
-<dt class="hdlist1">Add <code>short</code> and <code>ushort</code> to the list of supported data types for the subgroup broadcast, scan, and reduction functions: </dt>
+<dt class="hdlist1">Add <code>short</code> and <code>ushort</code> to the list of supported data types for the sub-group broadcast, scan, and reduction functions: </dt>
 <dd>
 <div class="openblock">
 <div class="content">
@@ -999,75 +1251,75 @@ void  intel_sub_group_block_write_ui8( image2d_t image, int2 byte_coord, uint8 d
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_broadcast(
-          gentype x,
-          uint sub_group_local_id )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kp">gentype</span> <span class="nf">sub_group_broadcast</span><span class="p">(</span>
+          <span class="kp">gentype</span> <span class="n">x</span><span class="p">,</span>
+          <span class="kt">uint</span> <span class="n">sub_group_local_id</span> <span class="p">);</span>
 
-short    intel_sub_group_broadcast(
-          short x,
-          uint sub_group_local_id )
-ushort   intel_sub_group_broadcast(
-          ushort x,
-          uint sub_group_local_id )</code></pre>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_broadcast</span><span class="p">(</span>
+          <span class="kt">short</span> <span class="n">x</span><span class="p">,</span>
+          <span class="kt">uint</span> <span class="n">sub_group_local_id</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_broadcast</span><span class="p">(</span>
+          <span class="kt">ushort</span> <span class="n">x</span><span class="p">,</span>
+          <span class="kt">uint</span> <span class="n">sub_group_local_id</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Broadcasts the value of <em>x</em> for work item identified by <em>sub_group_local_id</em> (value returned by  <strong>get_sub_group_local_id</strong>) to all work items in the subgroup.
-<em>sub_group_local_id</em> must be the same value for all work items in the subgroup.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Broadcasts the value of <em>x</em> for work item identified by <em>sub_group_local_id</em> (value returned by  <strong>get_sub_group_local_id</strong>) to all work items in the sub-group.
+<em>sub_group_local_id</em> must be the same value for all work items in the sub-group.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_reduce_add( gentype x )
-gentype sub_group_reduce_min( gentype x )
-gentype sub_group_reduce_max( gentype x )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kp">gentype</span> <span class="nf">sub_group_reduce_add</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kp">gentype</span> <span class="nf">sub_group_reduce_min</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kp">gentype</span> <span class="nf">sub_group_reduce_max</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">x</span> <span class="p">);</span>
 
-short    intel_sub_group_reduce_add( short x )
-ushort   intel_sub_group_reduce_add( ushort x )
-short    intel_sub_group_reduce_min( short x )
-ushort   intel_sub_group_reduce_min( ushort x )
-short    intel_sub_group_reduce_max( short x )
-ushort   intel_sub_group_reduce_max( ushort x )</code></pre>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_reduce_add</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_reduce_add</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_reduce_min</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_reduce_min</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_reduce_max</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_reduce_max</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the result of the specified reduction operation for all values of <em>x</em> specified by work items in a subgroup.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Returns the result of the specified reduction operation for all values of <em>x</em> specified by work items in a sub-group.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_scan_exclusive_add( gentype x )
-gentype sub_group_scan_exclusive_min( gentype x )
-gentype sub_group_scan_exclusive_max( gentype x )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kp">gentype</span> <span class="nf">sub_group_scan_exclusive_add</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kp">gentype</span> <span class="nf">sub_group_scan_exclusive_min</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kp">gentype</span> <span class="nf">sub_group_scan_exclusive_max</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">x</span> <span class="p">);</span>
 
-short    intel_sub_group_scan_exclusive_add( short x )
-ushort   intel_sub_group_scan_exclusive_add( ushort x )
-short    intel_sub_group_scan_exclusive_min( short x )
-ushort   intel_sub_group_scan_exclusive_min( ushort x )
-short    intel_sub_group_scan_exclusive_max( short x )
-ushort   intel_sub_group_scan_exclusive_max( ushort x )</code></pre>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_exclusive_add</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_exclusive_add</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_exclusive_min</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_exclusive_min</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_exclusive_max</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_exclusive_max</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Performs the specified exclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
+<td class="tableblock halign-left valign-top"><p class="tableblock">Performs the specified exclusive scan operation of all values <em>x</em> specified by work items in a sub-group.
 The scan results are returned for each work item.</p>
-<p class="tableblock">The scan order is defined by increasing subgroup local ID within the subgroup.</p></td>
+<p class="tableblock">The scan order is defined by increasing sub-group local ID within the sub-group.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">gentype sub_group_scan_inclusive_add( gentype x)
-gentype sub_group_scan_inclusive_min( gentype x)
-gentype sub_group_scan_inclusive_max( gentype x)
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kp">gentype</span> <span class="nf">sub_group_scan_inclusive_add</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kp">gentype</span> <span class="nf">sub_group_scan_inclusive_min</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kp">gentype</span> <span class="nf">sub_group_scan_inclusive_max</span><span class="p">(</span> <span class="kp">gentype</span> <span class="n">x</span> <span class="p">);</span>
 
-short    intel_sub_group_scan_inclusive_add( short x )
-ushort   intel_sub_group_scan_inclusive_add( ushort x )
-short    intel_sub_group_scan_inclusive_min( short x )
-ushort   intel_sub_group_scan_inclusive_min( ushort x )
-short    intel_sub_group_scan_inclusive_max( short x )
-ushort   intel_sub_group_scan_inclusive_max( ushort x )</code></pre>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_inclusive_add</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_inclusive_add</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_inclusive_min</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_inclusive_min</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">short</span>   <span class="nf">intel_sub_group_scan_inclusive_max</span><span class="p">(</span> <span class="kt">short</span> <span class="n">x</span> <span class="p">);</span>
+<span class="kt">ushort</span>  <span class="nf">intel_sub_group_scan_inclusive_max</span><span class="p">(</span> <span class="kt">ushort</span> <span class="n">x</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Performs the specified inclusive scan operation of all values <em>x</em> specified by work items in a subgroup.
+<td class="tableblock halign-left valign-top"><p class="tableblock">Performs the specified inclusive scan operation of all values <em>x</em> specified by work items in a sub-group.
 The scan results are returned for each work item.</p>
-<p class="tableblock">The scan order is defined by increasing subgroup local ID within the subgroup.</p></td>
+<p class="tableblock">The scan order is defined by increasing sub-group local ID within the sub-group.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1078,7 +1330,7 @@ The scan results are returned for each work item.</p>
 </div>
 </div>
 <div class="sect2">
-<h3 id="_additions_to_section_6_13_x_sub_group_shuffle_functions">Additions to Section 6.13.X - "Sub Group Shuffle Functions"</h3>
+<h3 id="_additions_to_section_6_13_x_sub_group_shuffle_functions"><a class="anchor" href="#_additions_to_section_6_13_x_sub_group_shuffle_functions"></a>Additions to Section 6.13.X - "Sub-group Shuffle Functions"</h3>
 <div class="paragraph">
 <p>This section was added by the <code>cl_intel_subgroups</code> extension.</p>
 </div>
@@ -1089,9 +1341,9 @@ The scan results are returned for each work item.</p>
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
-<p>The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a subgroup.
-These built-in functions need not be encountered by all work items in a subgroup executing the kernel, however, data may only be shuffled among work items encountering the subgroup shuffle function.
-Shuffling data from a work item that does not encounter the subgroup shuffle function will produce undefined results.
+<p>The OpenCL C programming language implements the following built-in functions to allow data to be exchanged among work items in a sub-group.
+These built-in functions need not be encountered by all work items in a sub-group executing the kernel, however, data may only be shuffled among work items encountering the sub-group shuffle function.
+Shuffling data from a work item that does not encounter the sub-group shuffle function will produce undefined results.
 For these functions, <code>gentype</code> is <code>float</code>, <code>float2</code>, <code>float3</code>, <code>float4</code>, <code>float8</code>, <code>float16</code>, <code>short</code>, <code>short2</code>, <code>short3</code>, <code>short4</code>, <code>short8</code>, <code>short16</code>, <code>ushort</code>, <code>ushort2</code>, <code>ushort3</code>, <code>ushort4</code>, <code>ushort8</code>, <code>ushort16</code>, <code>int</code>, <code>int2</code>, <code>int3</code>, <code>int4</code>, <code>int8</code>, <code>int16</code>, <code>uint</code>, <code>uint2</code>, <code>uint3</code>, <code>uint4</code>, <code>uint8</code>, <code>uint16</code>, <code>long</code>, or <code>ulong</code>.</p>
 </div>
 <div class="paragraph">
@@ -1107,7 +1359,7 @@ For these functions, <code>gentype</code> is <code>float</code>, <code>float2</c
 </div>
 </div>
 <div class="sect2">
-<h3 id="_modifications_to_section_6_13_x_sub_group_read_and_write_functions">Modifications to Section 6.13.X "Sub Group Read and Write Functions"</h3>
+<h3 id="_modifications_to_section_6_13_x_sub_group_read_and_write_functions"><a class="anchor" href="#_modifications_to_section_6_13_x_sub_group_read_and_write_functions"></a>Modifications to Section 6.13.X "Sub-group Read and Write Functions"</h3>
 <div class="paragraph">
 <p>This section was added by the <code>cl_intel_subgroups</code> extension.</p>
 </div>
@@ -1132,114 +1384,114 @@ For these functions, <code>gentype</code> is <code>float</code>, <code>float2</c
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">uint  intel_sub_group_block_read(
-        const __global uint* p )
-uint2 intel_sub_group_block_read2(
-        const __global uint* p )
-uint4 intel_sub_group_block_read4(
-        const __global uint* p )
-uint8 intel_sub_group_block_read8(
-        const __global uint* p )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">uint</span>  <span class="nf">intel_sub_group_block_read</span><span class="p">(</span>
+        <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint2</span> <span class="nf">intel_sub_group_block_read2</span><span class="p">(</span>
+        <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint4</span> <span class="nf">intel_sub_group_block_read4</span><span class="p">(</span>
+        <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint8</span> <span class="nf">intel_sub_group_block_read8</span><span class="p">(</span>
+        <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
 
-uint  intel_sub_group_block_read_ui(
-        const __global uint* p )
-uint2 intel_sub_group_block_read_ui2(
-        const __global uint* p )
-uint4 intel_sub_group_block_read_ui4(
-        const __global uint* p )
-uint8 intel_sub_group_block_read_ui8(
-        const __global uint* p )</code></pre>
+<span class="kt">uint</span>  <span class="nf">intel_sub_group_block_read_ui</span><span class="p">(</span>
+        <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint2</span> <span class="nf">intel_sub_group_block_read_ui2</span><span class="p">(</span>
+        <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint4</span> <span class="nf">intel_sub_group_block_read_ui4</span><span class="p">(</span>
+        <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">uint8</span> <span class="nf">intel_sub_group_block_read_ui8</span><span class="p">(</span>
+        <span class="k">const</span> <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified pointer as a block operation&#8230;&#8203;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified pointer as a block operation&#8230;&#8203;</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">uint  intel_sub_group_block_read(
-        image2d_t image,
-        int2 byte_coord )
-uint2 intel_sub_group_block_read2(
-        image2d_t image,
-        int2 byte_coord )
-uint4 intel_sub_group_block_read4(
-        image2d_t image,
-        int2 byte_coord )
-uint8 intel_sub_group_block_read8(
-        image2d_t image,
-        int2 byte_coord )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">uint</span>  <span class="nf">intel_sub_group_block_read</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">uint2</span> <span class="nf">intel_sub_group_block_read2</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">uint4</span> <span class="nf">intel_sub_group_block_read4</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">uint8</span> <span class="nf">intel_sub_group_block_read8</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
 
-uint  intel_sub_group_block_read_ui(
-        image2d_t image,
-        int2 byte_coord )
-uint2 intel_sub_group_block_read_ui2(
-        image2d_t image,
-        int2 byte_coord )
-uint4 intel_sub_group_block_read_ui4(
-        image2d_t image,
-        int2 byte_coord )
-uint8 intel_sub_group_block_read_ui8(
-        image2d_t image,
-        int2 byte_coord )</code></pre>
+<span class="kt">uint</span>  <span class="nf">intel_sub_group_block_read_ui</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">uint2</span> <span class="nf">intel_sub_group_block_read_ui2</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">uint4</span> <span class="nf">intel_sub_group_block_read_ui4</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">uint8</span> <span class="nf">intel_sub_group_block_read_ui8</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the subgroup from the specified image at the specified coordinate as a block operation&#8230;&#8203;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 uints of data for each work item in the sub-group from the specified image at the specified coordinate as a block operation&#8230;&#8203;</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write(
-        __global uint* p, uint data )
-void  intel_sub_group_block_write2(
-        __global uint* p, uint2 data )
-void  intel_sub_group_block_write4(
-        __global uint* p, uint4 data )
-void  intel_sub_group_block_write8(
-        __global uint* p, uint8 data )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">void</span>  <span class="nf">intel_sub_group_block_write</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write2</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write4</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write8</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint8</span> <span class="n">data</span> <span class="p">);</span>
 
-void  intel_sub_group_block_write_ui(
-        __global uint* p, uint data )
-void  intel_sub_group_block_write_ui2(
-        __global uint* p, uint2 data )
-void  intel_sub_group_block_write_ui4(
-        __global uint* p, uint4 data )
-void  intel_sub_group_block_write_ui8(
-        __global uint* p, uint8 data )</code></pre>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui2</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui4</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui8</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">uint</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">uint8</span> <span class="n">data</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified pointer as a block operation&#8230;&#8203;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified pointer as a block operation&#8230;&#8203;</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write(
-        image2d_t image,
-        int2 byte_coord, uint data )
-void  intel_sub_group_block_write2(
-        image2d_t image,
-        int2 byte_coord, uint2 data )
-void  intel_sub_group_block_write4(
-        image2d_t image,
-        int2 byte_coord, uint4 data )
-void  intel_sub_group_block_write8(
-        image2d_t image,
-        int2 byte_coord, uint8 data )
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">void</span>  <span class="nf">intel_sub_group_block_write</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write2</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write4</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write8</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint8</span> <span class="n">data</span> <span class="p">);</span>
 
-void  intel_sub_group_block_write_ui(
-        image2d_t image,
-        int2 byte_coord, uint data )
-void  intel_sub_group_block_write_ui2(
-        image2d_t image,
-        int2 byte_coord, uint2 data )
-void  intel_sub_group_block_write_ui4(
-        image2d_t image,
-        int2 byte_coord, uint4 data )
-void  intel_sub_group_block_write_ui8(
-        image2d_t image,
-        int2 byte_coord, uint8 data )</code></pre>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui2</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui4</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_ui8</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">uint8</span> <span class="n">data</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the subgroup to the specified image at the specified coordinate as a block operation&#8230;&#8203;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 uints of data for each work item in the sub-group to the specified image at the specified coordinate as a block operation&#8230;&#8203;</p></td>
 </tr>
 </tbody>
 </table>
@@ -1265,17 +1517,21 @@ void  intel_sub_group_block_write_ui8(
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">ushort   intel_sub_group_block_read_us(
-          const __global ushort* p )
-ushort2  intel_sub_group_block_read_us2(
-          const __global ushort* p )
-ushort4  intel_sub_group_block_read_us4(
-          const __global ushort* p )
-ushort8  intel_sub_group_block_read_us8(
-          const __global ushort* p )</code></pre>
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">ushort</span>  <span class="nf">intel_sub_group_block_read_us</span><span class="p">(</span>
+          <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">ushort2</span> <span class="nf">intel_sub_group_block_read_us2</span><span class="p">(</span>
+          <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">ushort4</span> <span class="nf">intel_sub_group_block_read_us4</span><span class="p">(</span>
+          <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+<span class="kt">ushort8</span> <span class="nf">intel_sub_group_block_read_us8</span><span class="p">(</span>
+          <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span>
+
+<span class="cm">/* For extension version 1.1 or newer: */</span>
+<span class="kt">ushort16</span> <span class="nf">intel_sub_group_block_read_us16</span><span class="p">(</span>
+          <span class="k">const</span> <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 ushorts of data for each work item in the subgroup from the specified pointer as a block operation.
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 (or 16, for extension version 1.1 or newer) ushorts of data for each work item in the sub-group from the specified pointer as a block operation.
 The data is read strided, so the first value read is:</p>
 <p class="tableblock"><code>p[ sub_group_local_id ]</code></p>
 <p class="tableblock">and the second value read is:</p>
@@ -1287,21 +1543,26 @@ The data is read strided, so the first value read is:</p>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">ushort   intel_sub_group_block_read_us(
-          image2d_t image,
-          int2 byte_coord )
-ushort2  intel_sub_group_block_read_us2(
-          image2d_t image,
-          int2 byte_coord )
-ushort4  intel_sub_group_block_read_us4(
-          image2d_t image,
-          int2 byte_coord )
-ushort8  intel_sub_group_block_read_us8(
-          image2d_t image,
-          int2 byte_coord )</code></pre>
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">ushort</span>  <span class="nf">intel_sub_group_block_read_us</span><span class="p">(</span>
+          <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+          <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">ushort2</span> <span class="nf">intel_sub_group_block_read_us2</span><span class="p">(</span>
+          <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+          <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">ushort4</span> <span class="nf">intel_sub_group_block_read_us4</span><span class="p">(</span>
+          <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+          <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+<span class="kt">ushort8</span> <span class="nf">intel_sub_group_block_read_us8</span><span class="p">(</span>
+          <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+          <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span>
+
+<span class="cm">/* For extension version 1.1 or newer: */</span>
+<span class="kt">ushort16</span> <span class="nf">intel_sub_group_block_read_us16</span><span class="p">(</span>
+          <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+          <span class="kt">int2</span> <span class="n">byte_coord</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 ushorts of data for each work item in the subgroup from the specified <em>image</em> at the specified coordinate as a block operation.
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reads 1, 2, 4, or 8 (or 16, for extension version 1.1 or newer) ushorts of data for each work item in the sub-group from the specified <em>image</em> at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Also note that the image data is read without format conversion, so each work item may read multiple image elements
 (for images with element size smaller than 16-bits).</p>
@@ -1311,17 +1572,21 @@ Also note that the image data is read without format conversion, so each work it
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write_us(
-        __global ushort* p, ushort data )
-void  intel_sub_group_block_write_us2(
-        __global ushort* p, ushort2 data )
-void  intel_sub_group_block_write_us4(
-        __global ushort* p, ushort4 data )
-void  intel_sub_group_block_write_us8(
-        __global ushort* p, ushort8 data )</code></pre>
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us2</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us4</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us8</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort8</span> <span class="n">data</span> <span class="p">);</span>
+
+<span class="cm">/* For extension version 1.1 or newer: */</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us16</span><span class="p">(</span>
+        <span class="nx">__global</span> <span class="kt">ushort</span><span class="o">*</span> <span class="n">p</span><span class="p">,</span> <span class="kt">ushort16</span> <span class="n">data</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 ushorts of data for each work item in the subgroup to the specified pointer as a block operation.
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 (or 16, for extension version 1.1 or newer) ushorts of data for each work item in the sub-group to the specified pointer as a block operation.
 The data is written strided, so the first value is written to:</p>
 <p class="tableblock"><code>p[ sub_group_local_id ]</code></p>
 <p class="tableblock">and the second value is written to:</p>
@@ -1333,21 +1598,26 @@ The data is written strided, so the first value is written to:</p>
 <tr>
 <td class="tableblock halign-left valign-top"><div class="content"><div class="listingblock">
 <div class="content">
-<pre class="highlight"><code class="language-c" data-lang="c">void  intel_sub_group_block_write_us(
-        image2d_t image,
-        int2 byte_coord, ushort data )
-void  intel_sub_group_block_write_us2(
-        image2d_t image,
-        int2 byte_coord, ushort2 data )
-void  intel_sub_group_block_write_us4(
-        image2d_t image,
-        int2 byte_coord, ushort4 data )
-void  intel_sub_group_block_write_us8(
-        image2d_t image,
-        int2 byte_coord, ushort8 data )</code></pre>
+<pre class="rouge highlight"><code data-lang="opencl_c"><span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us2</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort2</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us4</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort4</span> <span class="n">data</span> <span class="p">);</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us8</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort8</span> <span class="n">data</span> <span class="p">);</span>
+
+<span class="cm">/* For extension version 1.1 or newer: */</span>
+<span class="kt">void</span>  <span class="nf">intel_sub_group_block_write_us16</span><span class="p">(</span>
+        <span class="kt">image2d_t</span> <span class="n">image</span><span class="p">,</span>
+        <span class="kt">int2</span> <span class="n">byte_coord</span><span class="p">,</span> <span class="kt">ushort16</span> <span class="n">data</span> <span class="p">);</span></code></pre>
 </div>
 </div></div></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 ushorts of data for each work item in the subgroup to the specified <em>image</em> at the specified coordinate as a block operation.
+<td class="tableblock halign-left valign-top"><p class="tableblock">Writes 1, 2, 4, or 8 (or 16, for extension version 1.1 or newer) ushorts of data for each work item in the sub-group to the specified <em>image</em> at the specified coordinate as a block operation.
 Note that the coordinate is a byte coordinate, not an image element coordinate.
 Unlike the image block read function, which may read from any arbitrary byte offset, the x-component of the byte coordinate for the image block write functions must be a multiple of four;
 in other words, the write must begin at 32-bit boundary.
@@ -1367,7 +1637,7 @@ Also, note that the image <em>data</em> is written without format conversion, so
 </div>
 </div>
 <div class="sect1">
-<h2 id="_issues">Issues</h2>
+<h2 id="_issues"><a class="anchor" href="#_issues"></a>Issues</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>None.</p>
@@ -1375,7 +1645,7 @@ Also, note that the image <em>data</em> is written without format conversion, so
 </div>
 </div>
 <div class="sect1">
-<h2 id="_revision_history">Revision History</h2>
+<h2 id="_revision_history"><a class="anchor" href="#_revision_history"></a>Revision History</h2>
 <div class="sectionbody">
 <table class="tableblock frame-all grid-rows stretch">
 <colgroup>
@@ -1386,7 +1656,7 @@ Also, note that the image <em>data</em> is written without format conversion, so
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Version</th>
 <th class="tableblock halign-left valign-top">Date</th>
 <th class="tableblock halign-left valign-top">Author</th>
 <th class="tableblock halign-left valign-top">Changes</th>
@@ -1394,22 +1664,34 @@ Also, note that the image <em>data</em> is written without format conversion, so
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rev 1</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">2016-10-20</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>First public revision.</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rev 2</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">2018-11-15</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Conversion to asciidoc.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">rev 3</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">2019-09-17</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Added vec3 types for shuffles and asciidoctor formatting fixes.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">First assigned version (same as rev 3).</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.1.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-04-14</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Added vec16 types for block reads and writes, switched to formal versioning.</p></td>
 </tr>
 </tbody>
 </table>
@@ -1418,11 +1700,11 @@ Also, note that the image <em>data</em> is written without format conversion, so
 </div>
 <div id="footer">
 <div id="footer-text">
-Version V2.2-11-30-g5ba09e4<br>
-Last updated 2019-10-23 15:35:34 -0700
+Version v3.0.14-10-gff88d06<br>
+Last updated 2023-05-22 14:25:19 -0700
 </div>
 </div>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 </body>
 </html>


### PR DESCRIPTION
Please publish version 1.1 of the cl_intel_subgroups_short extension.

The OpenCL-Docs PR that updated the asciidoc source for this extension is: https://github.com/KhronosGroup/OpenCL-Docs/pull/906