### PR TITLE
remove OpenCL 1.2 dependency from two Intel extensions

### DIFF
--- a/extensions/intel/cl_intel_device_side_avc_motion_estimation.txt
+++ b/extensions/intel/cl_intel_device_side_avc_motion_estimation.txt
@@ -30,8 +30,6 @@ Status
 
 Dependencies
 
-   OpenCL 1.2 is required.
-
    The OpenCL Intel vendor extension cl_intel_subgroups is required. The
    VME built-in functions are an extension of the subgroup functions
    defined in cl_intel_subgroups.

--- a/extensions/intel/cl_intel_media_block_io.txt
+++ b/extensions/intel/cl_intel_media_block_io.txt
@@ -26,8 +26,6 @@ Status
 
 Dependencies
 
-  OpenCL 1.2 is required.
-
   The OpenCL Intel vendor extension cl_intel_subgroups is required. The media
   block read/write built-in functions are an extension of the subgroup
   functions defined in cl_intel_subgroups.


### PR DESCRIPTION
This PR updates two extensions that are still published via plaintext documents to remove an OpenCL 1.2 dependency, consistent with https://github.com/KhronosGroup/OpenCL-Docs/pull/1514.