### PR TITLE
Remove extension pragma in cl_arm_integer_dot_product code snippet

### DIFF
--- a/extensions/arm/cl_arm_integer_dot_product.txt
+++ b/extensions/arm/cl_arm_integer_dot_product.txt
@@ -51,7 +51,6 @@ Overview
     function is not available may use the following pattern:
 
     #ifdef cl_arm_integer_dot_product_XXX
-    #pragma OPENCL EXTENSION cl_arm_integer_dot_product_XXX : enable
         code using arm_dot_xxx()
     #else
         alternative implementation


### PR DESCRIPTION
It was never required and is confusing users.