### PR TITLE
update cl_intel_subgroup_matrix_multiply_accumulate

### DIFF
--- a/extensions/intel/cl_intel_subgroup_matrix_multiply_accumulate.html
+++ b/extensions/intel/cl_intel_subgroup_matrix_multiply_accumulate.html
@@ -372,7 +372,7 @@ b.button:after { content: "]"; padding: 0 2px 0 3px; }
 #content #toc > :first-child { margin-top: 0; }
 #content #toc > :last-child { margin-bottom: 0; }
 
-#footer { max-width: 100%; background-color: none; padding: 1.25em; }
+#footer { max-width: 100%; background: none; padding: 1.25em; }
 
 #footer-text { color: black; line-height: 1.44; }
 
@@ -855,9 +855,9 @@ table.CodeRay td.code{padding:0 0 0 .75em}
 <div id="header">
 <h1>cl_intel_subgroup_matrix_multiply_accumulate</h1>
 <div class="details">
-<span id="revnumber">version v3.0.14-10-gff88d06,</span>
-<span id="revdate">Mon, 12 Jun 2023 23:00:00 +0000</span>
-<br><span id="revremark">from git branch: main commit: ff88d0674a775a7b458bf1500d052f2f67a2c2fe</span>
+<span id="revnumber">version v3.0.16-59-gd65b7393,</span>
+<span id="revdate">Fri, 11 Oct 2024 23:07:29 +0000</span>
+<br><span id="revremark">from git branch: main commit: d65b7393847d2d9c8c23e2f7502c559e8089ccc7</span>
 </div>
 </div>
 <div id="content">
@@ -895,7 +895,7 @@ Lukasz Towarek, Intel</p>
 <h2 id="_notice"><a class="anchor" href="#_notice"></a>Notice</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Copyright (c) 2022-2023 Intel Corporation.  All rights reserved.</p>
+<p>Copyright (c) 2022-2024 Intel Corporation.  All rights reserved.</p>
 </div>
 </div>
 </div>
@@ -911,7 +911,7 @@ Lukasz Towarek, Intel</p>
 <h2 id="_version"><a class="anchor" href="#_version"></a>Version</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Built On: 2023-06-12<br>
+<p>Built On: 2024-10-11<br>
 Revision: 1.0.0</p>
 </div>
 </div>
@@ -992,6 +992,27 @@ int2 intel_sub_group_u8_u8_matrix_mad_k32(uint2 a, uint8 b, int2 acc);
 int4 intel_sub_group_u8_u8_matrix_mad_k32(uint4 a, uint8 b, int4 acc);
 int8 intel_sub_group_u8_u8_matrix_mad_k32(uint8 a, uint8 b, int8 acc);
 
+// 4-bit matrices:
+int  intel_sub_group_i4_i4_matrix_mad_k64(int   a, int8  b, int  acc);
+int2 intel_sub_group_i4_i4_matrix_mad_k64(int2  a, int8  b, int2 acc);
+int4 intel_sub_group_i4_i4_matrix_mad_k64(int4  a, int8  b, int4 acc);
+int8 intel_sub_group_i4_i4_matrix_mad_k64(int8  a, int8  b, int8 acc);
+
+int  intel_sub_group_i4_u4_matrix_mad_k64(int   a, uint8 b, int  acc);
+int2 intel_sub_group_i4_u4_matrix_mad_k64(int2  a, uint8 b, int2 acc);
+int4 intel_sub_group_i4_u4_matrix_mad_k64(int4  a, uint8 b, int4 acc);
+int8 intel_sub_group_i4_u4_matrix_mad_k64(int8  a, uint8 b, int8 acc);
+
+int  intel_sub_group_u4_i4_matrix_mad_k64(uint  a, int8  b, int  acc);
+int2 intel_sub_group_u4_i4_matrix_mad_k64(uint2 a, int8  b, int2 acc);
+int4 intel_sub_group_u4_i4_matrix_mad_k64(uint4 a, int8  b, int4 acc);
+int8 intel_sub_group_u4_i4_matrix_mad_k64(uint8 a, int8  b, int8 acc);
+
+int  intel_sub_group_u4_u4_matrix_mad_k64(uint  a, uint8 b, int  acc);
+int2 intel_sub_group_u4_u4_matrix_mad_k64(uint2 a, uint8 b, int2 acc);
+int4 intel_sub_group_u4_u4_matrix_mad_k64(uint4 a, uint8 b, int4 acc);
+int8 intel_sub_group_u4_u4_matrix_mad_k64(uint8 a, uint8 b, int8 acc);
+
 // bfloat16 matrices:
 float  intel_sub_group_bf16_bf16_matrix_mad_k16(int  a, int8 b, float  acc);
 float2 intel_sub_group_bf16_bf16_matrix_mad_k16(int2 a, int8 b, float2 acc);
@@ -1031,17 +1052,50 @@ int2 intel_sub_group_u8_u8_matrix_mad_k32(ushort2 a, uint8 b, int2 acc);
 int4 intel_sub_group_u8_u8_matrix_mad_k32(ushort4 a, uint8 b, int4 acc);
 int8 intel_sub_group_u8_u8_matrix_mad_k32(ushort8 a, uint8 b, int8 acc);
 
-// bfloat16 matrices:
+// 4-bit matrices:
+int  intel_sub_group_i4_i4_matrix_mad_k64(short   a, int8  b, int  acc);
+int2 intel_sub_group_i4_i4_matrix_mad_k64(short2  a, int8  b, int2 acc);
+int4 intel_sub_group_i4_i4_matrix_mad_k64(short4  a, int8  b, int4 acc);
+int8 intel_sub_group_i4_i4_matrix_mad_k64(short8  a, int8  b, int8 acc);
+
+int  intel_sub_group_i4_u4_matrix_mad_k64(short   a, uint8 b, int  acc);
+int2 intel_sub_group_i4_u4_matrix_mad_k64(short2  a, uint8 b, int2 acc);
+int4 intel_sub_group_i4_u4_matrix_mad_k64(short4  a, uint8 b, int4 acc);
+int8 intel_sub_group_i4_u4_matrix_mad_k64(short8  a, uint8 b, int8 acc);
+
+int  intel_sub_group_u4_i4_matrix_mad_k64(ushort  a, int8  b, int  acc);
+int2 intel_sub_group_u4_i4_matrix_mad_k64(ushort2 a, int8  b, int2 acc);
+int4 intel_sub_group_u4_i4_matrix_mad_k64(ushort4 a, int8  b, int4 acc);
+int8 intel_sub_group_u4_i4_matrix_mad_k64(ushort8 a, int8  b, int8 acc);
+
+int  intel_sub_group_u4_u4_matrix_mad_k64(ushort  a, uint8 b, int  acc);
+int2 intel_sub_group_u4_u4_matrix_mad_k64(ushort2 a, uint8 b, int2 acc);
+int4 intel_sub_group_u4_u4_matrix_mad_k64(ushort4 a, uint8 b, int4 acc);
+int8 intel_sub_group_u4_u4_matrix_mad_k64(ushort8 a, uint8 b, int8 acc);
+
+// bfloat16 matrices with float accumulator:
 float  intel_sub_group_bf16_bf16_matrix_mad_k16(short  a, int8 b, float  acc);
 float2 intel_sub_group_bf16_bf16_matrix_mad_k16(short2 a, int8 b, float2 acc);
 float4 intel_sub_group_bf16_bf16_matrix_mad_k16(short4 a, int8 b, float4 acc);
 float8 intel_sub_group_bf16_bf16_matrix_mad_k16(short8 a, int8 b, float8 acc);
 
-// fp16 matrices:
+// fp16 matrices with float accumulator:
 float  intel_sub_group_f16_f16_matrix_mad_k16(short  a, int8 b, float  acc);
 float2 intel_sub_group_f16_f16_matrix_mad_k16(short2 a, int8 b, float2 acc);
 float4 intel_sub_group_f16_f16_matrix_mad_k16(short4 a, int8 b, float4 acc);
-float8 intel_sub_group_f16_f16_matrix_mad_k16(short8 a, int8 b, float8 acc);</code></pre>
+float8 intel_sub_group_f16_f16_matrix_mad_k16(short8 a, int8 b, float8 acc);
+
+// bfloat16 with bfloat16 accumulator:
+short  intel_sub_group_bf16_bf16_matrix_mad_k16(short  a, int8 b, short  acc);
+short2 intel_sub_group_bf16_bf16_matrix_mad_k16(short2 a, int8 b, short2 acc);
+short4 intel_sub_group_bf16_bf16_matrix_mad_k16(short4 a, int8 b, short4 acc);
+short8 intel_sub_group_bf16_bf16_matrix_mad_k16(short8 a, int8 b, short8 acc);
+
+// fp16 matrices with fp16 accumulator:
+half   intel_sub_group_f16_f16_matrix_mad_k16(short  a, int8 b, half  acc);
+half2  intel_sub_group_f16_f16_matrix_mad_k16(short2 a, int8 b, half2 acc);
+half4  intel_sub_group_f16_f16_matrix_mad_k16(short4 a, int8 b, half4 acc);
+half8  intel_sub_group_f16_f16_matrix_mad_k16(short8 a, int8 b, half8 acc);</code></pre>
 </div>
 </div>
 </div>
@@ -1182,12 +1236,15 @@ For this list of functions:</p>
 In other words, the only supported subgroup sizes are 8 and 16.</p>
 </li>
 <li>
-<p>Supported integer matrix types for <code>a</code> and <code>b</code> are any combination of signed or unsigned 8-bit integers.
-For these integer matrix types, the accumulation value <code>acc</code> and result value are signed 32-bit integers, and <code>K</code> must be equal to 32.</p>
+<p>Supported integer matrix types for <code>a</code> and <code>b</code> are any combination of signed or unsigned 8-bit integers, or any combination of signed or unsigned 4-bit integers.
+For 8-bit matrices, <code>K</code> must be equal to 32.  For 4-bit matrices, <code>K</code> must be equal to 64.
+For these integer matrix types, the accumulation value <code>acc</code> and result value are signed 32-bit integers.</p>
 </li>
 <li>
 <p>The supported floating-point matrix types for <code>a</code> and <code>b</code> are fp16 (half) or bfloat16.
-For these floating-point matrix type, the accumulation value <code>acc</code> and result value are 32-bit floating-point values, and <code>K</code> must be equal to 16.</p>
+For these floating-point matrices, <code>K</code> must be equal to 16.
+The accumulation value <code>acc</code> and result value are 32-bit floating-point values.
+For devices with <code>N</code> equal to 16, the accumulation value <code>acc</code> and result value may also be fp16 for fp16 matrices, or bfloat16 for bfloat16 matrices.</p>
 </li>
 </ul>
 </div>
@@ -1268,9 +1325,6 @@ int2 intel_sub_group_i8_i8_matrix_mad_k32(int2  a, int8  b, int2 acc)
 <div class="sect1">
 <h2 id="_issues"><a class="anchor" href="#_issues"></a>Issues</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>None.</p>
-</div>
 <div class="olist arabic">
 <ol class="arabic">
 <li>
@@ -1278,7 +1332,7 @@ int2 intel_sub_group_i8_i8_matrix_mad_k32(int2  a, int8  b, int2 acc)
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
-<p><code>RESOLVED</code>: This extension will use signed types to represent fp16 and bf16 data even though this is inconsistent with other extensions such as cl_intel_bfloat16 conversions.
+<p><code>RESOLVED</code>: This extension will use signed types to represent fp16 and bf16 data even though this is inconsistent with other extensions, such as the <code>cl_intel_bfloat16_conversions</code> extension.
 This inconsistency may be addressed in a future extension or in a future version of this extension.
 Applications are encouraged to use <code>as_type</code> to reinterpret unsigned data as signed data as needed to use the functions added by this extension.</p>
 </div>
@@ -1314,15 +1368,15 @@ Applications are encouraged to use <code>as_type</code> to reinterpret unsigned 
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial public revision</strong></p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-06-06</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Document additional functions.</p></td>
+</tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Version v3.0.14-10-gff88d06<br>
-Last updated 2023-06-12 16:00:00 -0700
 </div>
 </div>
 


### PR DESCRIPTION
Please publish an update to the cl_intel_subgroup_matrix_multiply_accumulate extension.

This update includes the changes from https://github.com/KhronosGroup/OpenCL-Docs/pull/1181.