### PR TITLE
add extension links for EXT extensions

### DIFF
--- a/extensions/clext.php
+++ b/extensions/clext.php
@@ -43,6 +43,8 @@
 </li>
 <li><a href="extensions/ext/cl_ext_atomic_counters_64.txt">cl_ext_atomic_counters_64</a>
 </li>
+<li><a href="specs/3.0-unified/html/OpenCL_API.html#cl_ext_buffer_device_address">cl_ext_buffer_device_address</a>
+</li>
 <li><a href="extensions/ext/cl_ext_cxx_for_opencl.html">cl_ext_cxx_for_opencl</a>
 </li>
 <li><a href="extensions/ext/cl_ext_device_fission.txt">cl_ext_device_fission</a>
@@ -54,6 +56,8 @@
 <li><a href="extensions/ext/cl_ext_image_raw10_raw12.html">cl_ext_image_raw10_raw12</a>
 </li>
 <li><a href="extensions/ext/cl_ext_image_requirements_info.html">cl_ext_image_requirements_info</a>
+</li>
+<li><a href="specs/3.0-unified/html/OpenCL_API.html#cl_ext_immutable_memory_objects">cl_ext_immutable_memory_objects</a>
 </li>
 <li><a href="extensions/ext/cl_ext_migrate_memobject.txt">cl_ext_migrate_memobject</a>
 </li>

--- a/extensions/registry.py
+++ b/extensions/registry.py
@@ -106,6 +106,11 @@ registry = {
         'flags' : { 'public' },
         'url' : 'extensions/ext/cl_ext_atomic_counters_64.txt',
     },
+    'cl_ext_buffer_device_address' : {
+        'number' : 87,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_API.html#cl_ext_buffer_device_address',
+    },
     'cl_ext_cxx_for_opencl' : {
         'number' : 64,
         'flags' : { 'public' },
@@ -135,6 +140,11 @@ registry = {
         'number' : 83,
         'flags' : { 'public' },
         'url' : 'extensions/ext/cl_ext_image_requirements_info.html',
+    },
+    'cl_ext_immutable_memory_objects' : {
+        'number' : 88,
+        'flags' : { 'public' },
+        'url' : 'specs/3.0-unified/html/OpenCL_API.html#cl_ext_immutable_memory_objects',
     },
     'cl_ext_migrate_memobject' : {
         'number' : 10,


### PR DESCRIPTION
When we published the OpenCL specifications v3.0.18 I missed adding the registry links for the new EXT extensions, specifically:

- cl_ext_buffer_device_address
- cl_ext_immutable_memory_objects

This PR adds the registry links for these two extensions.