### PR TITLE
update cl_intel_unified_shared_memory

### DIFF
--- a/extensions/intel/cl_intel_unified_shared_memory.html
+++ b/extensions/intel/cl_intel_unified_shared_memory.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.16">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>cl_intel_unified_shared_memory</title>
 <style>
 /*! normalize.css v2.1.2 | MIT License | git.io/normalize */
@@ -372,7 +372,7 @@ b.button:after { content: "]"; padding: 0 2px 0 3px; }
 #content #toc > :first-child { margin-top: 0; }
 #content #toc > :last-child { margin-bottom: 0; }
 
-#footer { max-width: 100%; background-color: none; padding: 1.25em; }
+#footer { max-width: 100%; background: none; padding: 1.25em; }
 
 #footer-text { color: black; line-height: 1.44; }
 
@@ -765,9 +765,9 @@ li > p > a[id^="VUID-"].link:hover { color: black; }
 <div id="header">
 <h1>cl_intel_unified_shared_memory</h1>
 <div class="details">
-<span id="revnumber">version v3.0.14-10-gff88d06,</span>
-<span id="revdate">Mon, 12 Jun 2023 23:00:00 +0000</span>
-<br><span id="revremark">from git branch: main commit: ff88d0674a775a7b458bf1500d052f2f67a2c2fe</span>
+<span id="revnumber">version v3.0.18-21-g4ae5ab5e,</span>
+<span id="revdate">Wed, 18 Jun 2025 18:58:41 +0000</span>
+<br><span id="revremark">from git branch: main commit: 4ae5ab5ed7660196765703d992d23126c4348735</span>
 </div>
 </div>
 <div id="content">
@@ -807,7 +807,7 @@ Lukasz Towarek, Intel</p>
 <h2 id="_notice"><a class="anchor" href="#_notice"></a>Notice</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Copyright (c) 2021-2023 Intel Corporation.  All rights reserved.</p>
+<p>Copyright (c) 2021-2025 Intel Corporation.  All rights reserved.</p>
 </div>
 </div>
 </div>
@@ -823,8 +823,8 @@ Lukasz Towarek, Intel</p>
 <h2 id="_version"><a class="anchor" href="#_version"></a>Version</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Built On: 2023-06-12<br>
-Revision: 1.0.0</p>
+<p>Built On: 2025-06-18<br>
+Revision: 1.1.0</p>
 </div>
 </div>
 </div>
@@ -1861,9 +1861,27 @@ Arguments to the kernel are referred to by indices that go from 0 for the leftmo
 <div class="paragraph">
 <p><em>arg_value</em> is the pointer value that should be used as the argument specified by <em>arg_index</em>.
 The pointer value will be used as the argument by all API calls that enqueue a kernel until the argument value is set to a different pointer value by a subsequent call.
-A pointer into Unified Shared Memory allocation may only be set as an argument value for an argument declared to be a pointer to <code>global</code> or <code>constant</code> memory.
+A pointer may only be set as an argument value for an argument declared to be a pointer to <code>global</code> or <code>constant</code> memory.</p>
+</div>
+<div id="valid-usm-pointer-argument-definition" class="paragraph">
+<p>The definition of a valid pointer value was changed in extension version 1.1.0:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>For extension versions prior to version 1.1.0:
 For devices supporting shared system allocations, any pointer value is valid.
 Otherwise, the pointer value must be <code>NULL</code> or must point into a Unified Shared Memory allocation returned by <strong>clHostMemAllocINTEL</strong>, <strong>clDeviceMemAllocINTEL</strong>, or <strong>clSharedMemAllocINTEL</strong>.</p>
+</li>
+<li>
+<p>For extension versions 1.1.0 and newer:
+For all devices, any pointer value is valid and may be set as an argument to a kernel.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>In this definition, a valid pointer value means that the function will not return an error.
+It still may not be valid to dereference the pointer inside of a kernel if the memory that the pointer points to is not accessible on the device.</p>
 </div>
 <div class="paragraph">
 <p><strong>clSetKernelArgMemPointerINTEL</strong> returns <code>CL_SUCCESS</code> if the function is executed successfully.
@@ -1934,6 +1952,28 @@ The new <em>param_name</em> values described below may be used with the existing
 </tr>
 </tbody>
 </table>
+<div class="paragraph">
+<p>The following errors may be returned by <strong>clSetKernelExecInfo</strong> for these new <em>param_name</em> values:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p><code>CL_INVALID_OPERATION</code> if <em>param_name</em> is <code>CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL</code> and no devices in the context associated with <em>kernel</em> support Unified Shared Memory.</p>
+</li>
+<li>
+<p><code>CL_INVALID_OPERATION</code> if <em>param_name</em> is <code>CL_KERNEL_EXEC_INFO_INDIRECT_HOST_ACCESS_INTEL</code> and no devices in the context associated with <em>kernel</em> support host Unified Shared Memory allocations.</p>
+</li>
+<li>
+<p><code>CL_INVALID_OPERATION</code> if <em>param_name</em> is <code>CL_KERNEL_EXEC_INFO_INDIRECT_DEVICE_ACCESS_INTEL</code> and no devices in the context associated with <em>kernel</em> support device Unified Shared Memory allocations.</p>
+</li>
+<li>
+<p><code>CL_INVALID_OPERATION</code> if <em>param_name</em> is <code>CL_KERNEL_EXEC_INFO_INDIRECT_SHARED_ACCESS_INTEL</code> and no devices in the context associated with <em>kernel</em> support shared Unified Shared Memory allocations.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>The <a href="#valid-usm-pointer-argument-definition">definition of a valid pointer value</a> specified using <code>CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL</code> was changed in extension version 1.1.0.</p>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_filling_and_copying_unified_shared_memory"><a class="anchor" href="#_filling_and_copying_unified_shared_memory"></a>Filling and Copying Unified Shared Memory</h4>
@@ -2642,20 +2682,25 @@ Trending "yes", by allowing <code>CL_MEM_FLAGS</code> as a property and <code>cl
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
-<p><strong>UNRESOLVED</strong>:
-Returning an error for an unknown pointer is helpful to identify and diagnose possible programming errors sooner, but passing a pointer to arbitrary memory to a function on the host is not an error until the pointer is dereferenced.</p>
+<p><code>RESOLVED</code>:
+The behavior of <strong>clSetKernelArgMemPointerINTEL</strong> was changed in version 1.1.0 of this extension.</p>
 </div>
 <div class="paragraph">
-<p>If we relax the error condition for <strong>clSetKernelArgMemPointerINTEL</strong> then we could also consider relaxing the error condition for <strong>clSetKernelExecInfo</strong>(<code>CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL</code>) similarly.</p>
+<p>Prior to version 1.1.0, it was considered an error to set an arbitrary pointer value as an argument to a kernel if no devices support system USM.
+This was helpful to identify possible programming errors, however it did not match the behavior of passing a pointer to a function on the host, where it is only a programming error if an invalid pointer is dereferenced.
+To provide a similar programming experience, the error condition was relaxed in version 1.1.0, and any arbitrary pointer value may be passed to a kernel.</p>
 </div>
 <div class="paragraph">
-<p>Note that if the error condition is removed we can still check for possible programming errors via optional USM checking layers, such as the <a href="https://github.com/intel/opencl-intercept-layer/blob/master/docs/controls.md#usmchecking-bool">USMChecking</a> functionality in the <a href="https://github.com/intel/opencl-intercept-layer">OpenCL Intercept Layer</a>.</p>
+<p>The behavior was also changed for <strong>clSetKernelExecInfo</strong>(<code>CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL</code>), similarly.</p>
+</div>
+<div class="paragraph">
+<p>If desired, additional checks to identify possible programming errors may still be provided via optional USM checking layers, such as the <a href="https://github.com/intel/opencl-intercept-layer/blob/master/docs/controls.md#usmchecking-bool">USMChecking</a> functionality in the <a href="https://github.com/intel/opencl-intercept-layer">OpenCL Intercept Layer</a>.</p>
 </div>
 </div>
 </div>
 </li>
 <li>
-<p>Should we support a "rect" memcpy similar to <strong>clEnqueueCopyBufferRect</strong>?</p>
+<p>Should we support a 2D "rect" memcpy similar to <strong>clEnqueueCopyBufferRect</strong>?</p>
 <div class="openblock">
 <div class="content">
 <div class="paragraph">
@@ -2663,7 +2708,106 @@ Returning an error for an unknown pointer is helpful to identify and diagnose po
 This would be a fairly straightforward addition if it is useful.</p>
 </div>
 <div class="paragraph">
-<p>Note that there is no similar SVM "rect" memcpy.</p>
+<p>Note that there is no similar 2D "rect" memcpy for SVM.</p>
+</div>
+<div class="paragraph">
+<p>We could also support a 2D "rect" fill or memset, though there are no similar functions for <code>cl_mem</code> buffers or SVM.</p>
+</div>
+</div>
+</div>
+</li>
+<li>
+<p>Should there be an upper limit on the size of an allocation using <strong>clHostMemAllocINTEL</strong>?
+If so, what should the upper limit be?</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph">
+<p><strong>UNRESOLVED</strong>:
+The upper limit is currently defined by <code>CL_DEVICE_MAX_MEM_ALLOC_SIZE</code> and if the allocation size exceeds this value then <strong>clHostMemAllocINTEL</strong> returns <code>CL_INVALID_BUFFER_SIZE</code>.</p>
+</div>
+<div class="paragraph">
+<p>This behavior is consistent with <strong>clSVMAlloc</strong> (although <strong>clSVMAlloc</strong> does not return an error code it is specified to return a <code>NULL</code> pointer in this case) and <strong>clCreateBuffer</strong>.
+However, because <strong>clHostMemAllocINTEL</strong> is intended to allocate host memory, some implementations are able to support larger allocation sizes using <strong>clHostMemAllocINTEL</strong>.</p>
+</div>
+<div class="paragraph">
+<p>Possible resolutions:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Add a new query representing the maximum host memory allocation size supported by the device, e.g. <code>CL_DEVICE_MAX_HOST_MEM_ALLOC_SIZE_INTEL</code>.
+For some devices, this query will return the same value as <code>CL_DEVICE_MAX_MEM_ALLOC_SIZE</code>, but for other devices this query will return a larger value.</p>
+</li>
+<li>
+<p>Relax the error behavior so implementations may return <code>CL_INVALID_BUFFER_SIZE</code>, but they would not be required to return an error if they support larger allocation sizes.</p>
+</li>
+<li>
+<p>Do nothing and keep the existing error behavior.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</li>
+<li>
+<p>Should it be an error to allocate zero bytes?</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph">
+<p><strong>UNRESOLVED</strong>:
+Currently, attempting to allocate zero bytes fails and returns <code>CL_INVALID_BUFFER_SIZE</code>.
+This is consistent with SVM, where <strong>clSVMAlloc</strong> fails and returns a <code>NULL</code> pointer if the size to allocate is zero.
+It is also consistent with CUDA, where <strong>cuMemAlloc</strong>, etc. returns an error if the size to allocate is zero.</p>
+</div>
+<div class="paragraph">
+<p>However, it is not necessarily consistent with other memory allocation functions.  For example:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>The result of calling <code>malloc(0)</code> is implementation-defined: it can either return a <code>NULL</code> pointer or a unique non-null pointer that must be freed.
+If a <code>NULL</code> pointer is returned then <code>errno</code> may be set to an implementation-defined value.
+If a unique non-null pointer is returned then it cannot be dereferenced.</p>
+</li>
+<li>
+<p>Allocating an array of zero elements using <code>new</code> must return a non-null pointer, though dereferencing the pointer is undefined.</p>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Possible resolutions:</p>
+</div>
+<div class="ulist">
+<ul>
+<li>
+<p>Allow zero-sized allocations and require returning a non-null pointer that must be freed.</p>
+</li>
+<li>
+<p>Allow zero-sized allocations but allow returning a <code>NULL</code> pointer.  No error would be generated, even if a <code>NULL</code> pointer is returned.</p>
+</li>
+<li>
+<p>Specify that this case is implementation-defined.</p>
+</li>
+<li>
+<p>Do nothing and keep the existing error behavior.</p>
+</li>
+</ul>
+</div>
+</div>
+</div>
+</li>
+<li>
+<p>Can a device USM allocation for a parent device be accessed by its sub-devices?
+Can a single device shared USM allocation associated with a parent device be accessed by its sub-devices?</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph">
+<p><strong>UNRESOLVED</strong>:
+Since a sub-device is a partition of a parent device a USM allocation against a parent device should be accessible by its sub-devices.
+We could document this expectation explicitly in this extension if it is not already covered by the main OpenCL specification.</p>
+</div>
+<div class="paragraph">
+<p>Note that a USM allocation against a sub-device need not be accessible by its parent device or by other sibling sub-devices, though some implementations may support this, just like some implementations optionally support access to USM allocations from other devices.</p>
 </div>
 </div>
 </div>
@@ -2692,120 +2836,6 @@ This would be a fairly straightforward addition if it is useful.</p>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">A</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-01-18</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial revision</strong></p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">B</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-03-25</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Minor name changes.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">C</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-06-18</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Moved flags argument into properties.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">D</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-07-19</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Editorial fixes.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">E</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-07-22</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Allocation properties should be const.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">F</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-07-26</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Removed DEFAULT mem alloc flag.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">G</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-08-23</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Added mem alloc query for associated device.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">H</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-10-11</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Added initial list and description of error codes.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">I</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-11-14</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Switched from a memset to a memfill API.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">J</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-11-18</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Updated a few more error conditions.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">K</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-12-18</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Krzysztof Gibala</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Updated write combine description.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">L</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-01-15</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Added invalid arg case to setkernelarg API.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">M</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-01-17</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Minor name changes, removed const from memfree API.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">N</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-01-22</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Updated write combine description.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">O</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-01-23</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Added aliases for USM migration flags.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">P</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-02-28</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Added blocking memfree API.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Q</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-03-12</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Name tweak for blocking memfree API, added comparison to SVM, allow zero memory advice.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">R</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-08-21</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Fixed enum name typo in table.</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">S</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-08-26</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Maciej Dziuban</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Added initial placement flags for shared allocations.</p></td>
-</tr>
-<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1.0.0</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">2021-11-07</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
@@ -2817,15 +2847,21 @@ This would be a fairly straightforward addition if it is useful.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Added new issues regarding error behavior for clSetKernelArgMemPointerINTEL and rect copies.</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.0.1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-08-28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Documented error conditions for clSetKernelExecInfo.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1.1.0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-07-30</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Modified error behavior for clSetKernelArgMemPointerINTEL and clSetKernelExecInfo.</p></td>
+</tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Version v3.0.14-10-gff88d06<br>
-Last updated 2023-06-12 16:00:00 -0700
 </div>
 </div>
 


### PR DESCRIPTION
Please publish an update to the cl_intel_unified_shared_memory extension.

This updates the specification version to 1.1 and includes the changes from https://github.com/KhronosGroup/OpenCL-Docs/pull/905.